### PR TITLE
fix: filter feature didn't activate in the 'service discovery' view

### DIFF
--- a/src/commands/filterProviderContent/filterProviderContent.ts
+++ b/src/commands/filterProviderContent/filterProviderContent.ts
@@ -3,35 +3,36 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { type IActionContext, type TreeElementBase } from '@microsoft/vscode-azext-utils';
+import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import { l10n } from 'vscode';
+import { Views } from '../../documentdb/Views';
 import { ext } from '../../extensionVariables';
 import { DiscoveryService } from '../../services/discoveryServices';
 import { type TreeElement } from '../../tree/TreeElement';
 
-export async function filterProviderContent(context: IActionContext, node: TreeElementBase): Promise<void> {
+export async function filterProviderContent(context: IActionContext, node: TreeElement): Promise<void> {
     if (!node) {
         throw new Error(l10n.t('No node selected.'));
     }
+    /**
+     * We can extract the provider id from the node instead of hardcoding it
+     * by accessing the node.id and looking from the start for the id in the following format
+     *
+     * node.id = '${Views.DiscoveryView}/<providerId>/potential/elements/thisNodesId'
+     *
+     * first, we'll verify that the id is in the format expected, if not, we'll return with an error
+     */
 
-    if (
-        // transition period code until the parent discovery is added
-        !node ||
-        !('parentId' in node) ||
-        !node.parentId ||
-        typeof node.parentId !== 'string' ||
-        !node.parentId.includes('/')
-    ) {
+    const idSections = node.id.split('/');
+    const isValidFormat =
+        idSections.length >= 2 && idSections[0] === String(Views.DiscoveryView) && idSections[1].length > 0;
+
+    if (!isValidFormat) {
+        ext.outputChannel.error('Internal error: Node id is not in the expected format.');
         return;
     }
 
-    /**
-     * We can extract the provider id from the node instead of hardcoding it
-     * by accessing the node.parentId and looking from the strart for the id in the following format
-     *
-     * node.parentId = '${Views.DiscoveryView}/<providerId>/potential/parents'
-     */
-    const providerId = node.parentId.split('/')[1];
+    const providerId = idSections[1];
     const provider = DiscoveryService.getProvider(providerId);
 
     if (!provider?.configureTreeItemFilter) {


### PR DESCRIPTION
This pull request refactors the `filterProviderContent` function in `src/commands/filterProviderContent/filterProviderContent.ts` to improve clarity and robustness. The changes include removing legacy code, updating type definitions, and adding validation for the node ID format.

### Code cleanup and refactoring:
* Removed outdated code that checked for `parentId` in the `TreeElement` node, simplifying the function logic.
* Updated the logic to extract the `providerId` from `node.id` instead of `node.parentId`. This aligns with the updated data structure.

### Type and validation improvements:
* Changed the `node` parameter type from `TreeElementBase` to `TreeElement` for better type specificity.
* Added validation to ensure the `node.id` follows the expected format before extracting the `providerId`. If the format is invalid, an error is logged, and the function exits gracefully.