### PR TITLE
fix: `Remove Registry` command didn't remove registries from the tree view

### DIFF
--- a/src/commands/removeDiscoveryRegistry/removeDiscoveryRegistry.ts
+++ b/src/commands/removeDiscoveryRegistry/removeDiscoveryRegistry.ts
@@ -3,34 +3,36 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { type IActionContext, type TreeElementBase } from '@microsoft/vscode-azext-utils';
+import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import { l10n } from 'vscode';
+import { Views } from '../../documentdb/Views';
 import { ext } from '../../extensionVariables';
 import { DiscoveryService } from '../../services/discoveryServices';
+import { type TreeElement } from '../../tree/TreeElement';
 
-export async function removeDiscoveryRegistry(_context: IActionContext, node: TreeElementBase): Promise<void> {
+export async function removeDiscoveryRegistry(_context: IActionContext, node: TreeElement): Promise<void> {
     if (!node) {
         throw new Error(l10n.t('No node selected.'));
     }
+    /**
+     * We can extract the provider id from the node instead of hardcoding it
+     * by accessing the node.id and looking from the start for the id in the following format
+     *
+     * node.id = '${Views.DiscoveryView}/<providerId>/potential/children/'
+     *
+     * first, we'll verify that the id is in the format expected, if not, we'll return with an error
+     */
 
-    if (
-        // transition period code until the parent discovery is added
-        !node ||
-        !('parentId' in node) ||
-        !node.parentId ||
-        typeof node.parentId !== 'string' ||
-        !node.parentId.includes('/')
-    ) {
+    const idSections = node.id.split('/');
+    const isValidFormat =
+        idSections.length >= 2 && idSections[0] === String(Views.DiscoveryView) && idSections[1].length > 0;
+
+    if (!isValidFormat) {
+        ext.outputChannel.error('Internal error: Node id is not in the expected format.');
         return;
     }
 
-    /**
-     * We can extract the provider id from the node instead of hardcoding it
-     * by accessing the node.parentId and looking from the strart for the id in the following format
-     *
-     * node.parentId = '${Views.DiscoveryView}/<providerId>/potential/parents'
-     */
-    const providerId = node.parentId.split('/')[1];
+    const providerId = idSections[1];
     const provider = DiscoveryService.getProvider(providerId);
 
     if (!provider) {


### PR DESCRIPTION
This pull request refactors the `removeDiscoveryRegistry` function in `src/commands/removeDiscoveryRegistry/removeDiscoveryRegistry.ts` to improve code clarity and robustness. The changes include updating type definitions, removing outdated validation logic, and adding more precise error handling for node ID format validation.

### Refactoring and Type Updates:

* Replaced the `TreeElementBase` type with a more specific `TreeElement` type for the `node` parameter to better reflect the expected structure.

### Code Simplification:

* Removed outdated validation logic for the `node.parentId` property, as it is no longer relevant to the function's behavior.

### Improved Error Handling:

* Added validation to ensure the `node.id` follows the expected format, using the `Views.DiscoveryView` constant. If the format is invalid, an error message is logged, and the function exits early.