### PR TITLE
feat: added improved support for `learn more` links to better guide users

### DIFF
--- a/package.json
+++ b/package.json
@@ -337,6 +337,13 @@
         "icon": "$(filter)"
       },
       {
+        "//": "[DiscoveryView] Learn More About Service Provider",
+        "category": "DocumentDB",
+        "command": "vscode-documentdb.command.discoveryView.learnMoreAboutProvider",
+        "title": "Learn More",
+        "icon": "$(info)"
+      },
+      {
         "//": "Refresh a Tree Item",
         "category": "DocumentDB",
         "command": "vscode-documentdb.command.refresh",
@@ -534,6 +541,16 @@
           "group": "inline"
         },
         {
+          "command": "vscode-documentdb.command.discoveryView.learnMoreAboutProvider",
+          "when": "view == discoveryView && viewItem =~ /\\benableLearnMoreCommand\\b/i",
+          "group": "1@3"
+        },
+        {
+          "command": "vscode-documentdb.command.discoveryView.learnMoreAboutProvider",
+          "when": "view == discoveryView && viewItem =~ /\\benableLearnMoreCommand\\b/i",
+          "group": "inline"
+        },
+        {
           "command": "vscode-documentdb.command.discoveryView.filterProviderContent",
           "when": "view == discoveryView && viewItem =~ /\\benableFilterCommand\\b/i",
           "group": "1@2"
@@ -674,6 +691,10 @@
         },
         {
           "command": "vscode-documentdb.command.discoveryView.filterProviderContent",
+          "when": "never"
+        },
+        {
+          "command": "vscode-documentdb.command.discoveryView.learnMoreAboutProvider",
           "when": "never"
         },
         {

--- a/src/commands/learnMoreAboutServiceProvider/learnMoreAboutServiceProvider.ts
+++ b/src/commands/learnMoreAboutServiceProvider/learnMoreAboutServiceProvider.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type IActionContext } from '@microsoft/vscode-azext-utils';
+import * as l10n from '@vscode/l10n';
+import { Views } from '../../documentdb/Views';
+import { ext } from '../../extensionVariables';
+import { DiscoveryService } from '../../services/discoveryServices';
+
+import { type TreeElement } from '../../tree/TreeElement';
+import { openUrl } from '../../utils/openUrl';
+
+export async function learnMoreAboutServiceProvider(_context: IActionContext, node: TreeElement): Promise<void> {
+    if (!node) {
+        throw new Error(l10n.t('No node selected.'));
+    }
+
+    /**
+     * We can extract the provider id from the node instead of hardcoding it
+     * by accessing the node.id and looking from the start for the id in the following format
+     *
+     * node.id = '${Views.DiscoveryView}/<providerId>/potential/children/'
+     *
+     * first, we'll verify that the id is in the format expected, if not, we'll return with an error
+     */
+
+    const idSections = node.id.split('/');
+    const isValidFormat =
+        idSections.length >= 2 && idSections[0] === String(Views.DiscoveryView) && idSections[1].length > 0;
+
+    if (!isValidFormat) {
+        ext.outputChannel.error('Internal error: Node id is not in the expected format.');
+        return;
+    }
+
+    const providerId = idSections[1];
+    const provider = DiscoveryService.getProvider(providerId);
+
+    if (!provider) {
+        ext.outputChannel.error(`Failed to access the service provider with the id "${providerId}".`);
+        return;
+    }
+
+    const learnMoreUrl = provider?.getLearnMoreUrl?.();
+
+    if (!learnMoreUrl) {
+        ext.outputChannel.error(`Failed to access the service provider with the id "${providerId}".`);
+        return;
+    }
+
+    await openUrl(learnMoreUrl);
+}

--- a/src/commands/newLocalConnection/mongo-ru/PromptMongoRUEmulatorSecurityStep.ts
+++ b/src/commands/newLocalConnection/mongo-ru/PromptMongoRUEmulatorSecurityStep.ts
@@ -60,7 +60,7 @@ export class PromptMongoRUEmulatorSecurityStep extends AzureWizardPromptStep<New
         if (selectedItem.id === 'learnMore') {
             context.telemetry.properties.emulatorLearnMoreSecurity = 'true';
 
-            await openUrl('https://aka.ms/vscode-documentdb-local-connections');
+            await openUrl('https://aka.ms/vscode-documentdb-local-connections-security');
             throw new UserCancelledError();
         }
     }

--- a/src/documentdb/ClustersExtension.ts
+++ b/src/documentdb/ClustersExtension.ts
@@ -29,6 +29,7 @@ import { exportEntireCollection, exportQueryResults } from '../commands/exportDo
 import { filterProviderContent } from '../commands/filterProviderContent/filterProviderContent';
 import { importDocuments } from '../commands/importDocuments/importDocuments';
 import { launchShell } from '../commands/launchShell/launchShell';
+import { learnMoreAboutServiceProvider } from '../commands/learnMoreAboutServiceProvider/learnMoreAboutServiceProvider';
 import { newConnection } from '../commands/newConnection/newConnection';
 import { newLocalConnection } from '../commands/newLocalConnection/newLocalConnection';
 import { openCollectionView, openCollectionViewInternal } from '../commands/openCollectionView/openCollectionView';
@@ -164,6 +165,11 @@ export class ClustersExtension implements vscode.Disposable {
                 registerCommandWithTreeNodeUnwrapping(
                     'vscode-documentdb.command.discoveryView.filterProviderContent',
                     filterProviderContent,
+                );
+
+                registerCommandWithTreeNodeUnwrapping(
+                    'vscode-documentdb.command.discoveryView.learnMoreAboutProvider',
+                    learnMoreAboutServiceProvider,
                 );
 
                 registerCommandWithTreeNodeUnwrapping(

--- a/src/plugins/service-azure-vm/AzureVMDiscoveryProvider.ts
+++ b/src/plugins/service-azure-vm/AzureVMDiscoveryProvider.ts
@@ -58,6 +58,10 @@ export class AzureVMDiscoveryProvider extends Disposable implements DiscoveryPro
         };
     }
 
+    getLearnMoreUrl(): string | undefined {
+        return 'https://aka.ms/vscode-documentdb-discovery-providers-azure-vms';
+    }
+
     async configureTreeItemFilter(context: IActionContext, node: TreeElement): Promise<void> {
         if (node instanceof AzureServiceRootItem) {
             await configureVmFilter(context, this.azureSubscriptionProvider);

--- a/src/plugins/service-azure-vm/discovery-tree/AzureServiceRootItem.ts
+++ b/src/plugins/service-azure-vm/discovery-tree/AzureServiceRootItem.ts
@@ -13,7 +13,8 @@ import { AzureSubscriptionItem } from './AzureSubscriptionItem';
 
 export class AzureServiceRootItem implements TreeElement, TreeElementWithContextValue {
     public readonly id: string;
-    public contextValue: string = 'enableRefreshCommand;enableFilterCommand;discoveryAzureVMRootItem';
+    public contextValue: string =
+        'enableRefreshCommand;enableFilterCommand;enableLearnMoreCommand;discoveryAzureVMRootItem';
 
     constructor(
         private readonly azureSubscriptionProvider: VSCodeAzureSubscriptionProvider,

--- a/src/plugins/service-azure/AzureDiscoveryProvider.ts
+++ b/src/plugins/service-azure/AzureDiscoveryProvider.ts
@@ -59,6 +59,10 @@ export class AzureDiscoveryProvider extends Disposable implements DiscoveryProvi
         };
     }
 
+    getLearnMoreUrl(): string | undefined {
+        return 'https://aka.ms/vscode-documentdb-discovery-providers-azure-vcore';
+    }
+
     async configureTreeItemFilter(context: IActionContext, node: TreeElement): Promise<void> {
         if (node instanceof AzureServiceRootItem) {
             await configureAzureSubscriptionFilter(context, this.azureSubscriptionProvider);

--- a/src/plugins/service-azure/discovery-tree/AzureServiceRootItem.ts
+++ b/src/plugins/service-azure/discovery-tree/AzureServiceRootItem.ts
@@ -13,7 +13,8 @@ import { AzureSubscriptionItem } from './AzureSubscriptionItem';
 
 export class AzureServiceRootItem implements TreeElement, TreeElementWithContextValue {
     public readonly id: string;
-    public contextValue: string = 'enableRefreshCommand;enableFilterCommand;discoveryAzureServiceRootItem';
+    public contextValue: string =
+        'enableRefreshCommand;enableFilterCommand;enableLearnMoreCommand;discoveryAzureServiceRootItem';
 
     constructor(
         private readonly azureSubscriptionProvider: VSCodeAzureSubscriptionProvider,

--- a/src/services/discoveryServices.ts
+++ b/src/services/discoveryServices.ts
@@ -52,6 +52,8 @@ export interface DiscoveryProvider extends ProviderDescription {
      */
     getDiscoveryTreeRootItem(parentId: string): TreeElement;
 
+    getLearnMoreUrl?(): string | undefined;
+
     configureTreeItemFilter?(context: IActionContext, node: TreeElement): Promise<void>;
 }
 


### PR DESCRIPTION
This pull request introduces a new "Learn More" feature for service providers in the Discovery View of the DocumentDB extension. It includes UI updates, command registration, and backend logic to support this functionality. Additionally, it updates existing URLs and adds new methods to support the feature.

### New "Learn More" Feature:

* **UI Enhancements**:
  - Added a new "Learn More" command to the `package.json` file, including its icon and visibility conditions for the Discovery View. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R339-R345) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R543-R552) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R696-R699)

* **Command Implementation**:
  - Introduced a new `learnMoreAboutServiceProvider` command in `src/commands/learnMoreAboutServiceProvider/learnMoreAboutServiceProvider.ts`. This command extracts the provider ID from the selected node, retrieves the provider's "Learn More" URL, and opens it.

* **Command Registration**:
  - Registered the `learnMoreAboutServiceProvider` command in the `ClustersExtension` class to make it available in the extension. [[1]](diffhunk://#diff-03a656b8edee71ac958868460933f9ca508e6c7e7bbe607b9ae4e98c664a2200R32) [[2]](diffhunk://#diff-03a656b8edee71ac958868460933f9ca508e6c7e7bbe607b9ae4e98c664a2200R170-R174)

* **Discovery Providers**:
  - Added a `getLearnMoreUrl` method to the `DiscoveryProvider` interface and implemented it for Azure VM and Azure VCore providers, returning specific URLs for each. [[1]](diffhunk://#diff-23681f11aacb46e3c7b7a514839e2a052af3497fa06301f23ab50f0a5790f6b8R55-R56) [[2]](diffhunk://#diff-acfb0f3b5f09f581584b50580d6aecb00ae399fe18295c10aacfe54090682954R61-R64) [[3]](diffhunk://#diff-06d8fd4cda22aaa7bd17d01f0224370a6fcf048dafecd05a406ace5b8bcd1a23R62-R65)

* **Tree Item Context Updates**:
  - Updated the `contextValue` of Azure service root items to include the `enableLearnMoreCommand` flag, enabling the "Learn More" command in the UI. [[1]](diffhunk://#diff-4527aa52b9fa7464bd373b5312ae1d9b67de64c5a58e2b30689394a85e3d528fL16-R17) [[2]](diffhunk://#diff-9bc5e17c5a50f1ec3932988966d2d84357bfbca5092b6ceb446d0b8d55cba9b1L16-R17)

### Other Updates:

* **URL Update**:
  - Updated the "Learn More" URL in the `PromptMongoRUEmulatorSecurityStep` class to point to a more specific security-related page.