### PR TITLE
fix: update VM icon to stay consistent with DocumentDB clusters

### DIFF
--- a/src/plugins/service-azure-vm/discovery-tree/vm/AzureVMResourceItem.ts
+++ b/src/plugins/service-azure-vm/discovery-tree/vm/AzureVMResourceItem.ts
@@ -33,7 +33,7 @@ export interface VirtualMachineModel extends ClusterModel {
 }
 
 export class AzureVMResourceItem extends ClusterItemBase {
-    iconPath = new vscode.ThemeIcon('vm'); // Generic VM icon
+    iconPath = new vscode.ThemeIcon('server-environment');
 
     constructor(
         readonly subscription: AzureSubscription, // Retained from original


### PR DESCRIPTION
This pull request updates the icon used for Azure Virtual Machine resource items in the `AzureVMResourceItem` class to better reflect its purpose.

UI/UX improvement:

* [`src/plugins/service-azure-vm/discovery-tree/vm/AzureVMResourceItem.ts`](diffhunk://#diff-5bde3dcaa4e214fc5cf444c7679c466c3a0f91095c18111c3ca4188bd54ae496L36-R36): Changed the `iconPath` from a generic VM icon (`vm`) to a more specific `server-environment` icon to improve clarity and alignment with the resource type.