### PR TITLE
fix: shell password handling on powershell + detecting other terminal options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "lodash.omit": "^4.5.0",
         "monaco-editor": "~0.51.0",
         "mongodb": "^6.14.2",
+        "mongodb-connection-string-url": "^3.0.2",
         "pg": "^8.13.3",
         "pg-connection-string": "^2.7.0",
         "react-hotkeys-hook": "^4.6.1",
@@ -16574,12 +16575,13 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.0.tgz",
-      "integrity": "sha512-t1Vf+m1I5hC2M5RJx/7AtxgABy1cZmIPQRMXw+gEIPn/cZNF3Oiy+l0UIypUwVB5trcWHq3crg2g3uAR9aAwsQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^13.0.0"
+        "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
     "node_modules/mongodb-connection-string-url/node_modules/tr46": {

--- a/package.json
+++ b/package.json
@@ -148,12 +148,12 @@
     "webpack-dev-server": "^5.2.0"
   },
   "dependencies": {
+    "@azure/arm-compute": "^22.4.0",
     "@azure/arm-cosmosdb": "16.0.0-beta.7",
+    "@azure/arm-network": "^33.5.0",
     "@azure/arm-postgresql": "^6.1.0",
     "@azure/arm-postgresql-flexible": "^8.0.0",
     "@azure/arm-resources": "^6.0.0",
-    "@azure/arm-compute": "^22.4.0",
-    "@azure/arm-network": "^33.5.0",
     "@azure/cosmos": "^4.2.0",
     "@azure/identity": "^4.6.0",
     "@fluentui/react-components": "^9.60.0",
@@ -179,6 +179,7 @@
     "lodash.omit": "^4.5.0",
     "monaco-editor": "~0.51.0",
     "mongodb": "^6.14.2",
+    "mongodb-connection-string-url": "^3.0.2",
     "pg": "^8.13.3",
     "pg-connection-string": "^2.7.0",
     "react-hotkeys-hook": "^4.6.1",

--- a/src/commands/launchShell/launchShell.ts
+++ b/src/commands/launchShell/launchShell.ts
@@ -28,6 +28,7 @@ export async function launchShell(
     }
 
     context.telemetry.properties.experience = node.experience.api;
+    context.telemetry.properties.isWindows = isWindows.toString();
 
     let rawConnectionString: string | undefined;
 
@@ -60,31 +61,63 @@ export async function launchShell(
     const randomSuffix = Math.floor(100000 + Math.random() * 900000).toString(); // Generate a 6-digit random number string
     const uniquePassEnvVar = `documentdb_${randomSuffix}`; // Use a lowercase, generic-looking variable name to avoid drawing attention in the shell output—this helps prevent bystanders from noticing sensitive info if they're watching the user's screen.
 
-    // Check if PowerShell is being used on Windows
-    let isWindowsPowerShell = false;
+    // Determine appropriate environment variable syntax based on shell type
+    let envVarSyntax = '';
     if (isWindows) {
         const terminalProfile = vscode.workspace.getConfiguration('terminal.integrated.defaultProfile').get('windows');
+
         if (terminalProfile === null || typeof terminalProfile === 'undefined') {
+            // Default to PowerShell if no profile is found
             ext.outputChannel.appendLog(
                 l10n.t(
                     'Default Windows terminal profile not found in VS Code settings. Assuming PowerShell for launching MongoDB shell.',
                 ),
             );
-            isWindowsPowerShell = true;
+            envVarSyntax = `$env:${uniquePassEnvVar}`;
+            context.telemetry.properties.terminalType = 'PowerShell';
         } else if (typeof terminalProfile === 'string') {
-            isWindowsPowerShell =
-                terminalProfile.toLowerCase() === 'powershell' || terminalProfile.toLowerCase() === 'pwsh';
+            const profile = terminalProfile.toLowerCase();
+
+            if (profile === 'powershell' || profile === 'pwsh' || profile === 'windows powershell') {
+                // PowerShell detected
+                envVarSyntax = `$env:${uniquePassEnvVar}`;
+                context.telemetry.properties.terminalType = 'PowerShell';
+            } else if (profile === 'cmd' || profile === 'command prompt') {
+                // Command Prompt detected
+                envVarSyntax = `%${uniquePassEnvVar}%`;
+                context.telemetry.properties.terminalType = 'Cmd';
+            } else if (profile === 'git bash') {
+                // Git Bash detected
+                envVarSyntax = `$${uniquePassEnvVar}`;
+                context.telemetry.properties.terminalType = 'GitBash';
+            } else if (profile.includes('wsl')) {
+                // WSL shell detected
+                envVarSyntax = `$${uniquePassEnvVar}`;
+                context.telemetry.properties.terminalType = 'WSL';
+            } else {
+                // Unrecognized profile, default to CMD syntax
+                envVarSyntax = `%${uniquePassEnvVar}%`;
+                context.telemetry.properties.terminalType = 'Other';
+                context.telemetry.properties.terminalProfileValue = terminalProfile;
+            }
         }
+    } else {
+        // Unix-like environment (macOS/Linux)
+        envVarSyntax = `$${uniquePassEnvVar}`;
+        context.telemetry.properties.terminalType = 'Unix';
     }
 
-    // Use correct variable syntax based on shell
-    if (isWindows && isWindowsPowerShell) {
-        connectionString.password = `$env:${uniquePassEnvVar}`;
-    } else if (isWindows) {
-        connectionString.password = `%${uniquePassEnvVar}%`;
-    } else {
-        connectionString.password = `$${uniquePassEnvVar}`;
-    }
+    // Note to code maintainers:
+    // We're using a sentinel value approach here to avoid URL encoding issues with environment variable
+    // references. For example, in PowerShell the environment variable reference "$env:VAR_NAME" contains
+    // a colon character (":") which gets URL encoded to "%3A" when added directly to connectionString.password.
+    // This encoding breaks the environment variable reference syntax in the shell.
+    //
+    // By using a unique sentinel string first and then replacing it with the raw (unencoded) environment
+    // variable reference after toString() is called, we ensure the shell correctly interprets the
+    // environment variable.
+    const PASSWORD_SENTINEL = '__MONGO_PASSWORD_PLACEHOLDER__';
+    connectionString.password = PASSWORD_SENTINEL;
 
     // If the username or password is empty, remove them from the connection string to avoid invalid connection strings
     if (!connectionString.username || !actualPassword) {
@@ -119,6 +152,9 @@ export async function launchShell(
 
     const tlsConfiguration = isEmulatorWithSecurityDisabled ? '--tlsAllowInvalidCertificates' : '';
 
-    terminal.sendText(`mongosh "${connectionString.toString()}" ${tlsConfiguration}`);
+    // Get the connection string and replace the sentinel with the environment variable syntax
+    const finalConnectionString = connectionString.toString().replace(PASSWORD_SENTINEL, envVarSyntax);
+
+    terminal.sendText(`mongosh "${finalConnectionString}" ${tlsConfiguration}`);
     terminal.show();
 }


### PR DESCRIPTION
This pull request introduces updates to dependencies in `package.json` and enhances the `launchShell` function in `launchShell.ts` to improve telemetry and environment variable handling for different terminal types. Below is a summary of the most important changes:

### Dependency Updates:

* Added `mongodb-connection-string-url` as a new dependency (`^3.0.2`).
* Re-added `@azure/arm-compute` (`^22.4.0`) and `@azure/arm-network` (`^33.5.0`) to the dependencies list after accidental removal.

### Telemetry Enhancements:

* Added telemetry property `isWindows` to capture whether the user is on a Windows platform.
* Updated telemetry to include `terminalType` and, for unrecognized profiles, `terminalProfileValue` to better track terminal environments.

### Improved Environment Variable Handling in `launchShell`:

* Replaced the previous approach of directly assigning environment variable syntax to `connectionString.password` with a sentinel value (`PASSWORD_SENTINEL`). This avoids URL encoding issues when working with environment variable references in shell commands. [[1]](diffhunk://#diff-eab2a39f022b72c2579c2a4745ffc8ca8a1dd5194daf877365d63520bc8f0465L63-R121) [[2]](diffhunk://#diff-eab2a39f022b72c2579c2a4745ffc8ca8a1dd5194daf877365d63520bc8f0465L122-R158)
* Enhanced logic to dynamically determine the correct environment variable syntax (`$env:`, `%`, `) based on the detected terminal type (e.g., PowerShell, CMD, Git Bash, WSL, Unix-like).