### PR TITLE
fix misleading cut-copy-paste context menu in table and tree view

### DIFF
--- a/src/webviews/api/webview-client/utils/useSelectiveContextMenuPrevention.ts
+++ b/src/webviews/api/webview-client/utils/useSelectiveContextMenuPrevention.ts
@@ -24,7 +24,7 @@ export const useSelectiveContextMenuPrevention = (): void => {
             // Add other editor selectors here as needed
         ];
 
-        const handleContextMenu = (e: Event): boolean | undefined => {
+        const handleContextMenu = (e: MouseEvent): void => {
             const target = e.target as HTMLElement;
 
             // Check if target is within any allowed element
@@ -32,16 +32,13 @@ export const useSelectiveContextMenuPrevention = (): void => {
 
             if (!isInAllowedElement) {
                 e.preventDefault();
-                return false;
             }
-
-            return undefined;
         };
 
-        document.oncontextmenu = handleContextMenu;
+        document.addEventListener('contextmenu', handleContextMenu);
 
         return () => {
-            document.oncontextmenu = null;
+            document.removeEventListener('contextmenu', handleContextMenu);
         };
     }, []);
 };

--- a/src/webviews/api/webview-client/utils/useSelectiveContextMenuPrevention.ts
+++ b/src/webviews/api/webview-client/utils/useSelectiveContextMenuPrevention.ts
@@ -13,16 +13,22 @@ import { useEffect } from 'react';
  *
  * Additional editor selectors can be added to the allowlist as needed.
  */
+/**
+ * List of allowed selectors for context menus in the Monaco editor.
+ * Update this list as needed to accommodate future editor changes.
+ */
+const ALLOWED_SELECTORS = [
+    '.monaco-editor',
+    '.monaco-editor-background',
+    '.view-lines',
+    '.monaco-scrollable-element',
+    '.monaco-mouse-cursor-text',
+    // Add other editor selectors here as needed
+];
+
 export const useSelectiveContextMenuPrevention = (): void => {
     useEffect(() => {
-        const allowedSelectors = [
-            '.monaco-editor',
-            '.monaco-editor-background',
-            '.view-lines',
-            '.monaco-scrollable-element',
-            '.monaco-mouse-cursor-text',
-            // Add other editor selectors here as needed
-        ];
+        const allowedSelectors = ALLOWED_SELECTORS;
 
         const handleContextMenu = (e: MouseEvent): void => {
             const target = e.target as HTMLElement;

--- a/src/webviews/api/webview-client/utils/useSelectiveContextMenuPrevention.ts
+++ b/src/webviews/api/webview-client/utils/useSelectiveContextMenuPrevention.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { useEffect } from 'react';
+
+/**
+ * Custom hook that selectively prevents context menus based on element selectors.
+ * Currently allows context menus in Monaco editor elements while preventing them elsewhere.
+ * This preserves editor functionality (copy/paste/formatting) while preventing unwanted
+ * context menus in data tables and other UI elements.
+ *
+ * Additional editor selectors can be added to the allowlist as needed.
+ */
+export const useSelectiveContextMenuPrevention = (): void => {
+    useEffect(() => {
+        const allowedSelectors = [
+            '.monaco-editor',
+            '.monaco-editor-background',
+            '.view-lines',
+            '.monaco-scrollable-element',
+            '.monaco-mouse-cursor-text',
+            // Add other editor selectors here as needed
+        ];
+
+        const handleContextMenu = (e: Event): boolean | undefined => {
+            const target = e.target as HTMLElement;
+
+            // Check if target is within any allowed element
+            const isInAllowedElement = allowedSelectors.some((selector) => target.closest(selector) !== null);
+
+            if (!isInAllowedElement) {
+                e.preventDefault();
+                return false;
+            }
+
+            return undefined;
+        };
+
+        document.oncontextmenu = handleContextMenu;
+
+        return () => {
+            document.oncontextmenu = null;
+        };
+    }, []);
+};

--- a/src/webviews/documentdb/collectionView/CollectionView.tsx
+++ b/src/webviews/documentdb/collectionView/CollectionView.tsx
@@ -370,6 +370,37 @@ export const CollectionView = (): JSX.Element => {
             });
     }
 
+    // Selective context menu prevention - allow only in Monaco editor
+    useEffect(() => {
+        const monacoSelectors = [
+            '.monaco-editor',
+            '.monaco-editor-background',
+            '.view-lines',
+            '.monaco-scrollable-element',
+            '.monaco-mouse-cursor-text',
+        ];
+
+        const handleContextMenu = (e: Event): boolean | undefined => {
+            const target = e.target as HTMLElement;
+
+            // Check if target is within any Monaco editor element
+            const isInMonacoEditor = monacoSelectors.some((selector) => target.closest(selector) !== null);
+
+            if (!isInMonacoEditor) {
+                e.preventDefault();
+                return false;
+            }
+
+            return undefined;
+        };
+
+        document.oncontextmenu = handleContextMenu;
+
+        return () => {
+            document.oncontextmenu = null;
+        };
+    }, []);
+
     return (
         <CollectionViewContext.Provider value={[currentContext, setCurrentContext]}>
             <div className="collectionView">

--- a/src/webviews/documentdb/collectionView/CollectionView.tsx
+++ b/src/webviews/documentdb/collectionView/CollectionView.tsx
@@ -10,6 +10,7 @@ import { type JSX, useEffect, useRef, useState } from 'react';
 import { type TableDataEntry } from '../../../documentdb/ClusterSession';
 import { UsageImpact } from '../../../utils/surveyTypes';
 import { useTrpcClient } from '../../api/webview-client/useTrpcClient';
+import { useSelectiveContextMenuPrevention } from '../../api/webview-client/utils/useSelectiveContextMenuPrevention';
 import './collectionView.scss';
 import {
     CollectionViewContext,
@@ -67,6 +68,8 @@ export const CollectionView = (): JSX.Element => {
 
     // that's our current global context of the view
     const [currentContext, setCurrentContext] = useState<CollectionViewContextType>(DefaultCollectionViewContext);
+
+    useSelectiveContextMenuPrevention();
 
     // that's the local view of query results
     // TODO: it's a potential data duplication in the end, consider moving it into the global context of the view
@@ -369,37 +372,6 @@ export const CollectionView = (): JSX.Element => {
                 console.debug('Failed to report an event:', error);
             });
     }
-
-    // Selective context menu prevention - allow only in Monaco editor
-    useEffect(() => {
-        const monacoSelectors = [
-            '.monaco-editor',
-            '.monaco-editor-background',
-            '.view-lines',
-            '.monaco-scrollable-element',
-            '.monaco-mouse-cursor-text',
-        ];
-
-        const handleContextMenu = (e: Event): boolean | undefined => {
-            const target = e.target as HTMLElement;
-
-            // Check if target is within any Monaco editor element
-            const isInMonacoEditor = monacoSelectors.some((selector) => target.closest(selector) !== null);
-
-            if (!isInMonacoEditor) {
-                e.preventDefault();
-                return false;
-            }
-
-            return undefined;
-        };
-
-        document.oncontextmenu = handleContextMenu;
-
-        return () => {
-            document.oncontextmenu = null;
-        };
-    }, []);
 
     return (
         <CollectionViewContext.Provider value={[currentContext, setCurrentContext]}>

--- a/src/webviews/documentdb/documentView/documentView.tsx
+++ b/src/webviews/documentdb/documentView/documentView.tsx
@@ -14,6 +14,7 @@ import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 import { UsageImpact } from '../../../utils/surveyTypes';
 import { useConfiguration } from '../../api/webview-client/useConfiguration';
 import { useTrpcClient } from '../../api/webview-client/useTrpcClient';
+import { useSelectiveContextMenuPrevention } from '../../api/webview-client/utils/useSelectiveContextMenuPrevention';
 import { MonacoEditor } from '../../MonacoEditor';
 import { ToolbarDocuments } from './components/toolbarDocuments';
 import { type DocumentsViewWebviewConfigurationType } from './documentsViewController';
@@ -46,6 +47,8 @@ export const DocumentView = (): JSX.Element => {
     const [editorContent] = configuration.mode === 'add' ? useState('{  }') : useState('{ "loading…": true }');
     const [isLoading, setIsLoading] = useState(configuration.mode !== 'add');
     const [isDirty, setIsDirty] = useState(true);
+
+    useSelectiveContextMenuPrevention();
 
     // a useEffect without a dependency runs only once after the first render only
     useEffect(() => {


### PR DESCRIPTION
This pull request introduces a new custom hook, `useSelectiveContextMenuPrevention`, to improve user experience by selectively disabling context menus in non-editor elements while preserving functionality in Monaco editor components. The hook is integrated into two views (`CollectionView` and `DocumentView`) to enhance their behavior.

### New feature: Custom hook for context menu prevention
* [`src/webviews/api/webview-client/utils/useSelectiveContextMenuPrevention.ts`](diffhunk://#diff-04d77bea3ae6d8542690354273b56533cb908d221e3f1ffa532c4b5db9d9f449R1-R47): Added the `useSelectiveContextMenuPrevention` hook, which prevents context menus in non-editor elements while allowing them in Monaco editor elements. This is achieved using an allowlist of selectors and event handling for `oncontextmenu`.

### Integration of the custom hook
* [`src/webviews/documentdb/collectionView/CollectionView.tsx`](diffhunk://#diff-89aed8cd70c9fd0abf90ebb1a77a18fd954e3e6515888bb503e8eda0bbd4836aR13): Imported and invoked `useSelectiveContextMenuPrevention` within the `CollectionView` component to manage context menu behavior. [[1]](diffhunk://#diff-89aed8cd70c9fd0abf90ebb1a77a18fd954e3e6515888bb503e8eda0bbd4836aR13) [[2]](diffhunk://#diff-89aed8cd70c9fd0abf90ebb1a77a18fd954e3e6515888bb503e8eda0bbd4836aR72-R73)
* [`src/webviews/documentdb/documentView/documentView.tsx`](diffhunk://#diff-eb55ee2e791b34918d4c23c48ec4b33728dcecbdf587e1fb118c37c75299097dR17): Imported and invoked `useSelectiveContextMenuPrevention` within the `DocumentView` component to ensure consistent context menu handling. [[1]](diffhunk://#diff-eb55ee2e791b34918d4c23c48ec4b33728dcecbdf587e1fb118c37c75299097dR17) [[2]](diffhunk://#diff-eb55ee2e791b34918d4c23c48ec4b33728dcecbdf587e1fb118c37c75299097dR51-R52)