### PR TITLE
 Password Prompt Fix

### DIFF
--- a/src/vscodeUriHandler.ts
+++ b/src/vscodeUriHandler.ts
@@ -77,10 +77,7 @@ async function handleConnectionStringRequest(
 
     // Parse the connection string
     const parsedCS = new ConnectionString(params.connectionString!);
-    if (
-        parsedCS.password &&
-        decodeURIComponent(parsedCS.password.trim()) === '<password>'
-    ) {
+    if (parsedCS.password && decodeURIComponent(parsedCS.password.trim()) === '<password>') {
         parsedCS.password = '';
     }
 


### PR DESCRIPTION
When the connection string uses username:<password>, we want the password prompt to come. Hence, treating <password> as empty password