### PR TITLE
fix: restore password support when new connections are created using a "connection string" feature.

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -458,6 +458,7 @@
   "Use anyway": "Use anyway",
   "User is not signed in to Azure.": "User is not signed in to Azure.",
   "Username and Password": "Username and Password",
+  "Username cannot be empty": "Username cannot be empty",
   "Username for {resource}": "Username for {resource}",
   "Using existing resource group \"{0}\".": "Using existing resource group \"{0}\".",
   "Using the table navigation, you can explore deeper levels or move back and forth between them.": "Using the table navigation, you can explore deeper levels or move back and forth between them.",

--- a/src/commands/newConnection/PromptPasswordStep.ts
+++ b/src/commands/newConnection/PromptPasswordStep.ts
@@ -41,6 +41,7 @@ export class PromptPasswordStep extends AzureWizardPromptStep<NewConnectionWizar
 
         try {
             const parsedConnectionString = new DocumentDBConnectionString(context.connectionString!);
+            parsedConnectionString.username = context.username ?? '';
             parsedConnectionString.password = password;
 
             const connectionString = parsedConnectionString.toString();

--- a/src/commands/newConnection/PromptUsernameStep.ts
+++ b/src/commands/newConnection/PromptUsernameStep.ts
@@ -20,6 +20,13 @@ export class PromptUsernameStep extends AzureWizardPromptStep<NewConnectionWizar
             ignoreFocusOut: true,
             value: context.username,
             validateInput: (username?: string) => this.validateInput(context, username),
+            // eslint-disable-next-line @typescript-eslint/require-await
+            asyncValidationTask: async (username?: string) => {
+                if (!username || username.trim().length === 0) {
+                    return l10n.t('Username cannot be empty');
+                }
+                return undefined;
+            },
         });
 
         context.valuesToMask.push(username);


### PR DESCRIPTION
This pull request improves the user experience and validation logic when entering a username during the new connection workflow. The main changes ensure that users cannot proceed with an empty username and that appropriate error messages are displayed.

**Validation and user feedback improvements:**

* Added an asynchronous validation task in `PromptUsernameStep` to prevent empty usernames and display a localized error message if the username is empty.
* Added the "Username cannot be empty" string to the localization bundle for proper error messaging.

**Connection string handling:**

* Updated `PromptPasswordStep` to ensure the username is always set (to an empty string if not provided) when constructing the connection string.…a connection string