### PR TITLE
Copy and Paste: Collection Size Migration Info Message

### DIFF
--- a/docs/learn-more/copy-and-paste.md
+++ b/docs/learn-more/copy-and-paste.md
@@ -165,7 +165,7 @@ You will be prompted to choose one of four strategies:
   Source has a document:
 
   ```json
-  { "\_id": 1, "data": "new" }
+  { "_id": 1, "data": "new" }
   ```
 
 - **Result**: A new document is inserted into the target with a brand new `_id`. The inserted document will look like:

--- a/docs/learn-more/copy-and-paste.md
+++ b/docs/learn-more/copy-and-paste.md
@@ -1,0 +1,201 @@
+<!-- Learn More Section Badge or Breadcrumb -->
+
+> **Learn More** - [Back to Learn More Index](./index.md)
+
+---
+
+# Copy and Paste Collections
+
+The **Copy and Paste** feature in DocumentDB for VS Code provides a convenient way to move smaller datasets between collections, whether they are on the same server or across different connections. It is designed for quick, ad-hoc data transfers directly within the VS Code environment.
+
+**Table of Contents**
+
+- [How It Works](#how-it-works)
+- [Important Considerations](#important-considerations)
+- [Step-by-Step Guide](#step-by-step-guide)
+  - [Flow 1: Paste into a Database (Create a New Collection)](#flow-1-paste-into-a-database-create-a-new-collection)
+  - [Flow 2: Paste into an Existing Collection](#flow-2-paste-into-an-existing-collection)
+- [For True Data Migrations](#for-true-data-migrations)
+
+## How It Works
+
+The copy-and-paste process is designed to be efficient for smaller collections by streaming data through your local machine. Here’s a step-by-step breakdown of the process:
+
+1.  **Data Streaming**: The extension initiates a stream from the source collection, reading documents one by one.
+2.  **In-Memory Buffering**: Documents are collected into a buffer in your computer's memory.
+3.  **Bulk Write Operation**: Once the buffer is full, the extension performs a bulk write operation to the target collection. This is more efficient than writing documents one at a time.
+4.  **Continuous Cycle**: This process repeats - refilling the buffer from the source and writing to the target - until all documents from the source collection have been copied.
+
+This method avoids loading the entire collection into memory at once, making it suitable for collections that are moderately sized.
+
+## Important Considerations
+
+### Not a Snapshot Copy
+
+The copy-and-paste operation is **not an atomic snapshot**. It is a live data transfer. If documents are being written to the source collection while the copy process is running, it is possible that only a subset of the new data will be copied. This feature is best used for moving smaller, relatively static datasets.
+
+### Large Collection Warnings
+
+Because this feature streams data through your local machine, it can be slow and resource-intensive for very large collections. To prevent accidental performance issues, the extension will show a warning for collections that exceed a certain size.
+
+You can customize this behavior in the settings:
+
+- **`documentDB.copyPaste.showLargeCollectionWarning`**: (Default: `true`) Set to `false` to disable the warning entirely.
+- **`documentDB.copyPaste.largeCollectionWarningThreshold`**: (Default: `100000`) Adjust the number of documents that triggers the warning.
+
+> For more details on handling large datasets, see the section on [For True Data Migrations](#for-true-data-migrations).
+
+---
+
+## Step-by-Step Guide
+
+The process is guided by a wizard that adapts based on your target, providing two main flows.
+
+### Flow 1: Paste into a Database (Create a New Collection)
+
+This flow is triggered when you right-click a database in the Connections view and select `Paste Collection`.
+
+#### Step 1: Large Collection Warning (Optional)
+
+If the source collection contains a large number of documents, a warning dialog will appear first.
+
+> This warning can be disabled or its threshold adjusted in the extension settings, as noted in the [Important Considerations](#important-considerations) section.
+
+#### Step 2: Name the New Collection
+
+You will be prompted to provide a name for the new collection.
+
+#### Step 3: Confirmation
+
+A final summary is displayed, showing the source and target details, including the new collection name. You must confirm to start the operation.
+
+### Flow 2: Paste into an Existing Collection
+
+This flow is triggered when you right-click an existing collection in the Connections View and select `Paste Collection`.
+
+#### Step 1: Large Collection Warning (Optional)
+
+If the source collection contains a large number of documents, a warning dialog will appear first.
+
+> This warning can be disabled or its threshold adjusted in the extension settings, as noted in the [Important Considerations](#important-considerations) section.
+
+#### Step 2: Choose a Conflict Resolution Strategy
+
+Because you are merging documents into a collection that may already contain data, you must decide how to handle documents from the source that have the same `_id` as documents in the target.
+
+You will be prompted to choose one of four strategies:
+
+##### 1. **Abort on Conflict**
+
+- **What it does**: The copy operation stops after processing the batch that contains the first document with a duplicate `_id`. Within that batch, all documents that do not have a duplicate `_id` will be inserted. Any documents inserted from previous batches will also remain. The operation is not rolled back.
+- **Use case**: When you want to stop the process on the first conflict, accepting that some data may have already been transferred.
+- **Example**: Target has a document:
+
+  ```json
+  { "_id": 3, "data": "original-three" }
+  ```
+
+  A batch of source documents is being processed:
+
+  ```json
+  [
+    { "_id": 1, "data": "one" },
+    { "_id": 2, "data": "two" },
+    { "_id": 3, "data": "three" }
+  ]
+  ```
+
+- **Result**: A conflict is detected for the document with `_id: 3`. The documents with `_id: 1` and `_id: 2` from the batch are inserted into the target collection. The copy operation then aborts. The target collection will contain the newly inserted documents and its original data. There is no automatic cleanup.
+
+##### 2. **Skip Conflicting Documents**
+
+- **What it does**: If a document with a duplicate `_id` is found, the source document is ignored, and the operation continues with the next document.
+- **Use case**: When you want to merge new documents but leave existing ones untouched.
+- **Example**: Target has a document:
+
+  ```json
+  { "_id": 1, "data": "original" }
+  ```
+
+  Source has documents:
+
+  ```json
+  { "_id": 1, "data": "new" }
+  { "_id": 2, "data": "fresh" }
+  ```
+
+- **Result**: The document with `_id: 1` is skipped. The document with `_id: 2` is inserted.
+  The target collection will contain
+  ```json
+  { "_id": 1, "data": "original" }
+  { "_id": 2, "data": "fresh" }
+  ```
+
+##### 3. **Overwrite Existing Documents**
+
+- **What it does**: If a document with a duplicate `_id` is found, the existing document in the target collection is replaced with the document from the source.
+- **Use case**: When you want to update existing documents with fresh data from the source.
+- **Example**: Target has a document:
+
+  ```json
+  { "_id": 1, "data": "original" }
+  ```
+
+  Source has a document:
+
+  ```json
+  { "_id": 1, "data": "new" }
+  ```
+
+- **Result**: The document with `_id: 1` in the target is replaced. The target collection will contain
+  ```json
+  { "_id": 1, "data": "new" }
+  ```
+
+##### 4. **Generate New IDs for All Documents**
+
+- **What it does**: Ignores `_id` conflicts entirely by generating a new, unique `_id` for **every document** copied from the source. The original `_id` is preserved in a new field with a prefix `_original_id`.
+- **Use case**: When you want to duplicate a collection's data without losing the reference to the original IDs. This is useful for creating copies for testing or development.
+- **Example**: Target has a document:
+
+  ```json
+  { "_id": 1, "data": "original" }
+  ```
+
+  Source has a document:
+
+  ```json
+  { "\_id": 1, "data": "new" }
+  ```
+
+- **Result**: A new document is inserted into the target with a brand new `_id`. The inserted document will look like:
+  ```json
+  { "_id": ObjectId("..."), "_original_id": 1, "data": "new" }
+  ```
+  The original document in the target remains untouched.
+
+#### Step 3: Confirmation
+
+A final summary is displayed, showing the source, the target, and the chosen conflict resolution strategy. You must confirm to start the operation.
+
+---
+
+## For True Data Migrations
+
+The copy-and-paste feature is a developer convenience, not a dedicated migration tool. For production-level data migrations, especially those involving large datasets, complex transformations, or the need for data verification, a specialized migration service is strongly recommended.
+
+Dedicated migration tools offer significant advantages:
+
+- **Performance**: They often run directly within the data center, avoiding the need to transfer data through your local machine. This dramatically reduces network latency and external traffic costs.
+- **Reliability**: They provide features like assessments, data validation, and better error handling to ensure a successful migration.
+- **Migration Types**: They support both **offline migrations** (where the source database is taken offline) and **online migrations** (which allow the source application to continue running during the migration with minimal downtime).
+- **Scalability**: Built to handle terabytes of data efficiently.
+
+### Professional Data Migrations
+
+The best tool often depends on your data source, target, and migration requirements. An internet search for "DocumentDB migrations" will provide a variety of options. Many cloud platforms and database vendors offer dedicated migration tools that are optimized for performance, reliability, and scale.
+
+For example, Microsoft provides guidance on migrating between different versions of its own services, such as from Azure Cosmos DB for MongoDB (RU) to the vCore-based service:
+[Migrate from Azure Cosmos DB for MongoDB (RU) to Azure Cosmos DB for MongoDB (vCore)](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/how-to-migrate-vcore)
+
+Before starting any significant migration, it is important to perform a thorough requirements analysis. For critical or large-scale projects, seeking professional help from migration specialists can ensure a successful outcome.

--- a/docs/learn-more/index.md
+++ b/docs/learn-more/index.md
@@ -16,4 +16,5 @@ This section contains additional documentation for features and concepts in Docu
 - [Local Connection](./local-connection.md)
   - [Local Connection: Azure CosmosDB for MongoDB (RU) Emulator](./local-connection-mongodb-ru.md)
   - [Local Connection: DocumentDB Local](./local-connection-documentdb-local.md)
+- [Copy and Paste Collections](./copy-and-paste.md)
 - [Data Migrations](./data-migrations.md) ⚠️ _Experimental_

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -132,6 +132,7 @@
   "Connection: \"{selectedConnectionName}\"\n\nThe connection will be added to the \"Connections View\" in the \"DocumentDB for VS Code\" extension. The \"Connections View\" will be opened once this process completes.\n\nDo you want to continue?": "Connection: \"{selectedConnectionName}\"\n\nThe connection will be added to the \"Connections View\" in the \"DocumentDB for VS Code\" extension. The \"Connections View\" will be opened once this process completes.\n\nDo you want to continue?",
   "Connection: {connectionName}": "Connection: {connectionName}",
   "Connections have moved": "Connections have moved",
+  "Continue": "Continue",
   "Copied {0} of {1} documents": "Copied {0} of {1} documents",
   "Copy \"{sourceCollection}\" from \"{sourceDatabase}\" to \"{targetDatabase}/{targetCollection}\"": "Copy \"{sourceCollection}\" from \"{sourceDatabase}\" to \"{targetDatabase}/{targetCollection}\"",
   "Copy index definitions from source collection?": "Copy index definitions from source collection?",
@@ -327,6 +328,7 @@
   "Invalid document ID: {0}": "Invalid document ID: {0}",
   "Invalid semver \"{0}\".": "Invalid semver \"{0}\".",
   "JSON View": "JSON View",
+  "Large Collection Copy Operation": "Large Collection Copy Operation",
   "Learn more": "Learn more",
   "Learn more about {0}.": "Learn more about {0}.",
   "Learn more about DocumentDB and MongoDB migrations.": "Learn more about DocumentDB and MongoDB migrations.",
@@ -492,6 +494,7 @@
   "Task will fail at a random step for testing": "Task will fail at a random step for testing",
   "Task with ID {0} already exists": "Task with ID {0} already exists",
   "Task with ID {0} not found": "Task with ID {0} not found",
+  "Tell me more": "Tell me more",
   "The \"{databaseId}\" database has been deleted.": "The \"{databaseId}\" database has been deleted.",
   "The \"{name}\" database has been created.": "The \"{name}\" database has been created.",
   "The \"{newCollectionName}\" collection has been created.": "The \"{newCollectionName}\" collection has been created.",
@@ -604,6 +607,7 @@
   "You might be asked for credentials to establish the connection.\nDo you want to continue?\n\nNote: You can disable these URL handling confirmations in the extension settings.": "You might be asked for credentials to establish the connection.\nDo you want to continue?\n\nNote: You can disable these URL handling confirmations in the extension settings.",
   "You must open a *.vscode-documentdb-scrapbook file to run commands.": "You must open a *.vscode-documentdb-scrapbook file to run commands.",
   "You need to provide the password for \"{username}\" in order to continue. Your password will not be stored.": "You need to provide the password for \"{username}\" in order to continue. Your password will not be stored.",
+  "You're attempting to copy a large number of documents. This process can be slow because it downloads all documents from the source to your computer and then uploads them to the destination, which can take a significant amount of time and bandwidth.\n\nFor larger data migrations, we recommend using a dedicated migration tool for a faster experience.\n\nNote: You can disable this warning or adjust the document count threshold in the extension settings.": "You're attempting to copy a large number of documents. This process can be slow because it downloads all documents from the source to your computer and then uploads them to the destination, which can take a significant amount of time and bandwidth.\n\nFor larger data migrations, we recommend using a dedicated migration tool for a faster experience.\n\nNote: You can disable this warning or adjust the document count threshold in the extension settings.",
   "Your database stores documents with embedded fields, allowing for hierarchical data organization.": "Your database stores documents with embedded fields, allowing for hierarchical data organization.",
   "Your VS Code window must be reloaded to perform this action.": "Your VS Code window must be reloaded to perform this action."
 }

--- a/package.json
+++ b/package.json
@@ -877,6 +877,13 @@
             "default": true,
             "description": "Show detailed operation summaries, displaying messages for actions such as database drops, document additions, deletions, or similar events."
           },
+          "documentDB.copyPaste.largeCollectionWarningThreshold": {
+            "order": 12,
+            "type": "number",
+            "default": 50000,
+            "minimum": 1,
+            "description": "The number of documents in a source collection that triggers a warning about potentially slow copy and paste operations. Set to a higher value to reduce warnings, or a lower value to see warnings for smaller collections."
+          },
           "documentDB.local.port": {
             "order": 20,
             "type": "integer",

--- a/package.json
+++ b/package.json
@@ -877,10 +877,16 @@
             "default": true,
             "description": "Show detailed operation summaries, displaying messages for actions such as database drops, document additions, deletions, or similar events."
           },
-          "documentDB.copyPaste.largeCollectionWarningThreshold": {
+          "documentDB.copyPaste.showLargeCollectionWarning": {
             "order": 12,
+            "type": "boolean",
+            "default": true,
+            "description": "Show a warning dialog before copying large collections. When disabled, copy operations will proceed without any size-based warnings."
+          },
+          "documentDB.copyPaste.largeCollectionWarningThreshold": {
+            "order": 13,
             "type": "number",
-            "default": 50000,
+            "default": 100000,
             "minimum": 1,
             "description": "The number of documents in a source collection that triggers a warning about potentially slow copy and paste operations. Set to a higher value to reduce warnings, or a lower value to see warnings for smaller collections."
           },

--- a/src/commands/copyCollection/copyCollection.ts
+++ b/src/commands/copyCollection/copyCollection.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { type IActionContext } from '@microsoft/vscode-azext-utils';
+import { type IActionContext, openUrl } from '@microsoft/vscode-azext-utils';
 import { l10n, window } from 'vscode';
 import { ext } from '../../extensionVariables';
 import { type CollectionItem } from '../../tree/documentdb/CollectionItem';
@@ -20,6 +20,7 @@ export async function copyCollection(context: IActionContext, node: CollectionIt
     const databaseName = node.databaseInfo.name;
 
     const undoCommand = l10n.t('Undo');
+    const learnMoreCommand = l10n.t('Learn more');
 
     const selectedCommand = await window.showInformationMessage(
         l10n.t(
@@ -29,11 +30,15 @@ export async function copyCollection(context: IActionContext, node: CollectionIt
         ),
         l10n.t('OK'),
         undoCommand,
+        learnMoreCommand,
     );
 
     if (selectedCommand === undoCommand) {
         ext.copiedCollectionNode = undefined;
         context.telemetry.properties.copiedCollectionUndone = 'true';
         void window.showInformationMessage(l10n.t('Copy operation cancelled.'));
+    } else if (selectedCommand === learnMoreCommand) {
+        await openUrl('https://aka.ms/vscode-documentdb-copy-and-paste');
+        context.telemetry.properties.learnMoreClicked = 'true';
     }
 }

--- a/src/commands/pasteCollection/LargeCollectionWarningStep.ts
+++ b/src/commands/pasteCollection/LargeCollectionWarningStep.ts
@@ -38,23 +38,7 @@ export class LargeCollectionWarningStep extends AzureWizardPromptStep<PasteColle
         context.telemetry.properties.largeCollectionWarningResult = response.title;
 
         if (response.title === tellMeMoreButton) {
-            // User chose to see documentation - abort the wizard flow
-
-            const migrationUrl = 'https://github.com/microsoft/vscode-cosmosdb/';
-
-            try {
-                // Try to open with Simple Browser first (extension may not be available)
-                await vscode.commands.executeCommand('simpleBrowser.api.open', migrationUrl, {
-                    viewColumn: vscode.ViewColumn.Beside,
-                    preserveFocus: false,
-                });
-                context.telemetry.properties.documentationOpenMethod = 'simpleBrowser';
-            } catch {
-                await openUrl(migrationUrl);
-                context.telemetry.properties.documentationOpenMethod = 'openUrl';
-            }
-
-            // Abort the wizard flow after opening documentation
+            await openUrl('https://aka.ms/vscode-documentdb-copy-and-paste-or-migration');
             throw new UserCancelledError();
         }
     }

--- a/src/commands/pasteCollection/LargeCollectionWarningStep.ts
+++ b/src/commands/pasteCollection/LargeCollectionWarningStep.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep, openUrl, UserCancelledError } from '@microsoft/vscode-azext-utils';
+import * as l10n from '@vscode/l10n';
+import * as vscode from 'vscode';
+import { type PasteCollectionWizardContext } from './PasteCollectionWizardContext';
+
+export class LargeCollectionWarningStep extends AzureWizardPromptStep<PasteCollectionWizardContext> {
+    public async prompt(context: PasteCollectionWizardContext): Promise<void> {
+        const title = l10n.t('Large Collection Copy Operation');
+        const detail = l10n.t(
+            'This copy and paste operation can be slow because the data is being read and written by your system. For larger migrations, a dedicated migration approach can be better.',
+        );
+
+        const tellMeMoreButton = l10n.t('Tell me more');
+        const continueButton = l10n.t('Continue');
+
+        // Show modal dialog with custom buttons
+        const response = await vscode.window.showInformationMessage(
+            title,
+            {
+                modal: true,
+                detail: detail,
+            },
+            { title: tellMeMoreButton },
+            { title: continueButton },
+        );
+
+        if (!response) {
+            // User pressed Esc or clicked the X button - treat as cancellation
+            context.telemetry.properties.largeCollectionWarningResult = 'cancelled';
+            throw new UserCancelledError();
+        }
+
+        if (response.title === tellMeMoreButton) {
+            // User chose to see documentation - abort the wizard flow
+            context.telemetry.properties.largeCollectionWarningResult = 'tellMeMore';
+
+            // Open documentation (placeholder URL as requested)
+            const migrationUrl = 'https://github.com/microsoft/vscode-cosmosdb/';
+
+            try {
+                // Try to open with Simple Browser first (extension may not be available)
+                await vscode.commands.executeCommand('simpleBrowser.api.open', migrationUrl, {
+                    viewColumn: vscode.ViewColumn.Beside,
+                    preserveFocus: false,
+                });
+                context.telemetry.properties.documentationOpenMethod = 'simpleBrowser';
+            } catch {
+                await openUrl(migrationUrl);
+                context.telemetry.properties.documentationOpenMethod = 'openUrl';
+            }
+
+            // Abort the wizard flow after opening documentation
+            throw new UserCancelledError();
+        }
+
+        // User chose to continue
+        context.telemetry.properties.largeCollectionWarningResult = 'continue';
+    }
+
+    public shouldPrompt(): boolean {
+        // The conditional logic is handled in the main wizard file
+        // This step is only added to the wizard when needed
+        return true;
+    }
+}

--- a/src/commands/pasteCollection/LargeCollectionWarningStep.ts
+++ b/src/commands/pasteCollection/LargeCollectionWarningStep.ts
@@ -12,7 +12,7 @@ export class LargeCollectionWarningStep extends AzureWizardPromptStep<PasteColle
     public async prompt(context: PasteCollectionWizardContext): Promise<void> {
         const title = l10n.t('Large Collection Copy Operation');
         const detail = l10n.t(
-            'This copy and paste operation can be slow because the data is being read and written by the extension. For larger migrations, a dedicated migration approach can be better.\n\nNote: You can configure the threshold for this warning in the extension settings (documentDB.copyPaste.largeCollectionWarningThreshold).',
+            "You're attempting to copy a large number of documents. This process can be slow because it downloads all documents from the source to your computer and then uploads them to the destination, which can take a significant amount of time and bandwidth.\n\nFor larger data migrations, we recommend using a dedicated migration tool for a faster experience.\n\nNote: You can disable this warning or adjust the document count threshold in the extension settings.",
         );
 
         const tellMeMoreButton = l10n.t('Tell me more');
@@ -25,8 +25,8 @@ export class LargeCollectionWarningStep extends AzureWizardPromptStep<PasteColle
                 modal: true,
                 detail: detail,
             },
-            { title: tellMeMoreButton },
             { title: continueButton },
+            { title: tellMeMoreButton },
         );
 
         if (!response) {
@@ -35,11 +35,11 @@ export class LargeCollectionWarningStep extends AzureWizardPromptStep<PasteColle
             throw new UserCancelledError();
         }
 
+        context.telemetry.properties.largeCollectionWarningResult = response.title;
+
         if (response.title === tellMeMoreButton) {
             // User chose to see documentation - abort the wizard flow
-            context.telemetry.properties.largeCollectionWarningResult = 'tellMeMore';
 
-            // Open documentation (placeholder URL as requested)
             const migrationUrl = 'https://github.com/microsoft/vscode-cosmosdb/';
 
             try {
@@ -57,14 +57,9 @@ export class LargeCollectionWarningStep extends AzureWizardPromptStep<PasteColle
             // Abort the wizard flow after opening documentation
             throw new UserCancelledError();
         }
-
-        // User chose to continue
-        context.telemetry.properties.largeCollectionWarningResult = 'continue';
     }
 
     public shouldPrompt(): boolean {
-        // The conditional logic is handled in the main wizard file
-        // This step is only added to the wizard when needed
         return true;
     }
 }

--- a/src/commands/pasteCollection/LargeCollectionWarningStep.ts
+++ b/src/commands/pasteCollection/LargeCollectionWarningStep.ts
@@ -12,7 +12,7 @@ export class LargeCollectionWarningStep extends AzureWizardPromptStep<PasteColle
     public async prompt(context: PasteCollectionWizardContext): Promise<void> {
         const title = l10n.t('Large Collection Copy Operation');
         const detail = l10n.t(
-            'This copy and paste operation can be slow because the data is being read and written by your system. For larger migrations, a dedicated migration approach can be better.',
+            'This copy and paste operation can be slow because the data is being read and written by the extension. For larger migrations, a dedicated migration approach can be better.\n\nNote: You can configure the threshold for this warning in the extension settings (documentDB.copyPaste.largeCollectionWarningThreshold).',
         );
 
         const tellMeMoreButton = l10n.t('Tell me more');

--- a/src/commands/pasteCollection/pasteCollection.ts
+++ b/src/commands/pasteCollection/pasteCollection.ts
@@ -137,19 +137,25 @@ export async function pasteCollection(
     // Create wizard with appropriate steps
     const promptSteps: AzureWizardPromptStep<PasteCollectionWizardContext>[] = [];
 
-    // Read the large collection warning threshold from settings
-    const largeCollectionThreshold = vscode.workspace
+    // Read large collection warning settings
+    const showLargeCollectionWarning = vscode.workspace
         .getConfiguration()
-        .get<number>(ext.settingsKeys.largeCollectionWarningThreshold, 50000);
+        .get<boolean>(ext.settingsKeys.showLargeCollectionWarning, true);
 
     // Add warning step for large collections as the first step
-    if (sourceCollectionSize !== undefined && sourceCollectionSize > largeCollectionThreshold) {
-        context.telemetry.properties.largeCollectionWarningShown = 'true';
-        context.telemetry.measurements.sourceCollectionSizeForWarning = sourceCollectionSize;
-        context.telemetry.measurements.largeCollectionThresholdUsed = largeCollectionThreshold;
-        promptSteps.push(new LargeCollectionWarningStep());
+    if (showLargeCollectionWarning) {
+        const largeCollectionThreshold = vscode.workspace
+            .getConfiguration()
+            .get<number>(ext.settingsKeys.largeCollectionWarningThreshold, 100000);
+
+        if (sourceCollectionSize !== undefined && sourceCollectionSize > largeCollectionThreshold) {
+            promptSteps.push(new LargeCollectionWarningStep());
+            context.telemetry.properties.largeCollectionWarningShown = 'true';
+            context.telemetry.measurements.sourceCollectionSizeForWarning = sourceCollectionSize;
+            context.telemetry.measurements.largeCollectionThresholdUsed = largeCollectionThreshold;
+        }
     } else {
-        context.telemetry.properties.largeCollectionWarningShown = 'false';
+        context.telemetry.properties.largeCollectionWarningDisabled = 'true';
     }
 
     // Only prompt for new collection name if pasting into a database (creating new collection)

--- a/src/commands/pasteCollection/pasteCollection.ts
+++ b/src/commands/pasteCollection/pasteCollection.ts
@@ -13,6 +13,7 @@ import { CollectionItem } from '../../tree/documentdb/CollectionItem';
 import { DatabaseItem } from '../../tree/documentdb/DatabaseItem';
 import { ConfirmOperationStep } from './ConfirmOperationStep';
 import { ExecuteStep } from './ExecuteStep';
+import { LargeCollectionWarningStep } from './LargeCollectionWarningStep';
 import { type PasteCollectionWizardContext } from './PasteCollectionWizardContext';
 import { PromptConflictResolutionStep } from './PromptConflictResolutionStep';
 import { PromptNewCollectionNameStep } from './PromptNewCollectionNameStep';
@@ -135,6 +136,13 @@ export async function pasteCollection(
 
     // Create wizard with appropriate steps
     const promptSteps: AzureWizardPromptStep<PasteCollectionWizardContext>[] = [];
+
+    // Add warning step for large collections as the first step (> 50,000 documents)
+    if (sourceCollectionSize !== undefined && sourceCollectionSize > 50000) {
+        context.telemetry.properties.largeCollectionWarningShown = 'true';
+        context.telemetry.measurements.sourceCollectionSizeForWarning = sourceCollectionSize;
+        promptSteps.push(new LargeCollectionWarningStep());
+    }
 
     // Only prompt for new collection name if pasting into a database (creating new collection)
     if (!isTargetExistingCollection) {

--- a/src/commands/pasteCollection/pasteCollection.ts
+++ b/src/commands/pasteCollection/pasteCollection.ts
@@ -150,6 +150,7 @@ export async function pasteCollection(
 
         if (sourceCollectionSize !== undefined && sourceCollectionSize > largeCollectionThreshold) {
             promptSteps.push(new LargeCollectionWarningStep());
+
             context.telemetry.properties.largeCollectionWarningShown = 'true';
             context.telemetry.measurements.sourceCollectionSizeForWarning = sourceCollectionSize;
             context.telemetry.measurements.largeCollectionThresholdUsed = largeCollectionThreshold;

--- a/src/commands/pasteCollection/pasteCollection.ts
+++ b/src/commands/pasteCollection/pasteCollection.ts
@@ -137,11 +137,19 @@ export async function pasteCollection(
     // Create wizard with appropriate steps
     const promptSteps: AzureWizardPromptStep<PasteCollectionWizardContext>[] = [];
 
-    // Add warning step for large collections as the first step (> 50,000 documents)
-    if (sourceCollectionSize !== undefined && sourceCollectionSize > 50000) {
+    // Read the large collection warning threshold from settings
+    const largeCollectionThreshold = vscode.workspace
+        .getConfiguration()
+        .get<number>(ext.settingsKeys.largeCollectionWarningThreshold, 50000);
+
+    // Add warning step for large collections as the first step
+    if (sourceCollectionSize !== undefined && sourceCollectionSize > largeCollectionThreshold) {
         context.telemetry.properties.largeCollectionWarningShown = 'true';
         context.telemetry.measurements.sourceCollectionSizeForWarning = sourceCollectionSize;
+        context.telemetry.measurements.largeCollectionThresholdUsed = largeCollectionThreshold;
         promptSteps.push(new LargeCollectionWarningStep());
+    } else {
+        context.telemetry.properties.largeCollectionWarningShown = 'false';
     }
 
     // Only prompt for new collection name if pasting into a database (creating new collection)

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -66,6 +66,7 @@ export namespace ext {
         export const confirmationStyle = 'documentDB.confirmations.confirmationStyle';
         export const showOperationSummaries = 'documentDB.userInterface.ShowOperationSummaries';
         export const showUrlHandlingConfirmations = 'documentDB.confirmations.showUrlHandlingConfirmations';
+        export const largeCollectionWarningThreshold = 'documentDB.copyPaste.largeCollectionWarningThreshold';
         export const localPort = 'documentDB.local.port';
 
         export namespace vsCode {

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -66,6 +66,7 @@ export namespace ext {
         export const confirmationStyle = 'documentDB.confirmations.confirmationStyle';
         export const showOperationSummaries = 'documentDB.userInterface.ShowOperationSummaries';
         export const showUrlHandlingConfirmations = 'documentDB.confirmations.showUrlHandlingConfirmations';
+        export const showLargeCollectionWarning = 'documentDB.copyPaste.showLargeCollectionWarning';
         export const largeCollectionWarningThreshold = 'documentDB.copyPaste.largeCollectionWarningThreshold';
         export const localPort = 'documentDB.local.port';
 


### PR DESCRIPTION
This pull request introduces a comprehensive user-facing warning system for large collection copy operations in the DocumentDB for VS Code extension. It adds a detailed "Copy and Paste Collections" documentation page, new settings for controlling large collection warnings, and updates the copy/paste workflow to prompt users when attempting to copy large datasets. The changes also include localized strings and telemetry enhancements for better tracking of user actions.

**User Experience Improvements:**

* Added a modal warning dialog (`LargeCollectionWarningStep`) when users attempt to copy collections exceeding a configurable size threshold, with options to continue, learn more, or cancel. The dialog links to detailed documentation for best practices and migration alternatives. [[1]](diffhunk://#diff-e9c88849f7ded2997c44d60d17c198b3d2b3ce252e0b2d0c7ec0fd34762e053bR1-R49) [[2]](diffhunk://#diff-7bd45d2e60ef3a9334370a0c9d6da6852681cf13e54eff65b26c6e306d6301feR140-R161)
* Updated the copy collection command to include a "Learn more" button that opens documentation about the copy and paste feature. [[1]](diffhunk://#diff-305c59d072ac0cf5ce6d8a4755120f0ba6eb87f1c0512fa6546d061d913b28afR23) [[2]](diffhunk://#diff-305c59d072ac0cf5ce6d8a4755120f0ba6eb87f1c0512fa6546d061d913b28afR33-R42) [[3]](diffhunk://#diff-305c59d072ac0cf5ce6d8a4755120f0ba6eb87f1c0512fa6546d061d913b28afL6-R6)

**Documentation:**

* Added a new `docs/learn-more/copy-and-paste.md` page explaining how the copy and paste feature works, important considerations, step-by-step guides for both new and existing collections, conflict resolution strategies, and recommendations for large-scale migrations.
* Linked the new documentation page in the Learn More index for discoverability.

**Settings & Configuration:**

* Introduced two new settings in `package.json`:
  - [`documentDB.copyPaste.showLargeCollectionWarning`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R880-R892): Enables/disables the large collection warning dialog.
  - [`documentDB.copyPaste.largeCollectionWarningThreshold`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R880-R892): Sets the document count threshold that triggers the warning.
* Registered these new settings in the extension variable namespace for consistent access.

**Localization:**

* Added and updated localized strings to support the new warning dialogs, buttons, and documentation references. [[1]](diffhunk://#diff-829b512e02461234524c007941f3260e67a43b109f48bedf257ab8e8033cc527R135) [[2]](diffhunk://#diff-829b512e02461234524c007941f3260e67a43b109f48bedf257ab8e8033cc527R331) [[3]](diffhunk://#diff-829b512e02461234524c007941f3260e67a43b109f48bedf257ab8e8033cc527R497) [[4]](diffhunk://#diff-829b512e02461234524c007941f3260e67a43b109f48bedf257ab8e8033cc527R610)