### PR TITLE
fix: tab & shift+tab for query input boxes

### DIFF
--- a/src/webviews/components/MonacoAutoHeight.tsx
+++ b/src/webviews/components/MonacoAutoHeight.tsx
@@ -188,6 +188,18 @@ export const MonacoAutoHeight = (props: MonacoAutoHeightProps) => {
         }
     };
 
+    /**
+     * Configures the Tab key behavior for the Monaco editor.
+     *
+     * When called, this function sets up or removes a keydown handler for the Tab key.
+     * If `shouldTrap` is true, Tab/Shift+Tab are trapped within the editor (focus remains in editor).
+     * If `shouldTrap` is false, Tab/Shift+Tab move focus to the next/previous focusable element outside the editor.
+     *
+     * @param {monacoEditor.editor.IStandaloneCodeEditor} editor - The Monaco editor instance.
+     * @param {boolean} shouldTrap - Whether to trap Tab key in the editor.
+     *   - true: Tab/Shift+Tab are trapped in the editor.
+     *   - false: Tab/Shift+Tab move focus to next/previous element.
+     */
     const configureTabKeyMode = (editor: monacoEditor.editor.IStandaloneCodeEditor, shouldTrap: boolean) => {
         if (tabKeyDisposerRef.current) {
             tabKeyDisposerRef.current.dispose();


### PR DESCRIPTION
This pull request enhances the `MonacoAutoHeight` component to improve keyboard accessibility and allow customizable Tab key behavior. The most important changes are the addition of a new `trapTabKey` prop, logic to control Tab focus handling, and integration with Fluent UI's focus management utilities.

**Accessibility and Focus Management Improvements:**

* Added a new `trapTabKey` prop to `MonacoAutoHeightProps`, allowing consumers to specify whether Tab/Shift+Tab should keep focus in the Monaco editor or move to the next/previous focusable element.
* Integrated Fluent UI's `useFocusFinders` hook to identify and move focus between focusable elements outside the editor when Tab/Shift+Tab is pressed and `trapTabKey` is false. [[1]](diffhunk://#diff-86b932436c92735057ce54a7b236b36bd5b97207b8ab2e8ee3072c274eed71ceR6) [[2]](diffhunk://#diff-86b932436c92735057ce54a7b236b36bd5b97207b8ab2e8ee3072c274eed71ceR62)
* Implemented the `configureTabKeyMode` function to toggle Tab key trapping dynamically based on the `trapTabKey` prop, and ensured proper cleanup of event listeners on unmount or prop changes. [[1]](diffhunk://#diff-86b932436c92735057ce54a7b236b36bd5b97207b8ab2e8ee3072c274eed71ceR98-R99) [[2]](diffhunk://#diff-86b932436c92735057ce54a7b236b36bd5b97207b8ab2e8ee3072c274eed71ceR124-R140) [[3]](diffhunk://#diff-86b932436c92735057ce54a7b236b36bd5b97207b8ab2e8ee3072c274eed71ceR191-R241)

These changes make the editor more accessible and flexible for keyboard users, especially in forms or multi-component layouts.