### PR TITLE
Feat: default + configurable page size of 50

### DIFF
--- a/package.json
+++ b/package.json
@@ -951,6 +951,17 @@
             "description": "The batch size to be used when querying working with the shell.",
             "default": 50
           },
+          "documentDB.collectionView.defaultPageSize": {
+            "type": "number",
+            "description": "Default page size for loading data in the collection view.",
+            "default": 50,
+            "enum": [
+              10,
+              50,
+              100,
+              500
+            ]
+          },
           "documentDB.aiAssistant.findQueryPromptPath": {
             "type": [
               "string",

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -66,6 +66,7 @@ export namespace ext {
         export const showOperationSummaries = 'documentDB.userInterface.ShowOperationSummaries';
         export const showUrlHandlingConfirmations = 'documentDB.confirmations.showUrlHandlingConfirmations';
         export const localPort = 'documentDB.local.port';
+        export const collectionViewDefaultPageSize = 'documentDB.collectionView.defaultPageSize';
 
         export namespace vsCode {
             export const proxyStrictSSL = 'http.proxyStrictSSL';

--- a/src/webviews/documentdb/collectionView/CollectionView.tsx
+++ b/src/webviews/documentdb/collectionView/CollectionView.tsx
@@ -8,6 +8,7 @@ import * as l10n from '@vscode/l10n';
 import { type JSX, useEffect, useRef, useState } from 'react';
 import { type TableDataEntry } from '../../../documentdb/ClusterSession';
 import { UsageImpact } from '../../../utils/surveyTypes';
+import { useConfiguration } from '../../api/webview-client/useConfiguration';
 import { useTrpcClient } from '../../api/webview-client/useTrpcClient';
 import { useSelectiveContextMenuPrevention } from '../../api/webview-client/utils/useSelectiveContextMenuPrevention';
 import './collectionView.scss';
@@ -17,6 +18,7 @@ import {
     DefaultCollectionViewContext,
     Views,
 } from './collectionViewContext';
+import { type CollectionViewWebviewConfigurationType } from './collectionViewController';
 import { QueryEditor } from './components/queryEditor/QueryEditor';
 import { QueryInsightsMain } from './components/queryInsightsTab/QueryInsightsTab';
 import { DataViewPanelJSON } from './components/resultsTab/DataViewPanelJSON';
@@ -43,7 +45,7 @@ export const CollectionView = (): JSX.Element => {
      * Use the configuration object to access the data passed to the webview at its creation.
      * Feel free to update the content of the object. It won't be synced back to the extension though.
      */
-    //const configuration = useConfiguration<DocumentsViewWebviewConfigurationType>();
+    const configuration = useConfiguration<CollectionViewWebviewConfigurationType>();
 
     /**
      * Use the `useTrpcClient` hook to get the tRPC client
@@ -67,7 +69,13 @@ export const CollectionView = (): JSX.Element => {
      */
 
     // that's our current global context of the view
-    const [currentContext, setCurrentContext] = useState<CollectionViewContextType>(DefaultCollectionViewContext);
+    const [currentContext, setCurrentContext] = useState<CollectionViewContextType>(() => ({
+        ...DefaultCollectionViewContext,
+        activeQuery: {
+            ...DefaultCollectionViewContext.activeQuery,
+            pageSize: configuration.defaultPageSize,
+        },
+    }));
 
     useSelectiveContextMenuPrevention();
 

--- a/src/webviews/documentdb/collectionView/collectionViewController.ts
+++ b/src/webviews/documentdb/collectionView/collectionViewController.ts
@@ -5,6 +5,7 @@
 
 import { API } from '../../../DocumentDBExperiences';
 import { ext } from '../../../extensionVariables';
+import { SettingsService } from '../../../services/SettingsService';
 import { WebviewController } from '../../api/extension-server/WebviewController';
 import { type RouterContext } from './collectionViewRouter';
 
@@ -13,16 +14,26 @@ export type CollectionViewWebviewConfigurationType = {
     clusterId: string;
     databaseName: string;
     collectionName: string;
+    defaultPageSize: number;
 };
 
 export class CollectionViewController extends WebviewController<CollectionViewWebviewConfigurationType> {
-    constructor(initialData: CollectionViewWebviewConfigurationType) {
+    constructor(initialData: Omit<CollectionViewWebviewConfigurationType, 'defaultPageSize'>) {
         // ext.context here is the vscode.ExtensionContext required by the ReactWebviewPanelController's original implementation
         // we're not modifying it here in order to be ready for future updates of the webview API.
 
         const title: string = `${initialData.databaseName}/${initialData.collectionName}`;
 
-        super(ext.context, API.DocumentDB, title, 'mongoClustersCollectionView', initialData);
+        // Get the default page size from settings
+        const defaultPageSize =
+            SettingsService.getSetting<number>(ext.settingsKeys.collectionViewDefaultPageSize) ?? 50;
+
+        const fullInitialData: CollectionViewWebviewConfigurationType = {
+            ...initialData,
+            defaultPageSize,
+        };
+
+        super(ext.context, API.DocumentDB, title, 'mongoClustersCollectionView', fullInitialData);
 
         const trpcContext: RouterContext = {
             dbExperience: API.DocumentDB,

--- a/src/webviews/documentdb/collectionView/components/toolbar/ToolbarViewNavigation.tsx
+++ b/src/webviews/documentdb/collectionView/components/toolbar/ToolbarViewNavigation.tsx
@@ -169,14 +169,14 @@ export const ToolbarViewNavigation = (): JSX.Element => {
                 <Dropdown
                     disabled={currentContext.isLoading}
                     onOptionSelect={(_e, data) => {
-                        setPageSize(parseInt(data.optionText ?? '10'));
+                        setPageSize(parseInt(data.optionText ?? currentContext.activeQuery.pageSize.toString()));
                     }}
                     style={{ minWidth: '100px', maxWidth: '100px' }}
-                    defaultValue="10"
-                    defaultSelectedOptions={['10']}
+                    value={currentContext.activeQuery.pageSize.toString()}
+                    selectedOptions={[currentContext.activeQuery.pageSize.toString()]}
                 >
                     <Option key="10">10</Option>
-                    <Option key="10">50</Option>
+                    <Option key="50">50</Option>
                     <Option key="100">100</Option>
                     <Option key="500">500</Option>
                 </Dropdown>


### PR DESCRIPTION
This pull request introduces support for configuring the default page size in the DocumentDB collection view, allowing users to customize how many documents are loaded per page. The main changes involve adding a new configuration setting, updating the controller to inject this value into the webview, and ensuring the UI properly reflects and uses the configured default.

**Configuration and Settings Integration:**

* Added a new setting `documentDB.collectionView.defaultPageSize` to `package.json`, allowing users to select a default page size from predefined options (10, 50, 100, 500).
* Registered the new setting key `collectionViewDefaultPageSize` in `src/extensionVariables.ts` for consistent usage throughout the extension.

**Webview Controller and Data Flow:**

* Updated the `CollectionViewController` to fetch the default page size from settings and inject it into the webview's initial configuration, ensuring the UI receives the correct value.

**Collection View UI Updates:**

* Modified the `CollectionView` component to initialize its context using the configured default page size, so the page size is set correctly when the view loads.
* Updated the page size dropdown in the toolbar to use the current context's page size for its value and selection, improving consistency and user experience.