### PR TITLE
fix: no reset of query insights while only paging through data

### DIFF
--- a/src/webviews/documentdb/collectionView/CollectionView.tsx
+++ b/src/webviews/documentdb/collectionView/CollectionView.tsx
@@ -97,14 +97,22 @@ export const CollectionView = (): JSX.Element => {
     }, [currentQueryResults, currentContext]);
 
     /**
-     * Reset query insights when query execution starts
-     * This happens whenever the user executes a query (even if same query text)
+     * Reset query insights when query changes (not on pagination)
+     * Only reset when executionIntent is 'initial' or 'refresh'
+     * On 'pagination', preserve Query Insights data since the query hasn't changed
      */
     useEffect(() => {
-        setCurrentContext((prev) => ({
-            ...prev,
-            queryInsights: DefaultCollectionViewContext.queryInsights,
-        }));
+        const intent = currentContext.activeQuery.executionIntent;
+
+        // Only reset on actual query changes, not pagination
+        if (intent === 'initial' || intent === 'refresh') {
+            console.trace('[CollectionView] Query changed (intent: {0}), resetting Query Insights', intent);
+            setCurrentContext((prev) => ({
+                ...prev,
+                queryInsights: DefaultCollectionViewContext.queryInsights,
+            }));
+        }
+        // On 'pagination' → preserve existing Query Insights state
     }, [currentContext.activeQuery]);
 
     /**


### PR DESCRIPTION
This pull request updates the logic for resetting Query Insights in the `CollectionView` component to improve user experience during query execution. Now, Query Insights are only reset when a new query is executed or the query is refreshed, and are preserved during pagination.

Query Insights reset logic improvements:

* Updated the `useEffect` in `CollectionView.tsx` to reset `queryInsights` only when `executionIntent` is `'initial'` or `'refresh'`, and to preserve Query Insights during `'pagination'` intents.