### PR TITLE
chore: update version to 0.7.2 and document changes in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ## 0.7.1 _(skipped)_
 
+Version 0.7.1 was reserved for an internal validation build and was not released on the Marketplace.
 ## 0.7.0
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@
 
 - **Dependency Updates**: Updates `minimatch` (3.1.2 → 3.1.4), `qs`, and `body-parser` to address security vulnerabilities. [#505](https://github.com/microsoft/vscode-documentdb/pull/505), [#514](https://github.com/microsoft/vscode-documentdb/pull/514)
 
-## 0.7.1 _(skipped)_
+## 0.7.1 _skipped_
 
 Version 0.7.1 was reserved for an internal validation build and was not released on the Marketplace.
+
 ## 0.7.0
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.7.1
+## 0.7.2
 
 ### Improvements
 
@@ -14,6 +14,8 @@
 ### Security
 
 - **Dependency Updates**: Updates `minimatch` (3.1.2 → 3.1.4), `qs`, and `body-parser` to address security vulnerabilities. [#505](https://github.com/microsoft/vscode-documentdb/pull/505), [#514](https://github.com/microsoft/vscode-documentdb/pull/514)
+
+## 0.7.1 _(skipped)_
 
 ## 0.7.0
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ The User Manual provides guidance on using DocumentDB for VS Code. It contains d
 
 Explore the history of updates and improvements to the DocumentDB for VS Code extension. Each release brings new features, enhancements, and fixes to improve your experience.
 
-- [0.7](./release-notes/0.7), [0.7.1](./release-notes/0.7#patch-release-v071)
+- [0.7](./release-notes/0.7), [0.7.2](./release-notes/0.7#patch-release-v072)
 - [0.6](./release-notes/0.6), [0.6.1](./release-notes/0.6#patch-release-v061), [0.6.2](./release-notes/0.6#patch-release-v062), [0.6.3](./release-notes/0.6#patch-release-v063)
 - [0.5](./release-notes/0.5), [0.5.1](./release-notes/0.5#patch-release-v051), [0.5.2](./release-notes/0.5#patch-release-v052)
 - [0.4](./release-notes/0.4), [0.4.1](./release-notes/0.4#patch-release-v041)

--- a/docs/release-notes/0.7.md
+++ b/docs/release-notes/0.7.md
@@ -203,11 +203,13 @@ See the full changelog entry for this release:
 
 ---
 
-## Patch Release v0.7.1
+## Patch Release v0.7.2
 
 This patch release improves data migration discoverability, adds reconnect prompts for error recovery, introduces an experimental AI query generation setting, and includes security dependency updates.
 
-### What's Changed in v0.7.1
+> **Note:** Version 0.7.1 was skipped.
+
+### What's Changed in v0.7.2
 
 #### 💠 **Data Migration Discoverability** ([#515](https://github.com/microsoft/vscode-documentdb/pull/515))
 
@@ -242,4 +244,4 @@ Updated `minimatch` (3.1.2 → 3.1.4), `qs` and `body-parser` to address securit
 ### Changelog
 
 See the full changelog entry for this release:
-➡️ [CHANGELOG.md#071](https://github.com/microsoft/vscode-documentdb/blob/main/CHANGELOG.md#071)
+➡️ [CHANGELOG.md#072](https://github.com/microsoft/vscode-documentdb/blob/main/CHANGELOG.md#072)

--- a/docs/release-notes/0.7.md
+++ b/docs/release-notes/0.7.md
@@ -207,7 +207,7 @@ See the full changelog entry for this release:
 
 This patch release improves data migration discoverability, adds reconnect prompts for error recovery, introduces an experimental AI query generation setting, and includes security dependency updates.
 
-> **Note:** Version 0.7.1 was skipped.
+> **Note:** Version 0.7.1 was reserved for internal validation and was not published as a public release.
 
 ### What's Changed in v0.7.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-documentdb",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-documentdb",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@azure/arm-compute": "^22.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-documentdb",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "releaseNotesUrl": "https://github.com/microsoft/vscode-documentdb/discussions/489",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "publisher": "ms-azuretools",


### PR DESCRIPTION
version 0.7.1 was skipped due to deployment issues, shipping 0.7.1 as 0.7.2