### PR TITLE
feat: collection view & autocompletion UX improvements (Step 4.6)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -200,6 +200,16 @@ This is a **DocumentDB** extension that uses the **MongoDB-compatible wire proto
 
 This applies to: code comments, JSDoc/TSDoc, naming (prefer `documentdb` prefix), user-facing strings, docs, and test descriptions.
 
+## TDD Contract Tests
+
+Test suites prefixed with `TDD:` (e.g., `describe('TDD: Completion Behavior', ...)`) are **behavior contracts** written before the implementation. If a `TDD:` test fails after a code change:
+
+1. **Do NOT automatically fix the test.**
+2. **Stop and ask the user** whether the behavior change is intentional.
+3. The user decides: update the contract (test) or fix the implementation.
+
+This applies to any test whose name starts with `TDD:`, regardless of folder location.
+
 ## Additional Patterns
 
 For detailed patterns, see:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,33 +1,35 @@
 {
-    "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": "explicit",
-        "source.organizeImports": "explicit"
-    },
-    "editor.detectIndentation": false,
-    "editor.formatOnSave": true,
-    "editor.formatOnPaste": false,
-    "editor.insertSpaces": true,
-    "editor.tabSize": 4,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "files.insertFinalNewline": true,
-    "files.trimTrailingWhitespace": true,
-    "search.exclude": {
-        "out": true,
-        "**/node_modules": true,
-        ".vscode-test": true
-    },
-    "typescript.preferences.importModuleSpecifier": "relative",
-    "typescript.tsdk": "node_modules/typescript/lib",
-    "antlr4.generation": {
-        // Settings for "ANTLR4 grammar syntax support" extension
-        "mode": "internal",
-        "listeners": true,
-        "visitors": false
-    },
-    "vscode-nmake-tools.workspaceBuildDirectories": ["."],
-    "vscode-nmake-tools.installOsRepoRustHelperExtension": false,
-    "sarif-viewer.connectToGithubCodeScanning": "off"
-    // "eslint.workingDirectories": [
-    //     ".", "src"
-    //   ]
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "explicit"
+  },
+  "editor.detectIndentation": false,
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": false,
+  "editor.insertSpaces": true,
+  "editor.tabSize": 4,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "search.exclude": {
+    "out": true,
+    "**/node_modules": true,
+    ".vscode-test": true
+  },
+  "typescript.preferences.importModuleSpecifier": "relative",
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "antlr4.generation": {
+    // Settings for "ANTLR4 grammar syntax support" extension
+    "mode": "internal",
+    "listeners": true,
+    "visitors": false
+  },
+  "vscode-nmake-tools.workspaceBuildDirectories": ["."],
+  "vscode-nmake-tools.installOsRepoRustHelperExtension": false,
+  "sarif-viewer.connectToGithubCodeScanning": "off",
+  "jest.runMode": "deferred",
+  "testing.automaticallyOpenTestResults": "neverOpen"
+  // "eslint.workingDirectories": [
+  //     ".", "src"
+  //   ]
 }

--- a/packages/documentdb-constants/resources/overrides/operator-overrides.md
+++ b/packages/documentdb-constants/resources/overrides/operator-overrides.md
@@ -17,6 +17,7 @@
 <!--   - **Description:** ...   (overrides description)                        -->
 <!--   - **Snippet:** ...       (overrides the generated snippet)             -->
 <!--   - **Doc Link:** ...      (overrides the doc link)                       -->
+<!--   - **Standalone:** false  (marks operator as not valid standalone)        -->
 <!--                                                                           -->
 <!-- Only fields you include are overridden; omitted fields keep their         -->
 <!-- scraped or generated values.                                              -->
@@ -276,3 +277,45 @@
 ### $minN
 
 - **Doc Link:** https://learn.microsoft.com/en-us/azure/documentdb/operators/accumulators/$minn
+
+## Geospatial Operators
+
+### $box
+
+- **Standalone:** false
+
+### $center
+
+- **Standalone:** false
+
+### $centerSphere
+
+- **Standalone:** false
+
+### $geometry
+
+- **Standalone:** false
+
+### $maxDistance
+
+- **Standalone:** false
+
+### $minDistance
+
+- **Standalone:** false
+
+### $polygon
+
+- **Standalone:** false
+
+## Projection Operators
+
+### $
+
+- **Standalone:** false
+
+## Miscellaneous Query Operators
+
+### $natural
+
+- **Standalone:** false

--- a/packages/documentdb-constants/scripts/generate-from-reference.ts
+++ b/packages/documentdb-constants/scripts/generate-from-reference.ts
@@ -49,6 +49,7 @@ interface ParsedOperator {
     docLink: string;
     category: string;
     snippetOverride?: string;
+    standalone?: boolean;
 }
 
 interface FileSpec {
@@ -271,6 +272,7 @@ interface OverrideEntry {
     syntax?: string;
     docLink?: string;
     snippet?: string;
+    standalone?: boolean;
 }
 
 function parseOverrides(content: string): Map<string, Map<string, OverrideEntry>> {
@@ -332,6 +334,10 @@ function parseOverrides(content: string): Map<string, Map<string, OverrideEntry>
                 snippet = snippet.slice(1, -1);
             }
             currentOp.entry.snippet = snippet;
+        }
+        if (currentOp && line.startsWith('- **Standalone:**')) {
+            const val = line.replace('- **Standalone:**', '').trim().toLowerCase();
+            currentOp.entry.standalone = val !== 'false' ? undefined : false;
         }
     }
 
@@ -417,6 +423,9 @@ function mergeOverride(op: ParsedOperator, override: OverrideEntry): void {
     }
     if (override.snippet !== undefined && override.snippet !== '') {
         op.snippetOverride = override.snippet;
+    }
+    if (override.standalone !== undefined) {
+        op.standalone = override.standalone;
     }
 }
 
@@ -525,8 +534,8 @@ function getApplicableBsonTypes(op: ParsedOperator, meta: string): string[] | un
     // Array-specific operators (query context)
     if (meta === 'META_QUERY_ARRAY') return ['array'];
 
-    // Bitwise query operators
-    if (meta === 'META_QUERY_BITWISE') return ['int', 'long'];
+    // Bitwise query operators — use 'int32' to match SchemaAnalyzer BSON types
+    if (meta === 'META_QUERY_BITWISE') return ['int32', 'long'];
 
     return undefined;
 }
@@ -688,6 +697,9 @@ function generateSection(spec: FileSpec, snippets: Map<string, Map<string, strin
         }
         if (bsonTypes) {
             section += `        applicableBsonTypes: [${bsonTypes.map((t) => `'${t}'`).join(', ')}],\n`;
+        }
+        if (op.standalone === false) {
+            section += `        standalone: false,\n`;
         }
         section += `    },\n`;
     }

--- a/packages/documentdb-constants/src/queryOperators.ts
+++ b/packages/documentdb-constants/src/queryOperators.ts
@@ -230,6 +230,7 @@ const geospatialOperators: readonly OperatorEntry[] = [
         description: 'The $box operator defines a rectangular area for geospatial queries using coordinate pairs.',
         snippet: '[[${1:bottomLeftX}, ${2:bottomLeftY}], [${3:upperRightX}, ${4:upperRightY}]]',
         link: getDocLink('$box', META_QUERY_GEOSPATIAL),
+        standalone: false,
     },
     {
         value: '$center',
@@ -237,6 +238,7 @@ const geospatialOperators: readonly OperatorEntry[] = [
         description: 'The $center operator specifies a circle using legacy coordinate pairs for $geoWithin queries.',
         snippet: '[[${1:x}, ${2:y}], ${3:radius}]',
         link: getDocLink('$center', META_QUERY_GEOSPATIAL),
+        standalone: false,
     },
     {
         value: '$centerSphere',
@@ -244,6 +246,7 @@ const geospatialOperators: readonly OperatorEntry[] = [
         description: 'The $centerSphere operator specifies a circle using spherical geometry for $geoWithin queries.',
         snippet: '[[${1:x}, ${2:y}], ${3:radiusInRadians}]',
         link: getDocLink('$centerSphere', META_QUERY_GEOSPATIAL),
+        standalone: false,
     },
     {
         value: '$geometry',
@@ -251,6 +254,7 @@ const geospatialOperators: readonly OperatorEntry[] = [
         description: 'The $geometry operator specifies a GeoJSON geometry for geospatial queries.',
         snippet: '{ type: "${1:Point}", coordinates: [${2:coordinates}] }',
         link: getDocLink('$geometry', META_QUERY_GEOSPATIAL),
+        standalone: false,
     },
     {
         value: '$maxDistance',
@@ -259,6 +263,7 @@ const geospatialOperators: readonly OperatorEntry[] = [
             'The $maxDistance operator specifies the maximum distance that can exist between two points in a geospatial query.',
         snippet: '${1:distance}',
         link: getDocLink('$maxDistance', META_QUERY_GEOSPATIAL),
+        standalone: false,
     },
     {
         value: '$minDistance',
@@ -267,6 +272,7 @@ const geospatialOperators: readonly OperatorEntry[] = [
             'The $minDistance operator specifies the minimum distance that must exist between two points in a geospatial query.',
         snippet: '${1:distance}',
         link: getDocLink('$minDistance', META_QUERY_GEOSPATIAL),
+        standalone: false,
     },
     {
         value: '$polygon',
@@ -275,6 +281,7 @@ const geospatialOperators: readonly OperatorEntry[] = [
             'The $polygon operator defines a polygon for geospatial queries, allowing you to find locations within an irregular shape.',
         snippet: '[[${1:x1}, ${2:y1}], [${3:x2}, ${4:y2}], [${5:x3}, ${6:y3}]]',
         link: getDocLink('$polygon', META_QUERY_GEOSPATIAL),
+        standalone: false,
     },
     {
         value: '$near',
@@ -382,6 +389,7 @@ const projectionOperators: readonly OperatorEntry[] = [
         description:
             'The $ positional operator identifies an element in an array to update without explicitly specifying the position of the element in the array.',
         link: 'https://learn.microsoft.com/en-us/azure/documentdb/operators/array-update/$', // inferred from another category
+        standalone: false,
     },
     {
         value: '$elemMatch',
@@ -427,6 +435,7 @@ const miscellaneousQueryOperators: readonly OperatorEntry[] = [
             'The $natural operator forces the query to use the natural order of documents in a collection, providing control over document ordering and retrieval.',
         snippet: '{ $natural: ${1:1} }',
         link: getDocLink('$natural', META_QUERY_MISC),
+        standalone: false,
     },
 ];
 

--- a/packages/documentdb-constants/src/types.ts
+++ b/packages/documentdb-constants/src/types.ts
@@ -48,6 +48,21 @@ export interface OperatorEntry {
     readonly applicableBsonTypes?: readonly string[];
 
     /**
+     * Whether this operator is valid as a standalone completion at top-level
+     * positions (key, value, operator). Defaults to `true` when absent.
+     *
+     * Set to `false` for operators that are only valid inside another operator's
+     * value object — e.g., geospatial shape specifiers (`$box`, `$geometry`)
+     * which are only valid inside `$geoWithin`/`$near`, or sort-only modifiers
+     * like `$natural`.
+     *
+     * Completion providers should filter out `standalone === false` entries
+     * from standard completion lists. These entries remain in the registry
+     * for hover documentation and future context-aware nested completions.
+     */
+    readonly standalone?: boolean;
+
+    /**
      * @experimental Not yet populated by the generator; reserved for a future
      * contextual-snippet feature.
      *

--- a/src/documentdb/ClusterSession.ts
+++ b/src/documentdb/ClusterSession.ts
@@ -167,9 +167,17 @@ export class ClusterSession {
             }
         }
 
-        // The user's query has changed, invalidate all caches
-        this._schemaAnalyzer.reset();
-        ext.outputChannel.trace('[SchemaAnalyzer] Reset — query changed');
+        // The user's query has changed, invalidate all caches.
+        //
+        // NOTE: We intentionally do NOT reset the SchemaAnalyzer here.
+        // When a new query returns 0 results, preserving field knowledge from
+        // previous queries is more valuable for autocompletion than having an
+        // empty field list. The SchemaAnalyzer accumulates field data
+        // monotonically — new fields are added, existing field type statistics
+        // are enriched with each query. This means type statistics represent
+        // aggregated observations across queries, not a single query snapshot.
+        // Consumers should treat type frequency data as approximate/relative
+        // (e.g., "mostly String") rather than absolute percentages.
         this._highestPageAccumulated = 0;
         this._currentPageSize = null;
         this._currentRawDocuments = [];

--- a/src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts
+++ b/src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts
@@ -23,6 +23,10 @@ export interface FieldCompletionData {
     displayType: string;
     /** Raw BSON type from FieldEntry */
     bsonType: string;
+    /** All observed BSON types for polymorphic fields (e.g., ["string", "int32"]) */
+    bsonTypes?: string[];
+    /** Human-readable display strings for all observed types (e.g., ["String", "Int32"]) */
+    displayTypes?: string[];
     /** Whether the field was not present in every inspected document (statistical observation, not a constraint) */
     isSparse: boolean;
     /** Text to insert when the user selects this completion — quoted/escaped if the field name contains special chars */
@@ -72,6 +76,8 @@ export function toFieldCompletionItems(fields: FieldEntry[]): FieldCompletionDat
             fieldName: entry.path,
             displayType,
             bsonType: entry.bsonType,
+            bsonTypes: entry.bsonTypes,
+            displayTypes: entry.bsonTypes?.map((t) => BSONTypes.toDisplayString(t as BSONTypes)),
             isSparse: entry.isSparse ?? false,
             insertText,
             referenceText: `$${entry.path}`,

--- a/src/webviews/components/MonacoAutoHeight.tsx
+++ b/src/webviews/components/MonacoAutoHeight.tsx
@@ -196,14 +196,21 @@ export const MonacoAutoHeight = (props: MonacoAutoHeightProps) => {
     /**
      * Configures the Tab key behavior for the Monaco editor.
      *
-     * When called, this function sets up or removes a keydown handler for the Tab key.
-     * If `shouldTrap` is true, Tab/Shift+Tab are trapped within the editor (focus remains in editor).
-     * If `shouldTrap` is false, Tab/Shift+Tab move focus to the next/previous focusable element outside the editor.
+     * When `shouldTrap` is true, Tab/Shift+Tab are trapped within the editor
+     * (default Monaco behavior for code indentation).
+     *
+     * When `shouldTrap` is false, Tab/Shift+Tab move focus to the next/previous
+     * focusable element outside the editor — UNLESS the editor is in snippet
+     * tab-stop mode (`inSnippetMode`), in which case Tab navigates between
+     * snippet placeholders. After the snippet session ends (final tab stop or
+     * ESC), Tab reverts to moving focus out of the editor.
+     *
+     * Uses `editor.addAction` with a precondition context key expression
+     * (`!inSnippetMode`) rather than `onKeyDown` interception, so Monaco's
+     * built-in snippet navigation takes priority when a snippet is active.
      *
      * @param {monacoEditor.editor.IStandaloneCodeEditor} editor - The Monaco editor instance.
      * @param {boolean} shouldTrap - Whether to trap Tab key in the editor.
-     *   - true: Tab/Shift+Tab are trapped in the editor.
-     *   - false: Tab/Shift+Tab move focus to next/previous element.
      */
     const configureTabKeyMode = (editor: monacoEditor.editor.IStandaloneCodeEditor, shouldTrap: boolean) => {
         if (tabKeyDisposerRef.current) {
@@ -215,17 +222,30 @@ export const MonacoAutoHeight = (props: MonacoAutoHeightProps) => {
             return;
         }
 
-        tabKeyDisposerRef.current = editor.onKeyDown((event) => {
-            if (event.keyCode !== monacoEditor.KeyCode.Tab) {
-                return;
-            }
-
-            event.preventDefault();
-            event.stopPropagation();
-
-            const direction = event.browserEvent.shiftKey ? 'previous' : 'next';
-            moveFocus(editor, direction);
+        // Register Tab and Shift+Tab actions that only fire when NOT in snippet mode.
+        // When inSnippetMode is true, Monaco's built-in snippet Tab handler takes over.
+        const tabAction = editor.addAction({
+            id: 'documentdb.tab.moveFocusNext',
+            label: 'Move Focus to Next Element',
+            keybindings: [monacoEditor.KeyCode.Tab],
+            precondition: '!inSnippetMode',
+            run: () => moveFocus(editor, 'next'),
         });
+
+        const shiftTabAction = editor.addAction({
+            id: 'documentdb.tab.moveFocusPrevious',
+            label: 'Move Focus to Previous Element',
+            keybindings: [monacoEditor.KeyMod.Shift | monacoEditor.KeyCode.Tab],
+            precondition: '!inSnippetMode',
+            run: () => moveFocus(editor, 'previous'),
+        });
+
+        tabKeyDisposerRef.current = {
+            dispose: () => {
+                tabAction.dispose();
+                shiftTabAction.dispose();
+            },
+        };
     };
 
     /**

--- a/src/webviews/components/MonacoEditor.tsx
+++ b/src/webviews/components/MonacoEditor.tsx
@@ -75,11 +75,20 @@ export const MonacoEditor = ({ onEscapeEditor, onMount, ...props }: MonacoEditor
             disposablesRef.current.forEach((d) => d.dispose());
             disposablesRef.current = [];
 
-            // Register Escape key handler to exit the editor
+            // Register Escape key handler to exit the editor.
+            // The context expression ensures ESC is only handled when:
+            // - The suggest (autocomplete) widget is NOT visible
+            // - The editor is NOT in snippet tab-stop mode
+            // This allows Monaco's built-in handlers to dismiss the suggest
+            // widget or exit snippet mode first, before our handler fires.
             if (onEscapeEditor) {
-                editor.addCommand(monacoInstance.KeyCode.Escape, () => {
-                    onEscapeEditor();
-                });
+                editor.addCommand(
+                    monacoInstance.KeyCode.Escape,
+                    () => {
+                        onEscapeEditor();
+                    },
+                    '!suggestWidgetVisible && !inSnippetMode',
+                );
             }
 
             // Announce escape hint once when editor gains focus

--- a/src/webviews/documentdb/collectionView/components/queryEditor/QueryEditor.tsx
+++ b/src/webviews/documentdb/collectionView/components/queryEditor/QueryEditor.tsx
@@ -131,10 +131,56 @@ export const QueryEditor = ({ onExecuteRequest }: QueryEditorProps): JSX.Element
         };
     };
 
+    /**
+     * Sets up pattern-based auto-trigger of completions.
+     * When the user types a space after `: ` or `, `, completions are
+     * triggered automatically after a short delay. This bridges the gap
+     * where selecting a field completion (e.g., `rating`) inserts `rating: `
+     * but the completion popup doesn't reappear for the value.
+     *
+     * Returns a cleanup function.
+     */
+    const setupSmartTrigger = (editor: monacoEditor.editor.IStandaloneCodeEditor): (() => void) => {
+        let triggerTimeout: ReturnType<typeof setTimeout>;
+        const disposable = editor.onDidChangeModelContent((e) => {
+            clearTimeout(triggerTimeout);
+
+            // Only fire for single-character insertions (typing)
+            const change = e.changes[0];
+            if (!change || change.text !== ' ') return;
+
+            // Check the two characters ending at the cursor: "X " where X is : or ,
+            const model = editor.getModel();
+            if (!model) return;
+
+            const offset = model.getOffsetAt(
+                // The position after the inserted space
+                model.getPositionAt(change.rangeOffset + 1),
+            );
+
+            // We need at least 2 chars: the trigger char + space
+            if (offset < 2) return;
+
+            const textBefore = model.getValue().substring(offset - 2, offset);
+            if (textBefore === ': ' || textBefore === ', ') {
+                triggerTimeout = setTimeout(() => {
+                    editor.trigger('smart-trigger', 'editor.action.triggerSuggest', {});
+                }, 50);
+            }
+        });
+        return () => {
+            clearTimeout(triggerTimeout);
+            disposable.dispose();
+        };
+    };
+
     // Track validation cleanup functions
     const filterValidationCleanupRef = useRef<(() => void) | null>(null);
     const projectValidationCleanupRef = useRef<(() => void) | null>(null);
     const sortValidationCleanupRef = useRef<(() => void) | null>(null);
+    const filterSmartTriggerCleanupRef = useRef<(() => void) | null>(null);
+    const projectSmartTriggerCleanupRef = useRef<(() => void) | null>(null);
+    const sortSmartTriggerCleanupRef = useRef<(() => void) | null>(null);
 
     const handleEditorDidMount = (editor: monacoEditor.editor.IStandaloneCodeEditor, monaco: typeof monacoEditor) => {
         // Store the filter editor reference
@@ -148,6 +194,9 @@ export const QueryEditor = ({ onExecuteRequest }: QueryEditorProps): JSX.Element
 
         // Set up debounced validation
         filterValidationCleanupRef.current = setupValidation(editor, monaco, model);
+
+        // Set up smart-trigger for completions after ": " and ", "
+        filterSmartTriggerCleanupRef.current = setupSmartTrigger(editor);
 
         const getCurrentQueryFunction = () => ({
             filter: filterValue,
@@ -201,6 +250,11 @@ export const QueryEditor = ({ onExecuteRequest }: QueryEditorProps): JSX.Element
             filterValidationCleanupRef.current?.();
             projectValidationCleanupRef.current?.();
             sortValidationCleanupRef.current?.();
+
+            // Clean up smart-trigger listeners
+            filterSmartTriggerCleanupRef.current?.();
+            projectSmartTriggerCleanupRef.current?.();
+            sortSmartTriggerCleanupRef.current?.();
 
             // Dispose Monaco models
             filterEditorRef.current?.getModel()?.dispose();
@@ -552,6 +606,9 @@ export const QueryEditor = ({ onExecuteRequest }: QueryEditorProps): JSX.Element
                                     // Set up validation
                                     projectValidationCleanupRef.current = setupValidation(editor, monaco, model);
 
+                                    // Set up smart-trigger
+                                    projectSmartTriggerCleanupRef.current = setupSmartTrigger(editor);
+
                                     editor.onDidChangeModelContent(() => {
                                         setProjectValue(editor.getValue());
                                     });
@@ -591,6 +648,9 @@ export const QueryEditor = ({ onExecuteRequest }: QueryEditorProps): JSX.Element
 
                                     // Set up validation
                                     sortValidationCleanupRef.current = setupValidation(editor, monaco, model);
+
+                                    // Set up smart-trigger
+                                    sortSmartTriggerCleanupRef.current = setupSmartTrigger(editor);
 
                                     editor.onDidChangeModelContent(() => {
                                         setSortValue(editor.getValue());

--- a/src/webviews/documentdb/collectionView/components/queryEditor/QueryEditor.tsx
+++ b/src/webviews/documentdb/collectionView/components/queryEditor/QueryEditor.tsx
@@ -238,6 +238,31 @@ export const QueryEditor = ({ onExecuteRequest }: QueryEditorProps): JSX.Element
         automaticLayout: false,
     };
 
+    // Intercept link clicks in Monaco hover tooltips.
+    // Monaco renders hover markdown links as <a> tags, but the webview CSP
+    // blocks direct navigation. Capture clicks and route through tRPC.
+    const editorContainerRef = useRef<HTMLDivElement | null>(null);
+    useEffect(() => {
+        const container = editorContainerRef.current;
+        if (!container) return;
+
+        const handleLinkClick = (e: MouseEvent): void => {
+            const target = e.target as HTMLElement;
+            const anchor = target.closest('a');
+            if (!anchor) return;
+
+            const href = anchor.getAttribute('href');
+            if (href && (href.startsWith('https://') || href.startsWith('http://'))) {
+                e.preventDefault();
+                e.stopPropagation();
+                void trpcClient.common.openUrl.mutate({ url: href });
+            }
+        };
+
+        container.addEventListener('click', handleLinkClick, true);
+        return () => container.removeEventListener('click', handleLinkClick, true);
+    }, [trpcClient]);
+
     // Cleanup any pending operations when component unmounts
     useEffect(() => {
         return () => {
@@ -421,7 +446,7 @@ export const QueryEditor = ({ onExecuteRequest }: QueryEditorProps): JSX.Element
     };
 
     return (
-        <div className="queryEditor">
+        <div className="queryEditor" ref={editorContainerRef}>
             {/* Optional AI prompt row */}
             <Collapse visible={configuration.enableAIQueryGeneration && currentContext.isAiRowVisible} unmountOnExit>
                 <div className={`aiRow${isAiActive ? ' ai-active' : ''}`}>

--- a/src/webviews/documentdb/collectionView/components/queryEditor/QueryEditor.tsx
+++ b/src/webviews/documentdb/collectionView/components/queryEditor/QueryEditor.tsx
@@ -132,21 +132,49 @@ export const QueryEditor = ({ onExecuteRequest }: QueryEditorProps): JSX.Element
     };
 
     /**
+     * Cancels any active snippet session on the given editor.
+     *
+     * After a snippet completion (e.g., `fieldName: $1`), Monaco keeps the
+     * snippet session alive and highlights the tab-stop placeholder. If the
+     * user continues typing, the highlight grows — the "ghost selection"
+     * bug. Calling this function ends the snippet session cleanly.
+     */
+    const cancelSnippetSession = (editor: monacoEditor.editor.IStandaloneCodeEditor): void => {
+        const controller = editor.getContribution('snippetController2') as { cancel: () => void } | null | undefined;
+        controller?.cancel();
+    };
+
+    /** Characters that signal the end of a field-value pair and should exit snippet mode. */
+    const SNIPPET_EXIT_CHARS = new Set([',', '}', ']']);
+
+    /**
      * Sets up pattern-based auto-trigger of completions.
      * When a content change results in a trigger character followed by a
      * space (`: `, `, `, `{ `, `[ `) at the end of the inserted text,
      * completions are triggered automatically after a short delay. This
      * handles both manual typing and completion acceptance.
      *
+     * Also cancels any active snippet session when a delimiter character
+     * (`,`, `}`, `]`) is typed, preventing the "ghost selection" bug
+     * where the tab-stop highlight expands as the user continues typing.
+     *
      * Returns a cleanup function.
      */
     const setupSmartTrigger = (editor: monacoEditor.editor.IStandaloneCodeEditor): (() => void) => {
         let triggerTimeout: ReturnType<typeof setTimeout>;
-        const disposable = editor.onDidChangeModelContent((e) => {
+        const contentDisposable = editor.onDidChangeModelContent((e) => {
             clearTimeout(triggerTimeout);
 
             const change = e.changes[0];
             if (!change || change.text.length === 0) return;
+
+            // Cancel snippet session when the user *types* a delimiter character.
+            // Only applies to single-character edits (user keystrokes), not to
+            // multi-character completion insertions which may legitimately
+            // contain commas or braces as part of the snippet text.
+            if (change.text.length === 1 && SNIPPET_EXIT_CHARS.has(change.text)) {
+                cancelSnippetSession(editor);
+            }
 
             const model = editor.getModel();
             if (!model) return;
@@ -165,9 +193,18 @@ export const QueryEditor = ({ onExecuteRequest }: QueryEditorProps): JSX.Element
                 }, 50);
             }
         });
+
+        // Cancel snippet session when the editor loses focus (Option D).
+        // If the user clicks away while a tab-stop is highlighted, the
+        // highlight should not persist when they return.
+        const blurDisposable = editor.onDidBlurEditorText(() => {
+            cancelSnippetSession(editor);
+        });
+
         return () => {
             clearTimeout(triggerTimeout);
-            disposable.dispose();
+            contentDisposable.dispose();
+            blurDisposable.dispose();
         };
     };
 

--- a/src/webviews/documentdb/collectionView/components/queryEditor/QueryEditor.tsx
+++ b/src/webviews/documentdb/collectionView/components/queryEditor/QueryEditor.tsx
@@ -133,10 +133,10 @@ export const QueryEditor = ({ onExecuteRequest }: QueryEditorProps): JSX.Element
 
     /**
      * Sets up pattern-based auto-trigger of completions.
-     * When the user types a space after `: ` or `, `, completions are
-     * triggered automatically after a short delay. This bridges the gap
-     * where selecting a field completion (e.g., `rating`) inserts `rating: `
-     * but the completion popup doesn't reappear for the value.
+     * When a content change results in a trigger character followed by a
+     * space (`: `, `, `, `{ `, `[ `) at the end of the inserted text,
+     * completions are triggered automatically after a short delay. This
+     * handles both manual typing and completion acceptance.
      *
      * Returns a cleanup function.
      */
@@ -145,24 +145,21 @@ export const QueryEditor = ({ onExecuteRequest }: QueryEditorProps): JSX.Element
         const disposable = editor.onDidChangeModelContent((e) => {
             clearTimeout(triggerTimeout);
 
-            // Only fire for single-character insertions (typing)
             const change = e.changes[0];
-            if (!change || change.text !== ' ') return;
+            if (!change || change.text.length === 0) return;
 
-            // Check the two characters ending at the cursor: "X " where X is : or ,
             const model = editor.getModel();
             if (!model) return;
 
-            const offset = model.getOffsetAt(
-                // The position after the inserted space
-                model.getPositionAt(change.rangeOffset + 1),
-            );
+            // Calculate the offset at the end of the inserted text in the new model
+            const endOffset = change.rangeOffset + change.text.length;
 
-            // We need at least 2 chars: the trigger char + space
-            if (offset < 2) return;
+            // We need at least 2 chars to check for ": " or ", "
+            if (endOffset < 2) return;
 
-            const textBefore = model.getValue().substring(offset - 2, offset);
-            if (textBefore === ': ' || textBefore === ', ') {
+            const fullText = model.getValue();
+            const lastTwo = fullText.substring(endOffset - 2, endOffset);
+            if (lastTwo === ': ' || lastTwo === ', ' || lastTwo === '{ ' || lastTwo === '[ ') {
                 triggerTimeout = setTimeout(() => {
                     editor.trigger('smart-trigger', 'editor.action.triggerSuggest', {});
                 }, 50);
@@ -181,7 +178,6 @@ export const QueryEditor = ({ onExecuteRequest }: QueryEditorProps): JSX.Element
     const filterSmartTriggerCleanupRef = useRef<(() => void) | null>(null);
     const projectSmartTriggerCleanupRef = useRef<(() => void) | null>(null);
     const sortSmartTriggerCleanupRef = useRef<(() => void) | null>(null);
-
     const handleEditorDidMount = (editor: monacoEditor.editor.IStandaloneCodeEditor, monaco: typeof monacoEditor) => {
         // Store the filter editor reference
         filterEditorRef.current = editor;

--- a/src/webviews/documentdbQuery/completions/README.md
+++ b/src/webviews/documentdbQuery/completions/README.md
@@ -26,11 +26,21 @@ registerLanguage.ts
    - **key / array-element** → field names + key-position operators
    - **value** → type suggestions + operators (with braces) + BSON constructors + JS globals
    - **operator** → operators only (braces stripped, type-aware sorting)
-   - **unknown / undefined** → all completions (fields, all operators, BSON constructors, JS globals)
+   - **empty** (unknown + needsWrapping) → key-position completions with `{ }` wrapping
+   - **unknown** (ambiguous, no wrapping) → all completions (fields, all operators, BSON constructors, JS globals)
 
 ## Sorting
 
 Completion items use `sortText` prefixes so Monaco displays them in the intended order. Lower prefixes appear higher in the list.
+
+### Empty position (no braces)
+
+Same as key position. All insertions wrapped with `{ }`.
+
+| Prefix | Content | Example |
+|--------|---------|---------|
+| `0_fieldName` | Schema field names (wrapped) | `{ age: $1 }`, `{ name: $1 }` |
+| `1_$and` | Key-position operators (with braces) | `{ $and: [...] }` |
 
 ### Value position
 
@@ -93,6 +103,7 @@ Curated domain rules that go beyond the auto-generated operator registry in `doc
 
 Operator snippets in `documentdb-constants` include outer braces: `{ $gt: ${1:value} }`.
 
+- **Empty position**: operators keep full braces (user has no braces); fields wrapped with `{ ... }`
 - **Value position**: inserted as-is (user is replacing the entire value)
 - **Operator position**: outer `{ }` stripped via `stripOuterBraces()` (user is already inside braces)
 - **Key position**: outer `{ }` stripped (user is already inside the query object)

--- a/src/webviews/documentdbQuery/completions/completionKnowledge.ts
+++ b/src/webviews/documentdbQuery/completions/completionKnowledge.ts
@@ -49,6 +49,10 @@
  * { age: { $and: … } }
  * ```
  *
+ * **`$not` is intentionally excluded** — despite being a logical operator,
+ * `$not` is a field-level operator that wraps a single field's expression:
+ * `{ price: { $not: { $gt: 1.99 } } }`. It does NOT work at query root.
+ *
  * The completion provider uses this set to:
  * - **Include** these operators at key position and array-element position
  * - **Exclude** them from operator position (inside `{ field: { … } }`)
@@ -60,7 +64,6 @@ export const KEY_POSITION_OPERATORS = new Set([
     '$and',
     '$or',
     '$nor',
-    '$not',
     '$comment',
     '$expr',
     '$jsonSchema',

--- a/src/webviews/documentdbQuery/completions/createCompletionItems.ts
+++ b/src/webviews/documentdbQuery/completions/createCompletionItems.ts
@@ -175,10 +175,13 @@ function createKeyPositionCompletions(
 
 /**
  * Value position completions:
- * 1. Type-aware suggestions (sort `00_`) — e.g., `true`/`false` for booleans
- * 2. Query operators with brace-wrapping snippets (sort `0_`–`2_`)
- * 3. BSON constructors (sort `3_`)
- * 4. JS globals: Date, Math, RegExp, etc. (sort `4_`)
+ * - **Project editor**: `1` (include) and `0` (exclude) — the most common projection values
+ * - **Sort editor**: `1` (ascending) and `-1` (descending)
+ * - **Filter editor** (default):
+ *   1. Type-aware suggestions (sort `00_`) — e.g., `true`/`false` for booleans
+ *   2. Query operators with brace-wrapping snippets (sort `0_`–`2_`)
+ *   3. BSON constructors (sort `3_`)
+ *   4. JS globals: Date, Math, RegExp, etc. (sort `4_`)
  */
 function createValuePositionCompletions(
     editorType: EditorType | undefined,
@@ -186,6 +189,16 @@ function createValuePositionCompletions(
     monaco: typeof monacoEditor,
     fieldBsonType: string | undefined,
 ): monacoEditor.languages.CompletionItem[] {
+    // Project editor: only show include/exclude values
+    if (editorType === EditorType.Project) {
+        return createProjectValueCompletions(range, monaco);
+    }
+
+    // Sort editor: only show ascending/descending values
+    if (editorType === EditorType.Sort) {
+        return createSortValueCompletions(range, monaco);
+    }
+
     const metaTags = getMetaTagsForEditorType(editorType);
     const allEntries = getFilteredCompletions({ meta: [...metaTags] });
 
@@ -220,6 +233,62 @@ function createValuePositionCompletions(
     const jsGlobals = createJsGlobalCompletionItems(range, monaco);
 
     return [...typeSuggestions, ...operatorItems, ...bsonItems, ...jsGlobals];
+}
+
+/**
+ * Value completions for the **project** editor: `1` (include) and `0` (exclude).
+ *
+ * Projection operators like `$slice` and `$elemMatch` are already available
+ * via operator-position completions; these simple numeric values cover the
+ * most common use case.
+ */
+function createProjectValueCompletions(
+    range: monacoEditor.IRange,
+    monaco: typeof monacoEditor,
+): monacoEditor.languages.CompletionItem[] {
+    return [
+        {
+            label: { label: '1', description: 'include field' },
+            kind: monaco.languages.CompletionItemKind.Value,
+            insertText: '1',
+            sortText: '00_1',
+            preselect: true,
+            range,
+        },
+        {
+            label: { label: '0', description: 'exclude field' },
+            kind: monaco.languages.CompletionItemKind.Value,
+            insertText: '0',
+            sortText: '00_0',
+            range,
+        },
+    ];
+}
+
+/**
+ * Value completions for the **sort** editor: `1` (ascending) and `-1` (descending).
+ */
+function createSortValueCompletions(
+    range: monacoEditor.IRange,
+    monaco: typeof monacoEditor,
+): monacoEditor.languages.CompletionItem[] {
+    return [
+        {
+            label: { label: '1', description: 'ascending' },
+            kind: monaco.languages.CompletionItemKind.Value,
+            insertText: '1',
+            sortText: '00_1',
+            preselect: true,
+            range,
+        },
+        {
+            label: { label: '-1', description: 'descending' },
+            kind: monaco.languages.CompletionItemKind.Value,
+            insertText: '-1',
+            sortText: '00_-1',
+            range,
+        },
+    ];
 }
 
 function createOperatorPositionCompletions(

--- a/src/webviews/documentdbQuery/completions/createCompletionItems.ts
+++ b/src/webviews/documentdbQuery/completions/createCompletionItems.ts
@@ -91,16 +91,21 @@ export function getMetaTagsForEditorType(editorType: EditorType | undefined): re
  * - **value**: type suggestions + operators (with braces) + BSON constructors
  * - **operator**: operators (without braces) with type-aware sorting
  * - **array-element**: same as key position
- * - **unknown / undefined**: all completions — fields, all operators, BSON
- *   constructors, and JS globals (backward-compatible fallback)
+ * - **empty** (unknown + needsWrapping): key-position completions with `{ }` wrapping
+ * - **unknown** (ambiguous): all completions — full discovery fallback
  */
 export function createCompletionItems(params: CreateCompletionItemsParams): monacoEditor.languages.CompletionItem[] {
     const { editorType, sessionId, range, monaco, fieldBsonTypes, cursorContext, needsWrapping } = params;
 
     if (!cursorContext || cursorContext.position === 'unknown') {
-        // When context is unknown (e.g., empty input, no braces), show all
-        // completions so the user can discover what's available.
-        return createAllCompletions(editorType, sessionId, range, monaco, needsWrapping);
+        if (needsWrapping) {
+            // EMPTY editor — no braces present. Show key-position completions
+            // (fields + root operators) with { } wrapping so inserted items
+            // produce valid syntax.
+            return createEmptyEditorCompletions(editorType, sessionId, range, monaco);
+        }
+        // Genuinely UNKNOWN — show all completions as a discovery fallback.
+        return createAllCompletions(editorType, sessionId, range, monaco);
     }
 
     switch (cursorContext.position) {
@@ -126,30 +131,53 @@ export function createCompletionItems(params: CreateCompletionItemsParams): mona
 // ---------- Context-specific completion builders ----------
 
 /**
- * All completions — used when cursor context is unknown or undefined.
- * Shows fields, all operators, BSON constructors, and JS globals.
+ * Empty editor completions — shows key-position items with `{ }` wrapping.
  *
- * When `needsWrapping` is true, field insertText is wrapped with `{ ... }`
- * to produce valid syntax in an empty editor.
+ * Used when the editor has no braces (user cleared content). Behaves like
+ * key position but wraps all inserted completions with outer `{ }` so they
+ * produce valid query syntax.
+ */
+function createEmptyEditorCompletions(
+    editorType: EditorType | undefined,
+    sessionId: string | undefined,
+    range: monacoEditor.IRange,
+    monaco: typeof monacoEditor,
+): monacoEditor.languages.CompletionItem[] {
+    const metaTags = getMetaTagsForEditorType(editorType);
+    const allEntries = getFilteredCompletions({ meta: [...metaTags] });
+
+    // Key-position operators — keep outer braces (don't strip)
+    const keyEntries = allEntries.filter((e) => KEY_POSITION_OPERATORS.has(e.value));
+    const operatorItems = keyEntries.map((entry) => {
+        const item = mapOperatorToCompletionItem(entry, range, monaco);
+        item.sortText = `1_${entry.value}`;
+        return item;
+    });
+
+    // Fields — wrap insertText with `{ ... }` for valid syntax
+    const fieldItems = getFieldCompletionItems(sessionId, range, monaco).map((item) => ({
+        ...item,
+        insertText: `{ ${item.insertText as string} }`,
+    }));
+
+    return [...fieldItems, ...operatorItems];
+}
+
+/**
+ * All completions — used when cursor context is genuinely ambiguous (UNKNOWN).
+ * Shows fields, all operators, BSON constructors, and JS globals.
+ * Full discovery fallback for positions the parser can't classify.
  */
 function createAllCompletions(
     editorType: EditorType | undefined,
     sessionId: string | undefined,
     range: monacoEditor.IRange,
     monaco: typeof monacoEditor,
-    needsWrapping?: boolean,
 ): monacoEditor.languages.CompletionItem[] {
     const metaTags = getMetaTagsForEditorType(editorType);
     const allEntries = getFilteredCompletions({ meta: [...metaTags] });
 
-    let fieldItems = getFieldCompletionItems(sessionId, range, monaco);
-    if (needsWrapping) {
-        // Wrap field insertText with { ... } for empty-editor context
-        fieldItems = fieldItems.map((item) => ({
-            ...item,
-            insertText: `{ ${item.insertText as string} }`,
-        }));
-    }
+    const fieldItems = getFieldCompletionItems(sessionId, range, monaco);
 
     const operatorItems = allEntries
         .filter((e) => e.meta !== 'bson' && e.meta !== 'variable')

--- a/src/webviews/documentdbQuery/completions/createCompletionItems.ts
+++ b/src/webviews/documentdbQuery/completions/createCompletionItems.ts
@@ -180,7 +180,7 @@ function createAllCompletions(
     const fieldItems = getFieldCompletionItems(sessionId, range, monaco);
 
     const operatorItems = allEntries
-        .filter((e) => e.meta !== 'bson' && e.meta !== 'variable')
+        .filter((e) => e.meta !== 'bson' && e.meta !== 'variable' && e.standalone !== false)
         .map((entry) => mapOperatorToCompletionItem(entry, range, monaco));
 
     const bsonItems = allEntries
@@ -255,7 +255,11 @@ function createValuePositionCompletions(
     //    operators (e.g., $eq) appear above irrelevant ones (e.g., $bitsAllSet).
     const fieldBsonTypes = fieldBsonType ? [fieldBsonType] : undefined;
     const operatorEntries = allEntries.filter(
-        (e) => e.meta !== 'bson' && e.meta !== 'variable' && !KEY_POSITION_OPERATORS.has(e.value),
+        (e) =>
+            e.meta !== 'bson' &&
+            e.meta !== 'variable' &&
+            e.standalone !== false &&
+            !KEY_POSITION_OPERATORS.has(e.value),
     );
     const operatorItems = operatorEntries.map((entry) => {
         const item = mapOperatorToCompletionItem(entry, range, monaco, fieldBsonTypes);
@@ -346,7 +350,11 @@ function createOperatorPositionCompletions(
     const allEntries = getFilteredCompletions({ meta: [...metaTags] });
 
     const operatorEntries = allEntries.filter(
-        (e) => e.meta !== 'bson' && e.meta !== 'variable' && !KEY_POSITION_OPERATORS.has(e.value),
+        (e) =>
+            e.meta !== 'bson' &&
+            e.meta !== 'variable' &&
+            e.standalone !== false &&
+            !KEY_POSITION_OPERATORS.has(e.value),
     );
     return operatorEntries.map((entry) => mapOperatorToCompletionItem(entry, range, monaco, fieldBsonTypes, true));
 }

--- a/src/webviews/documentdbQuery/completions/createCompletionItems.ts
+++ b/src/webviews/documentdbQuery/completions/createCompletionItems.ts
@@ -46,6 +46,12 @@ export interface CreateCompletionItemsParams {
      */
     fieldBsonTypes?: readonly string[];
     /**
+     * When true, completion snippets should include outer `{ }` wrapping.
+     * Set when the editor content has no braces (user cleared the editor),
+     * so that inserted completions produce valid query syntax.
+     */
+    needsWrapping?: boolean;
+    /**
      * Optional cursor context from the heuristic cursor position detector.
      * When provided, completions are filtered based on the semantic position
      * of the cursor. When undefined, falls back to showing all completions
@@ -89,12 +95,12 @@ export function getMetaTagsForEditorType(editorType: EditorType | undefined): re
  *   constructors, and JS globals (backward-compatible fallback)
  */
 export function createCompletionItems(params: CreateCompletionItemsParams): monacoEditor.languages.CompletionItem[] {
-    const { editorType, sessionId, range, monaco, fieldBsonTypes, cursorContext } = params;
+    const { editorType, sessionId, range, monaco, fieldBsonTypes, cursorContext, needsWrapping } = params;
 
     if (!cursorContext || cursorContext.position === 'unknown') {
         // When context is unknown (e.g., empty input, no braces), show all
         // completions so the user can discover what's available.
-        return createAllCompletions(editorType, sessionId, range, monaco);
+        return createAllCompletions(editorType, sessionId, range, monaco, needsWrapping);
     }
 
     switch (cursorContext.position) {
@@ -122,17 +128,28 @@ export function createCompletionItems(params: CreateCompletionItemsParams): mona
 /**
  * All completions — used when cursor context is unknown or undefined.
  * Shows fields, all operators, BSON constructors, and JS globals.
+ *
+ * When `needsWrapping` is true, field insertText is wrapped with `{ ... }`
+ * to produce valid syntax in an empty editor.
  */
 function createAllCompletions(
     editorType: EditorType | undefined,
     sessionId: string | undefined,
     range: monacoEditor.IRange,
     monaco: typeof monacoEditor,
+    needsWrapping?: boolean,
 ): monacoEditor.languages.CompletionItem[] {
     const metaTags = getMetaTagsForEditorType(editorType);
     const allEntries = getFilteredCompletions({ meta: [...metaTags] });
 
-    const fieldItems = getFieldCompletionItems(sessionId, range, monaco);
+    let fieldItems = getFieldCompletionItems(sessionId, range, monaco);
+    if (needsWrapping) {
+        // Wrap field insertText with { ... } for empty-editor context
+        fieldItems = fieldItems.map((item) => ({
+            ...item,
+            insertText: `{ ${item.insertText as string} }`,
+        }));
+    }
 
     const operatorItems = allEntries
         .filter((e) => e.meta !== 'bson' && e.meta !== 'variable')

--- a/src/webviews/documentdbQuery/completions/mapCompletionItems.ts
+++ b/src/webviews/documentdbQuery/completions/mapCompletionItems.ts
@@ -116,6 +116,7 @@ export function mapOperatorToCompletionItem(
         insertTextRules: hasSnippet ? monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet : undefined,
         documentation: {
             value: documentationValue,
+            isTrusted: true,
         },
         sortText: sortPrefix ? `${sortPrefix}${entry.value}` : undefined,
         range,

--- a/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
@@ -1821,7 +1821,7 @@ describe('documentdbQueryCompletionProvider', () => {
                 expect(categories.has('logical')).toBe(true);
             });
 
-            test('does NOT include field-level categories (comparison, array, evaluation, element)', () => {
+            test('does NOT include purely field-level categories (comparison, array, element)', () => {
                 const items = createCompletionItems({
                     editorType: EditorType.Filter,
                     sessionId: undefined,
@@ -1832,10 +1832,11 @@ describe('documentdbQueryCompletionProvider', () => {
                 });
 
                 const categories = getCategories(items);
+                // These categories have NO operators in KEY_POSITION_OPERATORS
                 expect(categories.has('comparison')).toBe(false);
                 expect(categories.has('array')).toBe(false);
-                expect(categories.has('evaluation')).toBe(false);
                 expect(categories.has('element')).toBe(false);
+                // Note: 'evaluation' IS present because $expr, $jsonSchema, $text are key-position
             });
 
             test('does NOT include "bson" or "JS global"', () => {
@@ -1946,10 +1947,10 @@ describe('documentdbQueryCompletionProvider', () => {
             });
         });
 
-        describe('unknown position (empty editor / no context)', () => {
+        describe('unknown position (genuinely ambiguous — shows everything)', () => {
             const unknownContext: CursorContext = { position: 'unknown' };
 
-            test('includes key-position "logical" category', () => {
+            test('includes all categories (full discovery fallback)', () => {
                 const items = createCompletionItems({
                     editorType: EditorType.Filter,
                     sessionId: undefined,
@@ -1960,39 +1961,12 @@ describe('documentdbQueryCompletionProvider', () => {
                 });
 
                 const categories = getCategories(items);
+                // UNKNOWN shows everything as discovery
                 expect(categories.has('logical')).toBe(true);
-            });
-
-            test('does NOT include field-level categories (comparison, array, evaluation, element)', () => {
-                const items = createCompletionItems({
-                    editorType: EditorType.Filter,
-                    sessionId: undefined,
-                    range: testRange,
-                    isDollarPrefix: false,
-                    monaco: mockMonaco,
-                    cursorContext: unknownContext,
-                });
-
-                const categories = getCategories(items);
-                expect(categories.has('comparison')).toBe(false);
-                expect(categories.has('array')).toBe(false);
-                expect(categories.has('evaluation')).toBe(false);
-                expect(categories.has('element')).toBe(false);
-            });
-
-            test('does NOT include "bson" or "JS global"', () => {
-                const items = createCompletionItems({
-                    editorType: EditorType.Filter,
-                    sessionId: undefined,
-                    range: testRange,
-                    isDollarPrefix: false,
-                    monaco: mockMonaco,
-                    cursorContext: unknownContext,
-                });
-
-                const categories = getCategories(items);
-                expect(categories.has('bson')).toBe(false);
-                expect(categories.has('JS global')).toBe(false);
+                expect(categories.has('comparison')).toBe(true);
+                expect(categories.has('array')).toBe(true);
+                expect(categories.has('bson')).toBe(true);
+                expect(categories.has('JS global')).toBe(true);
             });
 
             test('includes field names if store has data', () => {

--- a/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
@@ -900,9 +900,10 @@ describe('documentdbQueryCompletionProvider', () => {
                 expect(labels).toContain('$and');
                 expect(labels).toContain('$or');
                 expect(labels).toContain('$nor');
-                expect(labels).toContain('$not');
                 expect(labels).toContain('$comment');
                 expect(labels).toContain('$expr');
+                // $not is a field-level operator, NOT a key-position operator
+                expect(labels).not.toContain('$not');
             });
 
             test('does NOT show value-level operators ($gt, $lt, $regex, $eq)', () => {
@@ -1098,7 +1099,7 @@ describe('documentdbQueryCompletionProvider', () => {
         describe('operator position', () => {
             const operatorContext: CursorContext = { position: 'operator', fieldName: 'age' };
 
-            test('shows comparison operators ($gt, $lt, $eq, $in)', () => {
+            test('shows comparison operators ($gt, $lt, $eq, $in) and $not', () => {
                 const items = createCompletionItems({
                     editorType: EditorType.Filter,
                     sessionId: undefined,
@@ -1115,6 +1116,8 @@ describe('documentdbQueryCompletionProvider', () => {
                 expect(labels).toContain('$in');
                 expect(labels).toContain('$exists');
                 expect(labels).toContain('$regex');
+                // $not is a field-level operator, valid at operator position
+                expect(labels).toContain('$not');
             });
 
             test('does NOT show key-position operators ($and, $or)', () => {

--- a/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
@@ -1485,4 +1485,143 @@ describe('documentdbQueryCompletionProvider', () => {
             expect(items.filter((i) => i.sortText?.startsWith('00_'))).toHaveLength(0);
         });
     });
+
+    // ---------------------------------------------------------------
+    // Project and Sort value completions
+    // ---------------------------------------------------------------
+    describe('project editor value completions', () => {
+        const mockMonaco = createMockMonaco();
+
+        test('shows 1 (include) and 0 (exclude) at value position', () => {
+            const context: CursorContext = { position: 'value', fieldName: 'name' };
+            const items = createCompletionItems({
+                editorType: EditorType.Project,
+                sessionId: undefined,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: context,
+            });
+
+            expect(items).toHaveLength(2);
+            const labels = items.map((i) => getLabelText(i.label));
+            expect(labels).toContain('1');
+            expect(labels).toContain('0');
+        });
+
+        test('1 (include) has description "include field"', () => {
+            const context: CursorContext = { position: 'value', fieldName: 'name' };
+            const items = createCompletionItems({
+                editorType: EditorType.Project,
+                sessionId: undefined,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: context,
+            });
+
+            const includeItem = items.find((i) => getLabelText(i.label) === '1');
+            expect((includeItem?.label as { description: string }).description).toBe('include field');
+        });
+
+        test('does NOT show operators, BSON constructors, or JS globals', () => {
+            const context: CursorContext = { position: 'value', fieldName: 'name' };
+            const items = createCompletionItems({
+                editorType: EditorType.Project,
+                sessionId: undefined,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: context,
+            });
+
+            const labels = items.map((i) => getLabelText(i.label));
+            expect(labels).not.toContain('$gt');
+            expect(labels).not.toContain('ObjectId');
+            expect(labels).not.toContain('Date');
+        });
+
+        test('1 is preselected', () => {
+            const context: CursorContext = { position: 'value', fieldName: 'name' };
+            const items = createCompletionItems({
+                editorType: EditorType.Project,
+                sessionId: undefined,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: context,
+            });
+
+            const includeItem = items.find((i) => getLabelText(i.label) === '1');
+            expect(includeItem?.preselect).toBe(true);
+        });
+    });
+
+    describe('sort editor value completions', () => {
+        const mockMonaco = createMockMonaco();
+
+        test('shows 1 (ascending) and -1 (descending) at value position', () => {
+            const context: CursorContext = { position: 'value', fieldName: 'age' };
+            const items = createCompletionItems({
+                editorType: EditorType.Sort,
+                sessionId: undefined,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: context,
+            });
+
+            expect(items).toHaveLength(2);
+            const labels = items.map((i) => getLabelText(i.label));
+            expect(labels).toContain('1');
+            expect(labels).toContain('-1');
+        });
+
+        test('-1 has description "descending"', () => {
+            const context: CursorContext = { position: 'value', fieldName: 'age' };
+            const items = createCompletionItems({
+                editorType: EditorType.Sort,
+                sessionId: undefined,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: context,
+            });
+
+            const descItem = items.find((i) => getLabelText(i.label) === '-1');
+            expect((descItem?.label as { description: string }).description).toBe('descending');
+        });
+
+        test('does NOT show operators, BSON constructors, or JS globals', () => {
+            const context: CursorContext = { position: 'value', fieldName: 'age' };
+            const items = createCompletionItems({
+                editorType: EditorType.Sort,
+                sessionId: undefined,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: context,
+            });
+
+            const labels = items.map((i) => getLabelText(i.label));
+            expect(labels).not.toContain('$gt');
+            expect(labels).not.toContain('ObjectId');
+            expect(labels).not.toContain('Date');
+        });
+
+        test('1 is preselected', () => {
+            const context: CursorContext = { position: 'value', fieldName: 'age' };
+            const items = createCompletionItems({
+                editorType: EditorType.Sort,
+                sessionId: undefined,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: context,
+            });
+
+            const ascItem = items.find((i) => getLabelText(i.label) === '1');
+            expect(ascItem?.preselect).toBe(true);
+        });
+    });
 });

--- a/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
@@ -1396,6 +1396,84 @@ describe('documentdbQueryCompletionProvider', () => {
                 expect(andItem?.insertText).toContain('}');
             });
         });
+
+        // ---------------------------------------------------------------
+        // Category coverage: verify operator categories at each position
+        // ---------------------------------------------------------------
+        describe('operator category coverage by position', () => {
+            test('key position: only key-position operators, no field-level operators', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: { position: 'key', depth: 1 },
+                });
+
+                const labels = items.map((i) => getLabelText(i.label));
+                // Key-position: logical combinators and meta operators
+                expect(labels).toContain('$and'); // query:logical
+                expect(labels).toContain('$or'); // query:logical
+                expect(labels).toContain('$nor'); // query:logical
+                expect(labels).toContain('$comment'); // query:comment
+                expect(labels).toContain('$expr'); // query:expr
+                // Field-level operators must NOT appear at key position
+                expect(labels).not.toContain('$all'); // query:array — field-level
+                expect(labels).not.toContain('$elemMatch'); // query:array — field-level
+                expect(labels).not.toContain('$size'); // query:array — field-level
+                expect(labels).not.toContain('$gt'); // query:comparison
+                expect(labels).not.toContain('$regex'); // query:evaluation
+                expect(labels).not.toContain('$exists'); // query:element
+                expect(labels).not.toContain('$not'); // query:logical — field-level
+            });
+
+            test('value position: includes operators from all field-level categories', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: { position: 'value', fieldName: 'x' },
+                });
+
+                const labels = items.map((i) => getLabelText(i.label));
+                // Should include field-level operators from every category
+                expect(labels).toContain('$gt'); // query:comparison
+                expect(labels).toContain('$eq'); // query:comparison
+                expect(labels).toContain('$in'); // query:comparison
+                expect(labels).toContain('$regex'); // query:evaluation
+                expect(labels).toContain('$exists'); // query:element
+                expect(labels).toContain('$type'); // query:element
+                expect(labels).toContain('$all'); // query:array
+                expect(labels).toContain('$elemMatch'); // query:array
+                expect(labels).toContain('$size'); // query:array
+                expect(labels).toContain('$not'); // query:logical (field-level)
+                // Key-position operators should NOT be at value position
+                expect(labels).not.toContain('$and');
+                expect(labels).not.toContain('$or');
+            });
+
+            test('operator position: same field-level categories as value position', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: { position: 'operator', fieldName: 'x' },
+                });
+
+                const labels = items.map((i) => getLabelText(i.label));
+                expect(labels).toContain('$gt'); // query:comparison
+                expect(labels).toContain('$regex'); // query:evaluation
+                expect(labels).toContain('$exists'); // query:element
+                expect(labels).toContain('$all'); // query:array
+                expect(labels).toContain('$not'); // query:logical (field-level)
+                expect(labels).not.toContain('$and'); // key-position only
+            });
+        });
     });
 
     // ---------------------------------------------------------------

--- a/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
@@ -1790,9 +1790,7 @@ describe('documentdbQueryCompletionProvider', () => {
          * For JS globals it is "JS global".
          * For fields it is the type, e.g., "Number".
          */
-        function getDescription(
-            label: string | monacoEditor.languages.CompletionItemLabel,
-        ): string | undefined {
+        function getDescription(label: string | monacoEditor.languages.CompletionItemLabel): string | undefined {
             return typeof label === 'string' ? undefined : label.description;
         }
 

--- a/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
@@ -1777,4 +1777,252 @@ describe('documentdbQueryCompletionProvider', () => {
             expect(ascItem?.preselect).toBe(true);
         });
     });
+
+    // ---------------------------------------------------------------
+    // Category-based completion coverage by cursor position
+    // ---------------------------------------------------------------
+    describe('completion categories by cursor position', () => {
+        const mockMonaco = createMockMonaco();
+
+        /**
+         * Helper: extracts the description (category label) from a CompletionItem.
+         * For operator items this is getCategoryLabel(meta), e.g., "comparison", "array".
+         * For JS globals it is "JS global".
+         * For fields it is the type, e.g., "Number".
+         */
+        function getDescription(
+            label: string | monacoEditor.languages.CompletionItemLabel,
+        ): string | undefined {
+            return typeof label === 'string' ? undefined : label.description;
+        }
+
+        /** Returns Set of distinct category descriptions from a completion list. */
+        function getCategories(items: monacoEditor.languages.CompletionItem[]): Set<string> {
+            const categories = new Set<string>();
+            for (const item of items) {
+                const desc = getDescription(item.label);
+                if (desc) categories.add(desc);
+            }
+            return categories;
+        }
+
+        describe('key position ({ <cursor> })', () => {
+            const keyContext: CursorContext = { position: 'key', depth: 1 };
+
+            test('includes "logical" category operators', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: keyContext,
+                });
+
+                const categories = getCategories(items);
+                expect(categories.has('logical')).toBe(true);
+            });
+
+            test('does NOT include field-level categories (comparison, array, evaluation, element)', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: keyContext,
+                });
+
+                const categories = getCategories(items);
+                expect(categories.has('comparison')).toBe(false);
+                expect(categories.has('array')).toBe(false);
+                expect(categories.has('evaluation')).toBe(false);
+                expect(categories.has('element')).toBe(false);
+            });
+
+            test('does NOT include "bson" or "JS global"', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: keyContext,
+                });
+
+                const categories = getCategories(items);
+                expect(categories.has('bson')).toBe(false);
+                expect(categories.has('JS global')).toBe(false);
+            });
+        });
+
+        describe('value position ({ field: <cursor> })', () => {
+            const valueContext: CursorContext = { position: 'value', fieldName: 'x' };
+
+            test('includes field-level categories: comparison, array, evaluation, element', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: valueContext,
+                });
+
+                const categories = getCategories(items);
+                expect(categories.has('comparison')).toBe(true);
+                expect(categories.has('array')).toBe(true);
+                expect(categories.has('evaluation')).toBe(true);
+                expect(categories.has('element')).toBe(true);
+            });
+
+            test('includes "bson" and "JS global"', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: valueContext,
+                });
+
+                const categories = getCategories(items);
+                expect(categories.has('bson')).toBe(true);
+                expect(categories.has('JS global')).toBe(true);
+            });
+
+            test('does NOT include key-position-only operators', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: valueContext,
+                });
+
+                const labels = items.map((i) => getLabelText(i.label));
+                expect(labels).not.toContain('$and');
+                expect(labels).not.toContain('$or');
+                expect(labels).not.toContain('$nor');
+            });
+        });
+
+        describe('operator position ({ field: { <cursor> } })', () => {
+            const operatorContext: CursorContext = { position: 'operator', fieldName: 'x' };
+
+            test('includes field-level categories: comparison, array, evaluation, element', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: operatorContext,
+                });
+
+                const categories = getCategories(items);
+                expect(categories.has('comparison')).toBe(true);
+                expect(categories.has('array')).toBe(true);
+                expect(categories.has('evaluation')).toBe(true);
+                expect(categories.has('element')).toBe(true);
+            });
+
+            test('does NOT include "bson", "JS global", or key-position operators', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: operatorContext,
+                });
+
+                const categories = getCategories(items);
+                expect(categories.has('bson')).toBe(false);
+                expect(categories.has('JS global')).toBe(false);
+
+                const labels = items.map((i) => getLabelText(i.label));
+                expect(labels).not.toContain('$and');
+                expect(labels).not.toContain('$or');
+            });
+        });
+
+        describe('unknown position (empty editor / no context)', () => {
+            const unknownContext: CursorContext = { position: 'unknown' };
+
+            test('includes key-position "logical" category', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: unknownContext,
+                });
+
+                const categories = getCategories(items);
+                expect(categories.has('logical')).toBe(true);
+            });
+
+            test('does NOT include field-level categories (comparison, array, evaluation, element)', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: unknownContext,
+                });
+
+                const categories = getCategories(items);
+                expect(categories.has('comparison')).toBe(false);
+                expect(categories.has('array')).toBe(false);
+                expect(categories.has('evaluation')).toBe(false);
+                expect(categories.has('element')).toBe(false);
+            });
+
+            test('does NOT include "bson" or "JS global"', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: unknownContext,
+                });
+
+                const categories = getCategories(items);
+                expect(categories.has('bson')).toBe(false);
+                expect(categories.has('JS global')).toBe(false);
+            });
+
+            test('includes field names if store has data', () => {
+                setCompletionContext('test-session', {
+                    fields: [
+                        {
+                            fieldName: 'name',
+                            displayType: 'String',
+                            bsonType: 'string',
+                            isSparse: false,
+                            insertText: 'name',
+                            referenceText: '$name',
+                        },
+                    ],
+                });
+
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: 'test-session',
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: unknownContext,
+                });
+
+                const labels = items.map((i) => getLabelText(i.label));
+                expect(labels).toContain('name');
+            });
+        });
+    });
 });

--- a/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
@@ -163,6 +163,7 @@ describe('documentdbQueryCompletionProvider', () => {
             expect(item.insertTextRules).toBeUndefined();
             expect(item.documentation).toEqual({
                 value: 'Matches values equal to a specified value.',
+                isTrusted: true,
             });
             expect(item.range).toBe(testRange);
         });
@@ -199,6 +200,7 @@ describe('documentdbQueryCompletionProvider', () => {
             expect(item.insertTextRules).toBe(mockInsertTextRule.InsertAsSnippet);
             expect(item.documentation).toEqual({
                 value: 'Creates a new ObjectId value.\n\n[DocumentDB Docs](https://docs.example.com/objectid)',
+                isTrusted: true,
             });
         });
 

--- a/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryCompletionProvider.test.ts
@@ -1321,6 +1321,81 @@ describe('documentdbQueryCompletionProvider', () => {
                 expect(labels).toContain('ObjectId');
             });
         });
+
+        describe('needsWrapping (empty editor, no braces)', () => {
+            test('field insertText is wrapped with { } when needsWrapping is true', () => {
+                setCompletionContext('test-session', {
+                    fields: [
+                        {
+                            fieldName: 'name',
+                            displayType: 'String',
+                            bsonType: 'string',
+                            isSparse: false,
+                            insertText: 'name',
+                            referenceText: '$name',
+                        },
+                    ],
+                });
+
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: 'test-session',
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: { position: 'unknown' },
+                    needsWrapping: true,
+                });
+
+                const fieldItem = items.find((i) => getLabelText(i.label) === 'name');
+                expect(fieldItem?.insertText).toBe('{ name: $1 }');
+            });
+
+            test('field insertText is NOT wrapped when needsWrapping is false', () => {
+                setCompletionContext('test-session', {
+                    fields: [
+                        {
+                            fieldName: 'name',
+                            displayType: 'String',
+                            bsonType: 'string',
+                            isSparse: false,
+                            insertText: 'name',
+                            referenceText: '$name',
+                        },
+                    ],
+                });
+
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: 'test-session',
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: { position: 'unknown' },
+                    needsWrapping: false,
+                });
+
+                const fieldItem = items.find((i) => getLabelText(i.label) === 'name');
+                expect(fieldItem?.insertText).toBe('name: $1');
+            });
+
+            test('operators keep full brace-wrapping snippets when needsWrapping is true', () => {
+                const items = createCompletionItems({
+                    editorType: EditorType.Filter,
+                    sessionId: undefined,
+                    range: testRange,
+                    isDollarPrefix: false,
+                    monaco: mockMonaco,
+                    cursorContext: { position: 'unknown' },
+                    needsWrapping: true,
+                });
+
+                // Operator snippets include { } already — they should NOT be stripped
+                const andItem = items.find((i) => getLabelText(i.label) === '$and');
+                expect(andItem?.insertText).toContain('{');
+                expect(andItem?.insertText).toContain('}');
+            });
+        });
     });
 
     // ---------------------------------------------------------------

--- a/src/webviews/documentdbQuery/documentdbQueryHoverProvider.test.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryHoverProvider.test.ts
@@ -3,7 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { getHoverContent } from './documentdbQueryHoverProvider';
+import { type FieldCompletionData } from '../../utils/json/data-api/autocomplete/toFieldCompletionItems';
+import { getHoverContent, type FieldDataLookup } from './documentdbQueryHoverProvider';
+
+/** Creates a mock field lookup function from an array of fields. */
+function createFieldLookup(fields: FieldCompletionData[]): FieldDataLookup {
+    return (word: string) => fields.find((f) => f.fieldName === word);
+}
 
 describe('documentdbQueryHoverProvider', () => {
     describe('getHoverContent', () => {
@@ -68,6 +74,85 @@ describe('documentdbQueryHoverProvider', () => {
 
             const content = (hover!.contents[0] as { value: string }).value;
             expect(content).toContain('**UUID**');
+        });
+    });
+
+    describe('field hover', () => {
+        const fields: FieldCompletionData[] = [
+            {
+                fieldName: 'age',
+                displayType: 'Number',
+                bsonType: 'int32',
+                isSparse: false,
+                insertText: 'age',
+                referenceText: '$age',
+            },
+            {
+                fieldName: 'nickname',
+                displayType: 'String',
+                bsonType: 'string',
+                isSparse: true,
+                insertText: 'nickname',
+                referenceText: '$nickname',
+            },
+        ];
+
+        test('returns hover for a known field name', () => {
+            const hover = getHoverContent('age', createFieldLookup(fields));
+            expect(hover).not.toBeNull();
+
+            const content = (hover!.contents[0] as { value: string }).value;
+            expect(content).toContain('**age**');
+            expect(content).toContain('Number');
+        });
+
+        test('shows sparse indicator for sparse fields', () => {
+            const hover = getHoverContent('nickname', createFieldLookup(fields));
+            expect(hover).not.toBeNull();
+
+            const content = (hover!.contents[0] as { value: string }).value;
+            expect(content).toContain('**nickname**');
+            expect(content).toContain('String');
+            expect(content).toContain('sparse');
+        });
+
+        test('does NOT show sparse indicator for non-sparse fields', () => {
+            const hover = getHoverContent('age', createFieldLookup(fields));
+            expect(hover).not.toBeNull();
+
+            const content = (hover!.contents[0] as { value: string }).value;
+            expect(content).not.toContain('sparse');
+        });
+
+        test('returns null for unknown field when no operator match', () => {
+            const hover = getHoverContent('unknownField', createFieldLookup(fields));
+            expect(hover).toBeNull();
+        });
+
+        test('operators take priority over field names', () => {
+            // If a field happens to be named "gt", the operator $gt should match first
+            const fieldsWithOperatorName: FieldCompletionData[] = [
+                {
+                    fieldName: 'gt',
+                    displayType: 'String',
+                    bsonType: 'string',
+                    isSparse: false,
+                    insertText: 'gt',
+                    referenceText: '$gt',
+                },
+            ];
+
+            const hover = getHoverContent('gt', createFieldLookup(fieldsWithOperatorName));
+            expect(hover).not.toBeNull();
+
+            const content = (hover!.contents[0] as { value: string }).value;
+            // Should show operator hover, not field hover
+            expect(content).toContain('**$gt**');
+        });
+
+        test('returns null for field when no fieldLookup provided', () => {
+            const hover = getHoverContent('age');
+            expect(hover).toBeNull();
         });
     });
 });

--- a/src/webviews/documentdbQuery/documentdbQueryHoverProvider.test.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryHoverProvider.test.ts
@@ -157,12 +157,12 @@ describe('documentdbQueryHoverProvider', () => {
             expect(content).not.toContain('sparse');
         });
 
-        test('field hover has isTrusted set', () => {
+        test('field hover does NOT set isTrusted (user data is not trusted)', () => {
             const hover = getHoverContent('age', createFieldLookup(fields));
             expect(hover).not.toBeNull();
 
             const hoverContent = hover!.contents[0] as { isTrusted?: boolean };
-            expect(hoverContent.isTrusted).toBe(true);
+            expect(hoverContent.isTrusted).toBeUndefined();
         });
 
         test('returns null for unknown field when no operator match', () => {

--- a/src/webviews/documentdbQuery/documentdbQueryHoverProvider.test.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryHoverProvider.test.ts
@@ -62,7 +62,7 @@ describe('documentdbQueryHoverProvider', () => {
             expect(hover).not.toBeNull();
 
             const content = (hover!.contents[0] as { value: string }).value;
-            expect(content).toContain('[DocumentDB Docs]');
+            expect(content).toContain('Documentation]');
         });
 
         test('operator hover has isTrusted set for clickable links', () => {
@@ -120,12 +120,12 @@ describe('documentdbQueryHoverProvider', () => {
             expect(content).toContain('**age**');
         });
 
-        test('shows "Inferred Types" section with type list', () => {
+        test('shows "Inferred Type" section with type list', () => {
             const hover = getHoverContent('age', createFieldLookup(fields));
             expect(hover).not.toBeNull();
 
             const content = (hover!.contents[0] as { value: string }).value;
-            expect(content).toContain('**Inferred Types**');
+            expect(content).toContain('Inferred Type');
             expect(content).toContain('Number');
         });
 
@@ -134,7 +134,7 @@ describe('documentdbQueryHoverProvider', () => {
             expect(hover).not.toBeNull();
 
             const content = (hover!.contents[0] as { value: string }).value;
-            expect(content).toContain('**Inferred Types**');
+            expect(content).toContain('Inferred Type');
             expect(content).toContain('Double');
             expect(content).toContain('Int32');
         });

--- a/src/webviews/documentdbQuery/documentdbQueryHoverProvider.test.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryHoverProvider.test.ts
@@ -28,7 +28,6 @@ describe('documentdbQueryHoverProvider', () => {
 
             const content = (hover!.contents[0] as { value: string }).value;
             expect(content).toContain('**$eq**');
-            // It should have a description line
             expect(content.split('\n').length).toBeGreaterThan(1);
         });
 
@@ -51,7 +50,6 @@ describe('documentdbQueryHoverProvider', () => {
         });
 
         test('word without $ prefix matches operator when prefixed', () => {
-            // When cursor is on "gt" (after $ was already output), try $gt
             const hover = getHoverContent('gt');
             expect(hover).not.toBeNull();
 
@@ -64,8 +62,15 @@ describe('documentdbQueryHoverProvider', () => {
             expect(hover).not.toBeNull();
 
             const content = (hover!.contents[0] as { value: string }).value;
-            // $gt is a well-known operator that should have a doc link
             expect(content).toContain('[DocumentDB Docs]');
+        });
+
+        test('operator hover has isTrusted set for clickable links', () => {
+            const hover = getHoverContent('$gt');
+            expect(hover).not.toBeNull();
+
+            const hoverContent = hover!.contents[0] as { isTrusted?: boolean };
+            expect(hoverContent.isTrusted).toBe(true);
         });
 
         test('returns hover for UUID constructor', () => {
@@ -95,6 +100,16 @@ describe('documentdbQueryHoverProvider', () => {
                 insertText: 'nickname',
                 referenceText: '$nickname',
             },
+            {
+                fieldName: 'rating',
+                displayType: 'Double',
+                bsonType: 'double',
+                bsonTypes: ['double', 'int32'],
+                displayTypes: ['Double', 'Int32'],
+                isSparse: true,
+                insertText: 'rating',
+                referenceText: '$rating',
+            },
         ];
 
         test('returns hover for a known field name', () => {
@@ -103,7 +118,25 @@ describe('documentdbQueryHoverProvider', () => {
 
             const content = (hover!.contents[0] as { value: string }).value;
             expect(content).toContain('**age**');
+        });
+
+        test('shows "Inferred Types" section with type list', () => {
+            const hover = getHoverContent('age', createFieldLookup(fields));
+            expect(hover).not.toBeNull();
+
+            const content = (hover!.contents[0] as { value: string }).value;
+            expect(content).toContain('**Inferred Types**');
             expect(content).toContain('Number');
+        });
+
+        test('shows multiple types for polymorphic fields', () => {
+            const hover = getHoverContent('rating', createFieldLookup(fields));
+            expect(hover).not.toBeNull();
+
+            const content = (hover!.contents[0] as { value: string }).value;
+            expect(content).toContain('**Inferred Types**');
+            expect(content).toContain('Double');
+            expect(content).toContain('Int32');
         });
 
         test('shows sparse indicator for sparse fields', () => {
@@ -112,8 +145,8 @@ describe('documentdbQueryHoverProvider', () => {
 
             const content = (hover!.contents[0] as { value: string }).value;
             expect(content).toContain('**nickname**');
-            expect(content).toContain('String');
             expect(content).toContain('sparse');
+            expect(content).toContain('not present in all documents');
         });
 
         test('does NOT show sparse indicator for non-sparse fields', () => {
@@ -124,13 +157,20 @@ describe('documentdbQueryHoverProvider', () => {
             expect(content).not.toContain('sparse');
         });
 
+        test('field hover has isTrusted set', () => {
+            const hover = getHoverContent('age', createFieldLookup(fields));
+            expect(hover).not.toBeNull();
+
+            const hoverContent = hover!.contents[0] as { isTrusted?: boolean };
+            expect(hoverContent.isTrusted).toBe(true);
+        });
+
         test('returns null for unknown field when no operator match', () => {
             const hover = getHoverContent('unknownField', createFieldLookup(fields));
             expect(hover).toBeNull();
         });
 
         test('operators take priority over field names', () => {
-            // If a field happens to be named "gt", the operator $gt should match first
             const fieldsWithOperatorName: FieldCompletionData[] = [
                 {
                     fieldName: 'gt',
@@ -146,7 +186,6 @@ describe('documentdbQueryHoverProvider', () => {
             expect(hover).not.toBeNull();
 
             const content = (hover!.contents[0] as { value: string }).value;
-            // Should show operator hover, not field hover
             expect(content).toContain('**$gt**');
         });
 

--- a/src/webviews/documentdbQuery/documentdbQueryHoverProvider.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryHoverProvider.ts
@@ -6,13 +6,20 @@
 /**
  * Hover provider logic for the `documentdb-query` language.
  *
- * Provides inline documentation when hovering over operators and
- * BSON constructors. Uses `documentdb-constants` for the operator registry.
+ * Provides inline documentation when hovering over operators,
+ * BSON constructors, and field names. Uses `documentdb-constants` for
+ * the operator registry and the completion store for field type info.
  */
 
 import { getAllCompletions } from '@vscode-documentdb/documentdb-constants';
 // eslint-disable-next-line import/no-internal-modules
 import type * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
+import { type FieldCompletionData } from '../../utils/json/data-api/autocomplete/toFieldCompletionItems';
+
+/**
+ * A callback that resolves a word to field data from the completion store.
+ */
+export type FieldDataLookup = (word: string) => FieldCompletionData | undefined;
 
 /**
  * Returns hover content for a word under the cursor.
@@ -20,11 +27,15 @@ import type * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
  * Tries multiple candidates to handle cases where:
  * - The cursor is on `gt` after `$` (need to try `$gt`)
  * - The cursor is on `ObjectId` (try as-is)
+ * - The cursor is on a field name like `age` (check field data)
+ *
+ * Operators/BSON constructors take priority over field names.
  *
  * @param word - The word at the cursor position
+ * @param fieldLookup - optional callback to resolve field names to field data
  * @returns A Monaco Hover or null if no match
  */
-export function getHoverContent(word: string): monacoEditor.languages.Hover | null {
+export function getHoverContent(word: string, fieldLookup?: FieldDataLookup): monacoEditor.languages.Hover | null {
     // Try with '$' prefix first (for operators where cursor lands after $)
     // Then try the word as-is (for BSON constructors like ObjectId)
     const candidates = word.startsWith('$') ? [word] : [`$${word}`, word];
@@ -42,9 +53,37 @@ export function getHoverContent(word: string): monacoEditor.languages.Hover | nu
                 lines.push('', `[DocumentDB Docs](${match.link})`);
             }
             return {
-                contents: [{ value: lines.join('\n') }],
+                contents: [{ value: lines.join('\n'), isTrusted: true }],
             };
         }
     }
+
+    // If no operator match, try field name lookup
+    if (fieldLookup) {
+        const fieldData = fieldLookup(word);
+        if (fieldData) {
+            return buildFieldHover(fieldData);
+        }
+    }
+
     return null;
+}
+
+/**
+ * Builds a hover tooltip for a field name, showing its type info.
+ *
+ * Uses relative language for statistics (e.g., "sparse" rather than
+ * absolute percentages) since the SchemaAnalyzer accumulates data
+ * across queries and the numbers are approximate.
+ */
+function buildFieldHover(field: FieldCompletionData): monacoEditor.languages.Hover {
+    const lines: string[] = [`**${field.fieldName}**`];
+
+    // Type info
+    const sparseNote = field.isSparse ? ' *(sparse — not present in all documents)*' : '';
+    lines.push('', `Type: \`${field.displayType}\`${sparseNote}`);
+
+    return {
+        contents: [{ value: lines.join('\n') }],
+    };
 }

--- a/src/webviews/documentdbQuery/documentdbQueryHoverProvider.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryHoverProvider.ts
@@ -15,6 +15,7 @@ import { getAllCompletions } from '@vscode-documentdb/documentdb-constants';
 // eslint-disable-next-line import/no-internal-modules
 import type * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 import { type FieldCompletionData } from '../../utils/json/data-api/autocomplete/toFieldCompletionItems';
+import { escapeMarkdown } from '../utils/escapeMarkdown';
 
 /**
  * A callback that resolves a word to field data from the completion store.
@@ -80,7 +81,8 @@ export function getHoverContent(word: string, fieldLookup?: FieldDataLookup): mo
  * Builds a hover tooltip for a field name.
  */
 function buildFieldHover(field: FieldCompletionData): monacoEditor.languages.Hover {
-    let header = `**${field.fieldName}**`;
+    const safeName = escapeMarkdown(field.fieldName);
+    let header = `**${safeName}**`;
 
     if (field.isSparse) {
         header += ' &nbsp;&nbsp; <small>sparse: not present in all documents</small>';
@@ -93,10 +95,10 @@ function buildFieldHover(field: FieldCompletionData): monacoEditor.languages.Hov
     if (typeList && typeList.length > 0) {
         lines.push('---');
         lines.push('<br>');
-        lines.push(`Inferred Type: ${typeList.map((type) => `\`${type}\``).join(', ')}`);
+        lines.push(`Inferred Type: ${typeList.map((type) => `\`${escapeMarkdown(type)}\``).join(', ')}`);
     }
 
     return {
-        contents: [{ value: lines.join('\n\n'), isTrusted: true, supportHtml: true }],
+        contents: [{ value: lines.join('\n\n'), supportHtml: true }],
     };
 }

--- a/src/webviews/documentdbQuery/documentdbQueryHoverProvider.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryHoverProvider.ts
@@ -56,9 +56,6 @@ export function getHoverContent(word: string, fieldLookup?: FieldDataLookup): mo
                 lines.push(match.description);
             }
             if (match.link) {
-                if (match.description) {
-                    lines.push('<br>');
-                }
                 lines.push(`[ⓘ Documentation](${match.link})`);
             }
 

--- a/src/webviews/documentdbQuery/documentdbQueryHoverProvider.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryHoverProvider.ts
@@ -70,20 +70,30 @@ export function getHoverContent(word: string, fieldLookup?: FieldDataLookup): mo
 }
 
 /**
- * Builds a hover tooltip for a field name, showing its type info.
+ * Builds a hover tooltip for a field name.
  *
- * Uses relative language for statistics (e.g., "sparse" rather than
- * absolute percentages) since the SchemaAnalyzer accumulates data
- * across queries and the numbers are approximate.
+ * Format:
+ * ```
+ * **fieldName** <small>sparse: not present in all documents</small>
+ *
+ * **Inferred Types**
+ * String, Int32
+ * ```
  */
 function buildFieldHover(field: FieldCompletionData): monacoEditor.languages.Hover {
-    const lines: string[] = [`**${field.fieldName}**`];
+    // First line: field name, optionally with sparse note
+    let header = `**${field.fieldName}**`;
+    if (field.isSparse) {
+        header += ' &nbsp; <sub>sparse: not present in all documents</sub>';
+    }
 
-    // Type info
-    const sparseNote = field.isSparse ? ' *(sparse — not present in all documents)*' : '';
-    lines.push('', `Type: \`${field.displayType}\`${sparseNote}`);
+    const lines: string[] = [header];
+
+    // Inferred types section
+    const typeList = field.displayTypes && field.displayTypes.length > 0 ? field.displayTypes : [field.displayType];
+    lines.push('', '**Inferred Types**', typeList.join(', '));
 
     return {
-        contents: [{ value: lines.join('\n') }],
+        contents: [{ value: lines.join('\n'), isTrusted: true, supportHtml: true }],
     };
 }

--- a/src/webviews/documentdbQuery/documentdbQueryHoverProvider.ts
+++ b/src/webviews/documentdbQuery/documentdbQueryHoverProvider.ts
@@ -46,14 +46,24 @@ export function getHoverContent(word: string, fieldLookup?: FieldDataLookup): mo
         const match = allEntries.find((e) => e.value === candidate);
         if (match) {
             const lines: string[] = [`**${match.value}**`];
+
+            if (match.description || match.link) {
+                lines.push('---');
+                lines.push('<br>');
+            }
+
             if (match.description) {
-                lines.push('', match.description);
+                lines.push(match.description);
             }
             if (match.link) {
-                lines.push('', `[DocumentDB Docs](${match.link})`);
+                if (match.description) {
+                    lines.push('<br>');
+                }
+                lines.push(`[ⓘ Documentation](${match.link})`);
             }
+
             return {
-                contents: [{ value: lines.join('\n'), isTrusted: true }],
+                contents: [{ value: lines.join('\n\n'), isTrusted: true, supportHtml: true }],
             };
         }
     }
@@ -71,29 +81,25 @@ export function getHoverContent(word: string, fieldLookup?: FieldDataLookup): mo
 
 /**
  * Builds a hover tooltip for a field name.
- *
- * Format:
- * ```
- * **fieldName** <small>sparse: not present in all documents</small>
- *
- * **Inferred Types**
- * String, Int32
- * ```
  */
 function buildFieldHover(field: FieldCompletionData): monacoEditor.languages.Hover {
-    // First line: field name, optionally with sparse note
     let header = `**${field.fieldName}**`;
+
     if (field.isSparse) {
-        header += ' &nbsp; <sub>sparse: not present in all documents</sub>';
+        header += ' &nbsp;&nbsp; <small>sparse: not present in all documents</small>';
     }
 
     const lines: string[] = [header];
 
     // Inferred types section
     const typeList = field.displayTypes && field.displayTypes.length > 0 ? field.displayTypes : [field.displayType];
-    lines.push('', '**Inferred Types**', typeList.join(', '));
+    if (typeList && typeList.length > 0) {
+        lines.push('---');
+        lines.push('<br>');
+        lines.push(`Inferred Type: ${typeList.map((type) => `\`${type}\``).join(', ')}`);
+    }
 
     return {
-        contents: [{ value: lines.join('\n'), isTrusted: true, supportHtml: true }],
+        contents: [{ value: lines.join('\n\n'), isTrusted: true, supportHtml: true }],
     };
 }

--- a/src/webviews/documentdbQuery/extractQuotedKey.test.ts
+++ b/src/webviews/documentdbQuery/extractQuotedKey.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { extractQuotedKey } from './registerLanguage';
+import { extractQuotedKey } from './extractQuotedKey';
 
 describe('extractQuotedKey', () => {
     test('extracts double-quoted key when cursor is inside', () => {

--- a/src/webviews/documentdbQuery/extractQuotedKey.test.ts
+++ b/src/webviews/documentdbQuery/extractQuotedKey.test.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { extractQuotedKey } from './registerLanguage';
+
+describe('extractQuotedKey', () => {
+    test('extracts double-quoted key when cursor is inside', () => {
+        const line = '{ "address.street": "value" }';
+        //             01234567890123456789
+        const col = 5; // on 'a' of address
+        const result = extractQuotedKey(line, col);
+        expect(result).not.toBeNull();
+        expect(result!.key).toBe('address.street');
+    });
+
+    test('extracts single-quoted key when cursor is inside', () => {
+        const line = "{ 'address.street': 'value' }";
+        const col = 5;
+        const result = extractQuotedKey(line, col);
+        expect(result).not.toBeNull();
+        expect(result!.key).toBe('address.street');
+    });
+
+    test('returns null when cursor is not inside quotes', () => {
+        const line = '{ name: "value" }';
+        const col = 3; // on 'a' of name (unquoted)
+        const result = extractQuotedKey(line, col);
+        expect(result).toBeNull();
+    });
+
+    test('returns null when cursor is on a structural character', () => {
+        const line = '{ "key": "value" }';
+        const col = 0; // on '{'
+        const result = extractQuotedKey(line, col);
+        expect(result).toBeNull();
+    });
+
+    test('returns correct start/end for range highlighting', () => {
+        const line = '{ "address.street": 1 }';
+        //            0123456789012345678
+        const col = 10; // somewhere inside the quoted string
+        const result = extractQuotedKey(line, col);
+        expect(result).not.toBeNull();
+        expect(result!.start).toBe(2); // position of opening "
+        expect(result!.end).toBe(18); // position after closing "
+        expect(result!.key).toBe('address.street');
+    });
+
+    test('handles escaped quotes inside key', () => {
+        const line = '{ "key\\"name": 1 }';
+        const col = 5;
+        const result = extractQuotedKey(line, col);
+        expect(result).not.toBeNull();
+        expect(result!.key).toBe('key\\"name');
+    });
+
+    test('cursor on opening quote still works', () => {
+        const line = '{ "address.street": 1 }';
+        const col = 2; // on the opening "
+        const result = extractQuotedKey(line, col);
+        expect(result).not.toBeNull();
+        expect(result!.key).toBe('address.street');
+    });
+
+    test('cursor on closing quote still works', () => {
+        const line = '{ "address.street": 1 }';
+        const col = 17; // on the closing "
+        const result = extractQuotedKey(line, col);
+        expect(result).not.toBeNull();
+        expect(result!.key).toBe('address.street');
+    });
+
+    test('returns null for empty line', () => {
+        const result = extractQuotedKey('', 0);
+        expect(result).toBeNull();
+    });
+});

--- a/src/webviews/documentdbQuery/extractQuotedKey.ts
+++ b/src/webviews/documentdbQuery/extractQuotedKey.ts
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Extracts a quoted key string if the cursor is inside one.
+ *
+ * For `{ "address.street": 1 }`, when the cursor is anywhere between the
+ * opening and closing quotes, returns the unquoted key `"address.street"`
+ * along with the 0-based start/end positions of the full quoted string
+ * (including the quotes themselves, for hover range highlighting).
+ *
+ * Returns null if the cursor is not inside a quoted string.
+ *
+ * @param line - the full line content
+ * @param col0 - 0-based column position of the cursor
+ */
+export function extractQuotedKey(line: string, col0: number): { key: string; start: number; end: number } | null {
+    if (col0 < 0 || col0 >= line.length) return null;
+
+    // If cursor is on a quote, it could be the closing quote.
+    // Try treating the current position as the closing quote first.
+    const chAtCursor = line[col0];
+    if (chAtCursor === '"' || chAtCursor === "'") {
+        // Not escaped?
+        if (col0 === 0 || line[col0 - 1] !== '\\') {
+            // Try to find a matching opening quote before this one
+            const result = tryMatchAsClosingQuote(line, col0, chAtCursor);
+            if (result) return result;
+        }
+    }
+
+    // Scan backward to find the opening quote
+    let openQuoteIdx = -1;
+    let quoteChar: string | undefined;
+
+    for (let i = col0; i >= 0; i--) {
+        const ch = line[i];
+        if (ch === '"' || ch === "'") {
+            if (i > 0 && line[i - 1] === '\\') continue;
+            openQuoteIdx = i;
+            quoteChar = ch;
+            break;
+        }
+        if (ch === '{' || ch === '}' || ch === ':' || ch === ',') {
+            return null;
+        }
+    }
+
+    if (openQuoteIdx < 0 || !quoteChar) return null;
+
+    // Scan forward to find the closing quote
+    let closeQuoteIdx = -1;
+    for (let i = openQuoteIdx + 1; i < line.length; i++) {
+        if (line[i] === '\\') {
+            i++;
+            continue;
+        }
+        if (line[i] === quoteChar) {
+            closeQuoteIdx = i;
+            break;
+        }
+    }
+
+    if (closeQuoteIdx < 0) return null;
+    if (col0 < openQuoteIdx || col0 > closeQuoteIdx) return null;
+
+    const key = line.substring(openQuoteIdx + 1, closeQuoteIdx);
+    return { key, start: openQuoteIdx, end: closeQuoteIdx + 1 };
+}
+
+function tryMatchAsClosingQuote(
+    line: string,
+    closeIdx: number,
+    quoteChar: string,
+): { key: string; start: number; end: number } | null {
+    // Scan backward from before the closing quote to find the opening quote
+    for (let i = closeIdx - 1; i >= 0; i--) {
+        if (line[i] === '\\') continue;
+        if (line[i] === quoteChar) {
+            if (i > 0 && line[i - 1] === '\\') continue;
+            const key = line.substring(i + 1, closeIdx);
+            return { key, start: i, end: closeIdx + 1 };
+        }
+        // Stop at structural chars
+        if (line[i] === '{' || line[i] === '}' || line[i] === ':' || line[i] === ',') {
+            return null;
+        }
+    }
+    return null;
+}

--- a/src/webviews/documentdbQuery/isCursorInsideString.test.ts
+++ b/src/webviews/documentdbQuery/isCursorInsideString.test.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isCursorInsideString } from './isCursorInsideString';
+
+describe('isCursorInsideString', () => {
+    test('returns false for empty text', () => {
+        expect(isCursorInsideString('', 0)).toBe(false);
+    });
+
+    test('returns false when cursor is outside any string', () => {
+        const text = '{ name: "Alice", age: 30 }';
+        // cursor after the comma, outside the string
+        const cursorOffset = text.indexOf(',') + 1;
+        expect(isCursorInsideString(text, cursorOffset)).toBe(false);
+    });
+
+    test('returns true when cursor is inside a double-quoted string', () => {
+        const text = '{ name: "Ali';
+        expect(isCursorInsideString(text, text.length)).toBe(true);
+    });
+
+    test('returns true when cursor is inside a single-quoted string', () => {
+        const text = "{ name: 'Ali";
+        expect(isCursorInsideString(text, text.length)).toBe(true);
+    });
+
+    test('returns false when cursor is after a closed string', () => {
+        const text = '{ name: "Alice" }';
+        // cursor at the space after closing quote
+        const cursorOffset = text.indexOf('"', 9) + 1;
+        expect(isCursorInsideString(text, cursorOffset)).toBe(false);
+    });
+
+    test('handles escaped quotes inside strings', () => {
+        const text = '{ name: "has\\"quote';
+        // cursor is still inside the string (the \" is escaped)
+        expect(isCursorInsideString(text, text.length)).toBe(true);
+    });
+
+    test('returns false after escaped quote followed by closing quote', () => {
+        const text = '{ name: "has\\"quote" }';
+        // cursor after the closing quote
+        const closingQuoteIdx = text.lastIndexOf('"');
+        expect(isCursorInsideString(text, closingQuoteIdx + 1)).toBe(false);
+    });
+
+    // Edge cases from the plan
+    test('{ name: "Alice", | } — cursor outside string after comma', () => {
+        const text = '{ name: "Alice", ';
+        expect(isCursorInsideString(text, text.length)).toBe(false);
+    });
+
+    test('{ name: "has:colon" } — cursor inside string at colon', () => {
+        const text = '{ name: "has:';
+        expect(isCursorInsideString(text, text.length)).toBe(true);
+    });
+
+    test('{ name: "has:colon", | } — cursor outside string after comma', () => {
+        const text = '{ name: "has:colon", ';
+        expect(isCursorInsideString(text, text.length)).toBe(false);
+    });
+
+    test('{ tags: ["a", | ] } — cursor outside string in array', () => {
+        const text = '{ tags: ["a", ';
+        expect(isCursorInsideString(text, text.length)).toBe(false);
+    });
+
+    test('{ msg: "has[bracket" } — cursor inside string at bracket', () => {
+        const text = '{ msg: "has[';
+        expect(isCursorInsideString(text, text.length)).toBe(true);
+    });
+
+    test('{ $and: [ | ] } — cursor outside string in array', () => {
+        const text = '{ $and: [ ';
+        expect(isCursorInsideString(text, text.length)).toBe(false);
+    });
+
+    test('handles mixed quote types correctly', () => {
+        const text = '{ name: "it\'s" }';
+        // The single quote inside double quotes doesn't close anything
+        const cursorAfterClosingDouble = text.indexOf('"', 9) + 1;
+        expect(isCursorInsideString(text, cursorAfterClosingDouble)).toBe(false);
+    });
+});

--- a/src/webviews/documentdbQuery/isCursorInsideString.ts
+++ b/src/webviews/documentdbQuery/isCursorInsideString.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Determines whether the cursor is inside a string literal.
+ *
+ * Scans the text from the beginning up to the cursor offset, tracking whether
+ * we are inside a single-quoted or double-quoted string. Escaped quotes
+ * (preceded by `\`) do not toggle the state.
+ *
+ * This is a lightweight heuristic for suppressing auto-trigger completions
+ * when the trigger character (`:`, `,`, `[`) appears inside a string value
+ * rather than as structural syntax.
+ *
+ * @param text - the full text of the editor
+ * @param cursorOffset - the 0-based character offset of the cursor
+ * @returns true if the cursor is inside a string literal
+ */
+export function isCursorInsideString(text: string, cursorOffset: number): boolean {
+    let inString: "'" | '"' | false = false;
+
+    for (let i = 0; i < cursorOffset && i < text.length; i++) {
+        const ch = text[i];
+
+        if (inString) {
+            // Check for escape character
+            if (ch === '\\') {
+                // Skip the next character (escaped)
+                i++;
+                continue;
+            }
+            // Check for closing quote
+            if (ch === inString) {
+                inString = false;
+            }
+        } else {
+            // Check for opening quote
+            if (ch === '"' || ch === "'") {
+                inString = ch;
+            }
+        }
+    }
+
+    return inString !== false;
+}

--- a/src/webviews/documentdbQuery/registerLanguage.ts
+++ b/src/webviews/documentdbQuery/registerLanguage.ts
@@ -30,6 +30,7 @@ import { getCompletionContext } from './completionStore';
 import { detectCursorContext } from './cursorContext';
 import { createCompletionItems } from './documentdbQueryCompletionProvider';
 import { getHoverContent } from './documentdbQueryHoverProvider';
+import { extractQuotedKey } from './extractQuotedKey';
 import { isCursorInsideString } from './isCursorInsideString';
 import { LANGUAGE_ID, parseEditorUri } from './languageConfig';
 
@@ -211,92 +212,4 @@ async function doRegisterLanguage(monaco: typeof monacoEditor): Promise<void> {
  */
 export function _resetRegistration(): void {
     registrationPromise = undefined;
-}
-
-/**
- * Extracts a quoted key string if the cursor is inside one.
- *
- * For `{ "address.street": 1 }`, when the cursor is anywhere between the
- * opening and closing quotes, returns the unquoted key `"address.street"`
- * along with the 0-based start/end positions of the full quoted string
- * (including the quotes themselves, for hover range highlighting).
- *
- * Returns null if the cursor is not inside a quoted string.
- *
- * @param line - the full line content
- * @param col0 - 0-based column position of the cursor
- */
-export function extractQuotedKey(line: string, col0: number): { key: string; start: number; end: number } | null {
-    if (col0 < 0 || col0 >= line.length) return null;
-
-    // If cursor is on a quote, it could be the closing quote.
-    // Try treating the current position as the closing quote first.
-    const chAtCursor = line[col0];
-    if (chAtCursor === '"' || chAtCursor === "'") {
-        // Not escaped?
-        if (col0 === 0 || line[col0 - 1] !== '\\') {
-            // Try to find a matching opening quote before this one
-            const result = tryMatchAsClosingQuote(line, col0, chAtCursor);
-            if (result) return result;
-        }
-    }
-
-    // Scan backward to find the opening quote
-    let openQuoteIdx = -1;
-    let quoteChar: string | undefined;
-
-    for (let i = col0; i >= 0; i--) {
-        const ch = line[i];
-        if (ch === '"' || ch === "'") {
-            if (i > 0 && line[i - 1] === '\\') continue;
-            openQuoteIdx = i;
-            quoteChar = ch;
-            break;
-        }
-        if (ch === '{' || ch === '}' || ch === ':' || ch === ',') {
-            return null;
-        }
-    }
-
-    if (openQuoteIdx < 0 || !quoteChar) return null;
-
-    // Scan forward to find the closing quote
-    let closeQuoteIdx = -1;
-    for (let i = openQuoteIdx + 1; i < line.length; i++) {
-        if (line[i] === '\\') {
-            i++;
-            continue;
-        }
-        if (line[i] === quoteChar) {
-            closeQuoteIdx = i;
-            break;
-        }
-    }
-
-    if (closeQuoteIdx < 0) return null;
-    if (col0 < openQuoteIdx || col0 > closeQuoteIdx) return null;
-
-    const key = line.substring(openQuoteIdx + 1, closeQuoteIdx);
-    return { key, start: openQuoteIdx, end: closeQuoteIdx + 1 };
-}
-
-function tryMatchAsClosingQuote(
-    line: string,
-    closeIdx: number,
-    quoteChar: string,
-): { key: string; start: number; end: number } | null {
-    // Scan backward from before the closing quote to find the opening quote
-    for (let i = closeIdx - 1; i >= 0; i--) {
-        if (line[i] === '\\') continue;
-        if (line[i] === quoteChar) {
-            if (i > 0 && line[i - 1] === '\\') continue;
-            const key = line.substring(i + 1, closeIdx);
-            return { key, start: i, end: closeIdx + 1 };
-        }
-        // Stop at structural chars
-        if (line[i] === '{' || line[i] === '}' || line[i] === ':' || line[i] === ',') {
-            return null;
-        }
-    }
-    return null;
 }

--- a/src/webviews/documentdbQuery/registerLanguage.ts
+++ b/src/webviews/documentdbQuery/registerLanguage.ts
@@ -30,6 +30,7 @@ import { getCompletionContext } from './completionStore';
 import { detectCursorContext } from './cursorContext';
 import { createCompletionItems } from './documentdbQueryCompletionProvider';
 import { getHoverContent } from './documentdbQueryHoverProvider';
+import { isCursorInsideString } from './isCursorInsideString';
 import { LANGUAGE_ID, parseEditorUri } from './languageConfig';
 
 /** Coalesces concurrent registrations into a single promise. */
@@ -67,7 +68,7 @@ async function doRegisterLanguage(monaco: typeof monacoEditor): Promise<void> {
 
     // Step 4: Register the completion provider
     monaco.languages.registerCompletionItemProvider(LANGUAGE_ID, {
-        triggerCharacters: ['$', '"', "'", '{', '.'],
+        triggerCharacters: ['$', '"', "'", '{', '.', ':', ',', '['],
         provideCompletionItems: (
             model: monacoEditor.editor.ITextModel,
             position: monacoEditor.Position,
@@ -101,6 +102,14 @@ async function doRegisterLanguage(monaco: typeof monacoEditor): Promise<void> {
             // Detect cursor context for context-sensitive completions
             const text = model.getValue();
             const cursorOffset = model.getOffsetAt(position);
+
+            // Suppress completions when the cursor is inside a string literal.
+            // This prevents trigger characters like ':', ',', '[' from firing
+            // inside strings like { name: "has:colon" } or { msg: "has[bracket" }.
+            if (isCursorInsideString(text, cursorOffset)) {
+                return { suggestions: [] };
+            }
+
             const sessionId = parsed?.sessionId;
 
             // Build field lookup from completion store to enrich context with BSON types

--- a/src/webviews/documentdbQuery/registerLanguage.ts
+++ b/src/webviews/documentdbQuery/registerLanguage.ts
@@ -147,11 +147,6 @@ async function doRegisterLanguage(monaco: typeof monacoEditor): Promise<void> {
             model: monacoEditor.editor.ITextModel,
             position: monacoEditor.Position,
         ): monacoEditor.languages.Hover | null => {
-            const wordAtPosition = model.getWordAtPosition(position);
-            if (!wordAtPosition) {
-                return null;
-            }
-
             // Build field lookup from completion store for field hover info
             const uriString = model.uri.toString();
             const parsedUri = parseEditorUri(uriString);
@@ -161,6 +156,35 @@ async function doRegisterLanguage(monaco: typeof monacoEditor): Promise<void> {
                       return ctx?.fields.find((f) => f.fieldName === word);
                   }
                 : undefined;
+
+            // Try to extract a quoted string key (e.g., "address.street")
+            // Monaco's getWordAtPosition treats quotes and dots as word boundaries,
+            // so for { "address.street": 1 } hovering on "address" would only match
+            // "address", not the full field name "address.street".
+            const lineContent = model.getLineContent(position.lineNumber);
+            const col0 = position.column - 1; // 0-based
+
+            const quotedResult = extractQuotedKey(lineContent, col0);
+            if (quotedResult) {
+                const hover = getHoverContent(quotedResult.key, hoverFieldLookup);
+                if (hover) {
+                    return {
+                        ...hover,
+                        range: {
+                            startLineNumber: position.lineNumber,
+                            endLineNumber: position.lineNumber,
+                            startColumn: quotedResult.start + 1, // 1-based
+                            endColumn: quotedResult.end + 1, // 1-based
+                        },
+                    };
+                }
+            }
+
+            // Fall back to standard word-based hover
+            const wordAtPosition = model.getWordAtPosition(position);
+            if (!wordAtPosition) {
+                return null;
+            }
 
             const hover = getHoverContent(wordAtPosition.word, hoverFieldLookup);
             if (!hover) {
@@ -187,4 +211,92 @@ async function doRegisterLanguage(monaco: typeof monacoEditor): Promise<void> {
  */
 export function _resetRegistration(): void {
     registrationPromise = undefined;
+}
+
+/**
+ * Extracts a quoted key string if the cursor is inside one.
+ *
+ * For `{ "address.street": 1 }`, when the cursor is anywhere between the
+ * opening and closing quotes, returns the unquoted key `"address.street"`
+ * along with the 0-based start/end positions of the full quoted string
+ * (including the quotes themselves, for hover range highlighting).
+ *
+ * Returns null if the cursor is not inside a quoted string.
+ *
+ * @param line - the full line content
+ * @param col0 - 0-based column position of the cursor
+ */
+export function extractQuotedKey(line: string, col0: number): { key: string; start: number; end: number } | null {
+    if (col0 < 0 || col0 >= line.length) return null;
+
+    // If cursor is on a quote, it could be the closing quote.
+    // Try treating the current position as the closing quote first.
+    const chAtCursor = line[col0];
+    if (chAtCursor === '"' || chAtCursor === "'") {
+        // Not escaped?
+        if (col0 === 0 || line[col0 - 1] !== '\\') {
+            // Try to find a matching opening quote before this one
+            const result = tryMatchAsClosingQuote(line, col0, chAtCursor);
+            if (result) return result;
+        }
+    }
+
+    // Scan backward to find the opening quote
+    let openQuoteIdx = -1;
+    let quoteChar: string | undefined;
+
+    for (let i = col0; i >= 0; i--) {
+        const ch = line[i];
+        if (ch === '"' || ch === "'") {
+            if (i > 0 && line[i - 1] === '\\') continue;
+            openQuoteIdx = i;
+            quoteChar = ch;
+            break;
+        }
+        if (ch === '{' || ch === '}' || ch === ':' || ch === ',') {
+            return null;
+        }
+    }
+
+    if (openQuoteIdx < 0 || !quoteChar) return null;
+
+    // Scan forward to find the closing quote
+    let closeQuoteIdx = -1;
+    for (let i = openQuoteIdx + 1; i < line.length; i++) {
+        if (line[i] === '\\') {
+            i++;
+            continue;
+        }
+        if (line[i] === quoteChar) {
+            closeQuoteIdx = i;
+            break;
+        }
+    }
+
+    if (closeQuoteIdx < 0) return null;
+    if (col0 < openQuoteIdx || col0 > closeQuoteIdx) return null;
+
+    const key = line.substring(openQuoteIdx + 1, closeQuoteIdx);
+    return { key, start: openQuoteIdx, end: closeQuoteIdx + 1 };
+}
+
+function tryMatchAsClosingQuote(
+    line: string,
+    closeIdx: number,
+    quoteChar: string,
+): { key: string; start: number; end: number } | null {
+    // Scan backward from before the closing quote to find the opening quote
+    for (let i = closeIdx - 1; i >= 0; i--) {
+        if (line[i] === '\\') continue;
+        if (line[i] === quoteChar) {
+            if (i > 0 && line[i - 1] === '\\') continue;
+            const key = line.substring(i + 1, closeIdx);
+            return { key, start: i, end: closeIdx + 1 };
+        }
+        // Stop at structural chars
+        if (line[i] === '{' || line[i] === '}' || line[i] === ':' || line[i] === ',') {
+            return null;
+        }
+    }
+    return null;
 }

--- a/src/webviews/documentdbQuery/registerLanguage.ts
+++ b/src/webviews/documentdbQuery/registerLanguage.ts
@@ -152,7 +152,17 @@ async function doRegisterLanguage(monaco: typeof monacoEditor): Promise<void> {
                 return null;
             }
 
-            const hover = getHoverContent(wordAtPosition.word);
+            // Build field lookup from completion store for field hover info
+            const uriString = model.uri.toString();
+            const parsedUri = parseEditorUri(uriString);
+            const hoverFieldLookup = parsedUri?.sessionId
+                ? (word: string) => {
+                      const ctx = getCompletionContext(parsedUri.sessionId);
+                      return ctx?.fields.find((f) => f.fieldName === word);
+                  }
+                : undefined;
+
+            const hover = getHoverContent(wordAtPosition.word, hoverFieldLookup);
             if (!hover) {
                 return null;
             }

--- a/src/webviews/documentdbQuery/registerLanguage.ts
+++ b/src/webviews/documentdbQuery/registerLanguage.ts
@@ -112,6 +112,11 @@ async function doRegisterLanguage(monaco: typeof monacoEditor): Promise<void> {
 
             const cursorContext = detectCursorContext(text, cursorOffset, fieldLookup);
 
+            // Detect whether the editor content has braces. When the user clears
+            // the editor (deleting initial `{  }`), completions need to include
+            // wrapping braces so inserted snippets produce valid query syntax.
+            const needsWrapping = !text.includes('{');
+
             // Build completion items based on context
             const items = createCompletionItems({
                 editorType: parsed?.editorType,
@@ -120,6 +125,7 @@ async function doRegisterLanguage(monaco: typeof monacoEditor): Promise<void> {
                 isDollarPrefix: charBefore === '$',
                 monaco,
                 cursorContext,
+                needsWrapping,
             });
 
             return { suggestions: items };

--- a/src/webviews/documentdbQuery/tdd/README.md
+++ b/src/webviews/documentdbQuery/tdd/README.md
@@ -1,0 +1,33 @@
+# TDD Behavior Tests
+
+This folder contains **behavior-driven TDD tests** for the `documentdb-query`
+autocompletion system. These tests define the expected behavior contract — they
+were written BEFORE the implementation and drive the design.
+
+## Important: TDD Contract
+
+> **⚠️ LLM/Agent Instruction:**
+> These tests represent intentional behavior specifications. If a test in this
+> folder fails after a code change, **do NOT automatically fix the test**.
+> Instead, alert the user that a TDD behavior contract has been violated.
+> The failure likely means the implementation change broke an expected behavior.
+> The user must decide whether to update the test (changing the contract) or
+> fix the implementation.
+
+## Test Files
+
+| File | What it tests |
+|------|---------------|
+| `completionBehavior.test.ts` | Which completion categories appear at each cursor position, sorting order, and snippet wrapping |
+
+## Specification
+
+See [readme.completionBehavior.md](readme.completionBehavior.md) for the full
+behavior specification with ASCII art examples.
+
+## Why a separate folder?
+
+These tests verify cross-cutting **behavior** (the completion matrix), not a
+single class or module. They sit at the `documentdbQuery/tdd/` level because
+they test the combined output of `cursorContext`, `createCompletionItems`,
+`mapCompletionItems`, and `completionKnowledge` working together.

--- a/src/webviews/documentdbQuery/tdd/completionBehavior.test.ts
+++ b/src/webviews/documentdbQuery/tdd/completionBehavior.test.ts
@@ -1,0 +1,526 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * TDD Behavior Tests — Completion Categories by Cursor Position
+ *
+ * These tests define the expected behavior CONTRACT for the autocompletion
+ * system. They were written BEFORE the implementation (TDD red→green cycle)
+ * and verify WHAT completions appear at each cursor position, not HOW they
+ * are produced internally.
+ *
+ * ⚠️ LLM/Agent Instruction:
+ * If these tests fail after a code change, do NOT automatically fix the tests.
+ * Alert the user that a TDD behavior contract has been violated. The failure
+ * means the implementation broke expected behavior. The user must decide
+ * whether to update the spec or fix the implementation.
+ *
+ * Tests are category-based (not specific-operator-based) to be resilient to
+ * changes in documentdb-constants. Categories come from the `description`
+ * field in CompletionItemLabel (e.g., "comparison", "logical", "bson").
+ *
+ * See: readme.completionBehavior.md for the full specification.
+ */
+
+// eslint-disable-next-line import/no-internal-modules
+import type * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
+import { clearAllCompletionContexts, setCompletionContext } from '../completionStore';
+import { type CursorContext } from '../cursorContext';
+import { createCompletionItems } from '../documentdbQueryCompletionProvider';
+import { EditorType } from '../languageConfig';
+
+// ---------- Test infrastructure ----------
+
+const mockCompletionItemKind: typeof monacoEditor.languages.CompletionItemKind = {
+    Method: 0,
+    Function: 1,
+    Constructor: 2,
+    Field: 3,
+    Variable: 4,
+    Class: 5,
+    Struct: 6,
+    Interface: 7,
+    Module: 8,
+    Property: 9,
+    Event: 10,
+    Operator: 11,
+    Unit: 12,
+    Value: 13,
+    Constant: 14,
+    Enum: 15,
+    EnumMember: 16,
+    Keyword: 17,
+    Text: 18,
+    Color: 19,
+    File: 20,
+    Reference: 21,
+    Customcolor: 22,
+    Folder: 23,
+    TypeParameter: 24,
+    User: 25,
+    Issue: 26,
+    Snippet: 27,
+};
+
+const mockInsertTextRule = {
+    InsertAsSnippet: 4,
+    KeepWhitespace: 1,
+    None: 0,
+} as typeof monacoEditor.languages.CompletionItemInsertTextRule;
+
+function createMockMonaco(): typeof monacoEditor {
+    return {
+        languages: {
+            CompletionItemKind: mockCompletionItemKind,
+            CompletionItemInsertTextRule: mockInsertTextRule,
+        },
+    } as unknown as typeof monacoEditor;
+}
+
+const testRange: monacoEditor.IRange = {
+    startLineNumber: 1,
+    endLineNumber: 1,
+    startColumn: 1,
+    endColumn: 1,
+};
+
+// ---------- Helpers ----------
+
+/** Extracts the description (category) from a CompletionItem label. */
+function getDescription(label: string | monacoEditor.languages.CompletionItemLabel): string | undefined {
+    return typeof label === 'string' ? undefined : label.description;
+}
+
+/** Returns the set of distinct categories present in a completion list. */
+function getCategories(items: monacoEditor.languages.CompletionItem[]): Set<string> {
+    const categories = new Set<string>();
+    for (const item of items) {
+        const desc = getDescription(item.label);
+        if (desc) categories.add(desc);
+    }
+    return categories;
+}
+
+/** Returns the label text from a CompletionItem. */
+function getLabelText(label: string | monacoEditor.languages.CompletionItemLabel): string {
+    return typeof label === 'string' ? label : label.label;
+}
+
+/**
+ * Returns all distinct sortText prefixes (the part before the underscore)
+ * found in a completion list.
+ */
+function getSortPrefixes(items: monacoEditor.languages.CompletionItem[]): Set<string> {
+    const prefixes = new Set<string>();
+    for (const item of items) {
+        if (item.sortText) {
+            const underscoreIdx = item.sortText.indexOf('_');
+            if (underscoreIdx > 0) {
+                prefixes.add(item.sortText.substring(0, underscoreIdx + 1));
+            }
+        }
+    }
+    return prefixes;
+}
+
+// ---------- Field data for tests ----------
+
+const testFields = [
+    {
+        fieldName: 'name',
+        displayType: 'String',
+        bsonType: 'string',
+        isSparse: false,
+        insertText: 'name',
+        referenceText: '$name',
+    },
+    {
+        fieldName: 'age',
+        displayType: 'Number',
+        bsonType: 'int32',
+        isSparse: false,
+        insertText: 'age',
+        referenceText: '$age',
+    },
+];
+
+// ---------- Key-position operator categories ----------
+// These are the categories that should appear at KEY / EMPTY positions.
+// We test by category name, not specific operators, for resilience.
+// (Used in assertions, not as a lookup — individual tests check specific categories.)
+
+// Field-level categories that should NOT appear at key/empty positions.
+// These categories have NO operators in KEY_POSITION_OPERATORS.
+// Note: 'logical' and 'evaluation' are shared — they have both key-position
+// operators ($and/$or for logical, $expr/$text for evaluation) and field-level
+// operators ($not for logical, $regex/$mod for evaluation).
+const FIELD_LEVEL_ONLY_CATEGORIES = ['comparison', 'array', 'element', 'bitwise', 'geospatial'];
+
+// =====================================================================
+// Tests
+// =====================================================================
+
+describe('Completion Behavior (TDD)', () => {
+    const mockMonaco = createMockMonaco();
+
+    afterEach(() => {
+        clearAllCompletionContexts();
+    });
+
+    // -----------------------------------------------------------------
+    // EMPTY position — no braces in editor
+    // -----------------------------------------------------------------
+    describe('EMPTY position (no braces, needsWrapping=true)', () => {
+        /**
+         * ┌──────────────────────────┐
+         * │ |                        │  ← cursor, no braces
+         * └──────────────────────────┘
+         *
+         * Expected: fields + key operators, all wrapped with { }
+         * NOT expected: comparison, array, evaluation, element, bson, JS global
+         */
+
+        function getEmptyCompletions(sessionId?: string): monacoEditor.languages.CompletionItem[] {
+            return createCompletionItems({
+                editorType: EditorType.Filter,
+                sessionId,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: { position: 'unknown' },
+                needsWrapping: true,
+            });
+        }
+
+        test('includes field names when store has data', () => {
+            setCompletionContext('s1', { fields: testFields });
+            const items = getEmptyCompletions('s1');
+            const labels = items.map((i) => getLabelText(i.label));
+            expect(labels).toContain('name');
+            expect(labels).toContain('age');
+        });
+
+        test('field insertText is wrapped with { }', () => {
+            setCompletionContext('s1', { fields: testFields });
+            const items = getEmptyCompletions('s1');
+            const nameItem = items.find((i) => getLabelText(i.label) === 'name');
+            expect(nameItem?.insertText).toMatch(/^\{.*\}$/);
+        });
+
+        test('includes key-position operator categories (logical)', () => {
+            const items = getEmptyCompletions();
+            const categories = getCategories(items);
+            expect(categories.has('logical')).toBe(true);
+        });
+
+        test('does NOT include field-level categories', () => {
+            const items = getEmptyCompletions();
+            const categories = getCategories(items);
+            for (const cat of FIELD_LEVEL_ONLY_CATEGORIES) {
+                expect(categories.has(cat)).toBe(false);
+            }
+        });
+
+        test('does NOT include "bson"', () => {
+            const items = getEmptyCompletions();
+            const categories = getCategories(items);
+            expect(categories.has('bson')).toBe(false);
+        });
+
+        test('does NOT include "JS global"', () => {
+            const items = getEmptyCompletions();
+            const categories = getCategories(items);
+            expect(categories.has('JS global')).toBe(false);
+        });
+
+        test('fields sort before operators (0_ < 1_)', () => {
+            setCompletionContext('s1', { fields: testFields });
+            const items = getEmptyCompletions('s1');
+            const fieldItem = items.find((i) => getLabelText(i.label) === 'name');
+            const operatorItems = items.filter((i) => getDescription(i.label) === 'logical');
+            expect(fieldItem?.sortText).toMatch(/^0_/);
+            expect(operatorItems.length).toBeGreaterThan(0);
+            expect(operatorItems[0]?.sortText).toMatch(/^1_/);
+        });
+    });
+
+    // -----------------------------------------------------------------
+    // KEY position — inside { }
+    // -----------------------------------------------------------------
+    describe('KEY position ({ | })', () => {
+        /**
+         * ┌──────────────────────────┐
+         * │ { |  }                   │  ← cursor inside braces
+         * └──────────────────────────┘
+         *
+         * Expected: fields + key operators
+         * NOT expected: comparison, array, evaluation, element, bson, JS global
+         */
+
+        const keyContext: CursorContext = { position: 'key', depth: 1 };
+
+        function getKeyCompletions(sessionId?: string): monacoEditor.languages.CompletionItem[] {
+            return createCompletionItems({
+                editorType: EditorType.Filter,
+                sessionId,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: keyContext,
+            });
+        }
+
+        test('includes key-position operator categories', () => {
+            const categories = getCategories(getKeyCompletions());
+            expect(categories.has('logical')).toBe(true);
+        });
+
+        test('does NOT include field-level categories', () => {
+            const categories = getCategories(getKeyCompletions());
+            for (const cat of FIELD_LEVEL_ONLY_CATEGORIES) {
+                expect(categories.has(cat)).toBe(false);
+            }
+        });
+
+        test('does NOT include "bson" or "JS global"', () => {
+            const categories = getCategories(getKeyCompletions());
+            expect(categories.has('bson')).toBe(false);
+            expect(categories.has('JS global')).toBe(false);
+        });
+
+        test('field sortText starts with 0_, operator sortText starts with 1_', () => {
+            setCompletionContext('s1', { fields: testFields });
+            const items = getKeyCompletions('s1');
+
+            // Every field item should have sortText starting with 0_
+            const fieldItems = items.filter((i) => getLabelText(i.label) === 'name' || getLabelText(i.label) === 'age');
+            for (const item of fieldItems) {
+                expect(item.sortText).toMatch(/^0_/);
+            }
+
+            // Every operator item should have sortText starting with 1_
+            const operatorItems = items.filter((i) => {
+                const desc = getDescription(i.label);
+                return desc === 'logical' || desc === 'evaluation' || desc === 'misc';
+            });
+            for (const item of operatorItems) {
+                expect(item.sortText).toMatch(/^1_/);
+            }
+        });
+    });
+
+    // -----------------------------------------------------------------
+    // VALUE position — { field: | }
+    // -----------------------------------------------------------------
+    describe('VALUE position ({ field: | })', () => {
+        /**
+         * ┌──────────────────────────┐
+         * │ { age: |  }              │  ← cursor at value position
+         * └──────────────────────────┘
+         *
+         * Expected: type suggestions + field-level operators + bson + JS globals
+         * NOT expected: key-position operators ($and, $or at root)
+         */
+
+        const valueContext: CursorContext = { position: 'value', fieldName: 'age' };
+
+        function getValueCompletions(): monacoEditor.languages.CompletionItem[] {
+            return createCompletionItems({
+                editorType: EditorType.Filter,
+                sessionId: undefined,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: valueContext,
+            });
+        }
+
+        test('includes field-level categories', () => {
+            const categories = getCategories(getValueCompletions());
+            for (const cat of FIELD_LEVEL_ONLY_CATEGORIES) {
+                expect(categories.has(cat)).toBe(true);
+            }
+        });
+
+        test('includes "bson" and "JS global"', () => {
+            const categories = getCategories(getValueCompletions());
+            expect(categories.has('bson')).toBe(true);
+            expect(categories.has('JS global')).toBe(true);
+        });
+
+        test('does NOT include key-position operators by label', () => {
+            const labels = getValueCompletions().map((i) => getLabelText(i.label));
+            // Check just a couple representative key operators
+            expect(labels).not.toContain('$and');
+            expect(labels).not.toContain('$or');
+        });
+
+        test('sort order: operators (0_) before bson (3_) before JS globals (4_)', () => {
+            const prefixes = getSortPrefixes(getValueCompletions());
+            expect(prefixes.has('0_')).toBe(true);
+            expect(prefixes.has('3_')).toBe(true);
+            expect(prefixes.has('4_')).toBe(true);
+        });
+
+        test('project editor shows only 1/0 at value position', () => {
+            const items = createCompletionItems({
+                editorType: EditorType.Project,
+                sessionId: undefined,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: valueContext,
+            });
+            expect(items).toHaveLength(2);
+            const labels = items.map((i) => getLabelText(i.label));
+            expect(labels).toContain('1');
+            expect(labels).toContain('0');
+        });
+
+        test('sort editor shows only 1/-1 at value position', () => {
+            const items = createCompletionItems({
+                editorType: EditorType.Sort,
+                sessionId: undefined,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: valueContext,
+            });
+            expect(items).toHaveLength(2);
+            const labels = items.map((i) => getLabelText(i.label));
+            expect(labels).toContain('1');
+            expect(labels).toContain('-1');
+        });
+    });
+
+    // -----------------------------------------------------------------
+    // OPERATOR position — { field: { | } }
+    // -----------------------------------------------------------------
+    describe('OPERATOR position ({ field: { | } })', () => {
+        /**
+         * ┌──────────────────────────┐
+         * │ { age: { |  } }          │  ← cursor inside operator object
+         * └──────────────────────────┘
+         *
+         * Expected: field-level operators (braces stripped)
+         * NOT expected: bson, JS global, key-position operators
+         */
+
+        const operatorContext: CursorContext = { position: 'operator', fieldName: 'age' };
+
+        function getOperatorCompletions(): monacoEditor.languages.CompletionItem[] {
+            return createCompletionItems({
+                editorType: EditorType.Filter,
+                sessionId: undefined,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: operatorContext,
+            });
+        }
+
+        test('includes field-level categories', () => {
+            const categories = getCategories(getOperatorCompletions());
+            for (const cat of FIELD_LEVEL_ONLY_CATEGORIES) {
+                expect(categories.has(cat)).toBe(true);
+            }
+        });
+
+        test('does NOT include "bson" or "JS global"', () => {
+            const categories = getCategories(getOperatorCompletions());
+            expect(categories.has('bson')).toBe(false);
+            expect(categories.has('JS global')).toBe(false);
+        });
+
+        test('does NOT include key-position operators', () => {
+            const labels = getOperatorCompletions().map((i) => getLabelText(i.label));
+            expect(labels).not.toContain('$and');
+            expect(labels).not.toContain('$or');
+        });
+    });
+
+    // -----------------------------------------------------------------
+    // ARRAY-ELEMENT position — { $and: [|] }
+    // -----------------------------------------------------------------
+    describe('ARRAY-ELEMENT position ({ $and: [|] })', () => {
+        /**
+         * Same behavior as KEY position
+         */
+
+        const arrayContext: CursorContext = { position: 'array-element', parentOperator: '$and' };
+
+        function getArrayElementCompletions(sessionId?: string): monacoEditor.languages.CompletionItem[] {
+            return createCompletionItems({
+                editorType: EditorType.Filter,
+                sessionId,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: arrayContext,
+            });
+        }
+
+        test('behaves like KEY: includes logical, excludes field-level categories', () => {
+            const categories = getCategories(getArrayElementCompletions());
+            expect(categories.has('logical')).toBe(true);
+            for (const cat of FIELD_LEVEL_ONLY_CATEGORIES) {
+                expect(categories.has(cat)).toBe(false);
+            }
+        });
+
+        test('includes fields when store has data', () => {
+            setCompletionContext('s1', { fields: testFields });
+            const labels = getArrayElementCompletions('s1').map((i) => getLabelText(i.label));
+            expect(labels).toContain('name');
+        });
+    });
+
+    // -----------------------------------------------------------------
+    // UNKNOWN position — genuinely ambiguous (show everything)
+    // -----------------------------------------------------------------
+    describe('UNKNOWN position (ambiguous, needsWrapping=false)', () => {
+        /**
+         * Genuinely unknown cursor position. Show everything as discovery.
+         * This is the fallback when the parser can't determine position AND
+         * the editor is not empty (has some content with braces but ambiguous).
+         */
+
+        function getUnknownCompletions(sessionId?: string): monacoEditor.languages.CompletionItem[] {
+            return createCompletionItems({
+                editorType: EditorType.Filter,
+                sessionId,
+                range: testRange,
+                isDollarPrefix: false,
+                monaco: mockMonaco,
+                cursorContext: { position: 'unknown' },
+                needsWrapping: false,
+            });
+        }
+
+        test('includes key-position categories', () => {
+            const categories = getCategories(getUnknownCompletions());
+            expect(categories.has('logical')).toBe(true);
+        });
+
+        test('includes field-level categories (full discovery)', () => {
+            const categories = getCategories(getUnknownCompletions());
+            for (const cat of FIELD_LEVEL_ONLY_CATEGORIES) {
+                expect(categories.has(cat)).toBe(true);
+            }
+        });
+
+        test('includes "bson" and "JS global"', () => {
+            const categories = getCategories(getUnknownCompletions());
+            expect(categories.has('bson')).toBe(true);
+            expect(categories.has('JS global')).toBe(true);
+        });
+
+        test('includes fields when store has data', () => {
+            setCompletionContext('s1', { fields: testFields });
+            const labels = getUnknownCompletions('s1').map((i) => getLabelText(i.label));
+            expect(labels).toContain('name');
+        });
+    });
+});

--- a/src/webviews/documentdbQuery/tdd/completionBehavior.test.ts
+++ b/src/webviews/documentdbQuery/tdd/completionBehavior.test.ts
@@ -162,8 +162,16 @@ const FIELD_LEVEL_ONLY_CATEGORIES = ['comparison', 'array', 'element', 'bitwise'
 // Tests
 // =====================================================================
 
-describe('Completion Behavior (TDD)', () => {
+describe('TDD: Completion Behavior', () => {
     const mockMonaco = createMockMonaco();
+
+    beforeAll(() => {
+        console.warn(
+            '\n⚠️  TDD CONTRACT TESTS — If any test below fails, do NOT auto-fix the test.\n' +
+                '    Alert the user that a TDD behavior contract has been violated.\n' +
+                '    The user must decide whether to update the spec or fix the implementation.\n',
+        );
+    });
 
     afterEach(() => {
         clearAllCompletionContexts();

--- a/src/webviews/documentdbQuery/tdd/readme.completionBehavior.md
+++ b/src/webviews/documentdbQuery/tdd/readme.completionBehavior.md
@@ -1,0 +1,135 @@
+# Completion Behavior Specification
+
+> **⚠️ LLM/Agent Instruction:**
+> This specification defines the expected completion behavior contract.
+> If tests based on this spec fail after a code change, **do NOT automatically
+> fix the tests**. Alert the user that a TDD behavior contract has been violated.
+> The user must decide whether the behavior change is intentional.
+
+## Cursor Positions & Expected Completions
+
+The completion system shows different items depending on the cursor's semantic
+position within a query expression. This spec defines what categories appear,
+their sort order, and how snippets are wrapped at each position.
+
+### Categories
+
+Completions are grouped by category (shown as the `description` field in the
+completion item label). The categories come from the operator's `meta` tag:
+
+| Category | Source | Example operators |
+|----------|--------|-------------------|
+| `logical` | `query:logical` | `$and`, `$or`, `$nor` |
+| `comparison` | `query:comparison` | `$eq`, `$gt`, `$in` |
+| `array` | `query:array` | `$all`, `$elemMatch`, `$size` |
+| `evaluation` | `query:evaluation` | `$regex`, `$mod` |
+| `element` | `query:element` | `$exists`, `$type` |
+| `bson` | `bson` | `ObjectId`, `UUID`, `ISODate` |
+| `JS global` | (hardcoded) | `Date`, `Math`, `RegExp` |
+| (field type) | field data | `String`, `Number`, etc. |
+
+### Position: EMPTY (no braces in editor)
+
+```
+┌──────────────────────────┐
+│ |                        │   ← cursor, editor has no braces
+└──────────────────────────┘
+```
+
+**Shows:** Fields + key-position operators only (same items as KEY)
+**Wrapping:** All insertions wrapped with `{ ... }`
+**Sort:** `0_` fields, `1_` key operators
+
+```
+Expected completions:
+  name      String     ← field, inserts: { name: $1 }
+  age       Number     ← field, inserts: { age: $1 }
+  $and      logical    ← key operator, inserts: { $and: [...] }
+  $or       logical    ← key operator
+  $nor      logical    ← key operator
+
+NOT shown:
+  $gt       comparison ← field-level, invalid at root
+  $all      array      ← field-level, invalid at root
+  ObjectId  bson       ← not valid at root key position
+  Date      JS global  ← not valid at root key position
+```
+
+### Position: KEY (`{ | }`)
+
+```
+┌──────────────────────────┐
+│ { |  }                   │   ← cursor inside braces
+└──────────────────────────┘
+```
+
+**Shows:** Fields + key-position operators
+**Wrapping:** None (already inside braces)
+**Sort:** `0_` fields, `1_` key operators
+**Snippets:** Outer `{ }` stripped from operator snippets
+
+```
+NOT shown: comparison, array, evaluation, element, bson, JS global
+```
+
+### Position: VALUE (`{ field: | }`)
+
+```
+┌──────────────────────────┐
+│ { age: |  }              │   ← cursor at value position
+└──────────────────────────┘
+```
+
+**Shows:** Type suggestions + field-level operators + BSON constructors + JS globals
+**Sort:** `00_` type suggestions, `0_`–`2_` operators, `3_` BSON, `4_` JS globals
+**Special:** Project editor → `1`/`0` only. Sort editor → `1`/`-1` only.
+
+```
+Shown categories: comparison, array, evaluation, element, logical ($not), bson, JS global
+NOT shown: key-position operators ($and, $or, $nor at root)
+```
+
+### Position: OPERATOR (`{ field: { | } }`)
+
+```
+┌──────────────────────────┐
+│ { age: { |  } }          │   ← cursor inside operator object
+└──────────────────────────┘
+```
+
+**Shows:** Field-level operators only (braces stripped)
+**Sort:** `0_` type-relevant, `1a_` comparison, `1b_` other universal, `2_` non-matching
+**Snippets:** Outer `{ }` stripped
+
+```
+Shown categories: comparison, array, evaluation, element, logical ($not)
+NOT shown: bson, JS global, key-position operators
+```
+
+### Position: ARRAY-ELEMENT (`{ $and: [|] }`)
+
+**Shows:** Same as KEY position
+**Sort:** Same as KEY position
+
+### Position: UNKNOWN (genuinely ambiguous)
+
+**Shows:** ALL completions (fields + all operators + BSON + JS globals)
+**Purpose:** Discovery fallback for positions the parser can't classify
+
+```
+Shown: everything — logical, comparison, array, evaluation, element, bson, JS global
+```
+
+## Sort Order Contract
+
+Each position has a defined sort prefix hierarchy. Items with lower prefixes
+appear higher in the completion list.
+
+| Position | Sort hierarchy |
+|----------|---------------|
+| EMPTY | `0_` fields → `1_` key operators |
+| KEY | `0_` fields → `1_` key operators |
+| VALUE | `00_` type suggestions → `0_`–`2_` operators → `3_` BSON → `4_` JS globals |
+| OPERATOR | `0_` type-relevant → `1a_` comparison → `1b_` universal → `2_` non-matching |
+| ARRAY-ELEMENT | same as KEY |
+| UNKNOWN | no enforced sort (Monaco default) |

--- a/src/webviews/utils/escapeMarkdown.test.ts
+++ b/src/webviews/utils/escapeMarkdown.test.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { escapeMarkdown } from './escapeMarkdown';
+
+describe('escapeMarkdown', () => {
+    test('returns plain text unchanged', () => {
+        expect(escapeMarkdown('age')).toBe('age');
+    });
+
+    test('escapes markdown bold characters', () => {
+        expect(escapeMarkdown('**bold**')).toBe('\\*\\*bold\\*\\*');
+    });
+
+    test('escapes markdown link syntax', () => {
+        expect(escapeMarkdown('[click](https://evil.com)')).toBe('\\[click\\]\\(https://evil\\.com\\)');
+    });
+
+    test('escapes angle brackets (HTML tags)', () => {
+        expect(escapeMarkdown('<script>alert(1)</script>')).toBe('\\<script\\>alert\\(1\\)\\</script\\>');
+    });
+
+    test('escapes backticks', () => {
+        expect(escapeMarkdown('`code`')).toBe('\\`code\\`');
+    });
+
+    test('escapes ampersands', () => {
+        expect(escapeMarkdown('a&b')).toBe('a\\&b');
+    });
+
+    test('handles dotted field names', () => {
+        expect(escapeMarkdown('address.street')).toBe('address\\.street');
+    });
+
+    test('passes through numbers and underscores', () => {
+        // underscore IS a markdown metacharacter, so it gets escaped
+        expect(escapeMarkdown('field_1')).toBe('field\\_1');
+    });
+});

--- a/src/webviews/utils/escapeMarkdown.ts
+++ b/src/webviews/utils/escapeMarkdown.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Escapes markdown metacharacters so user data renders as literal text.
+ *
+ * Covers characters that Markdown/HTML would otherwise interpret:
+ * `\`, `*`, `_`, `{`, `}`, `[`, `]`, `(`, `)`, `#`, `+`, `-`, `.`, `!`,
+ * `|`, `<`, `>`, `` ` ``, `~`, `&`
+ */
+export function escapeMarkdown(text: string): string {
+    return text.replace(/[\\*_{}[\]()#+\-.!|<>`~&]/g, '\\$&');
+}


### PR DESCRIPTION
## Step 4.6: Collection View & Autocompletion UX Improvements

Post-review UX fixes and enhancements for the autocompletion system built in Steps 4–4.5.

### Changes

#### Completion Provider Fixes
- **Documentation links clickable** — Set `isTrusted: true` on completion documentation MarkdownStrings so `[DocumentDB Docs](https://...)` links render as clickable hyperlinks
- **Field completion data preserved across queries** — Removed `SchemaAnalyzer.reset()` on query change so field knowledge accumulates monotonically; queries returning 0 results no longer wipe the field list
- **`$not` moved to field-level** — Removed `$not` from `KEY_POSITION_OPERATORS`; it now correctly appears at operator/value position (`{ price: { $not: { $gt: 1.99 } } }`) instead of key position where it is invalid
- **Project editor value completions** — At value position in the project editor, show `1` (include) and `0` (exclude) instead of filter-specific completions
- **Sort editor value completions** — At value position in the sort editor, show `1` (ascending) and `-1` (descending)
- **Top-level wrapping** — When the editor has no braces (user cleared content), field completions wrap with `{ fieldName: $1 }` and operator snippets keep their full brace-wrapping
- **Auto-trigger characters** — Added `:`, `,`, `[` to trigger characters with string-literal detection (`isCursorInsideString`) to suppress completions inside strings
- **Smart-trigger after `: ` and `, `** — After selecting a field completion, typing space triggers the suggestion popup via `editor.action.triggerSuggest` (50ms delay)
- **Empty editor = key-position** — Split EMPTY from UNKNOWN context: empty editor (no braces) now shows key-position completions (fields + root operators) with `{ }` wrapping, instead of showing all operators. UNKNOWN remains as full discovery fallback.
- **Standalone flag for operators** — Added `standalone?: boolean` to `OperatorEntry`. Non-standalone operators (geospatial sub-operators, `$`, `$natural`) are excluded from completion lists but remain in the registry for hover documentation.

#### Hover Provider Enhancements
- **Field type hover** — Extended `HoverProvider` to show field type info (bold field name, sparse indicator, "Inferred Types" section with all observed types for polymorphic fields)
- **Quoted string key hover** — Added `extractQuotedKey` helper so hover works on `"address.street"` key names (Monaco's `getWordAtPosition` treats `.` and `"` as word boundaries)
- **Hover links actionable** — Added delegated click handler routing Monaco hover `<a>` clicks through `trpcClient.common.openUrl.mutate()` → `vscode.env.openExternal` (webview CSP blocks direct navigation)
- **Polymorphic types** — Threaded `bsonTypes`/`displayTypes` through `FieldCompletionData` from `FieldEntry` for multi-type field display
- **Hover formatting cleanup** — Removed unnecessary line breaks in hover documentation links, enhanced inferred types section formatting

#### Accessibility Fixes
- **ESC respects suggest widget / snippet mode** — ESC now only exits the editor when the suggest widget and snippet mode are both inactive. First ESC dismisses the autocomplete popup, another ESC exits snippet mode, and only then does ESC move focus out.
- **Tab respects snippet tab stops** — Tab no longer moves focus out of the editor during snippet tab-stop navigation. Uses `addAction` with `precondition: '!inSnippetMode'` so Monaco's built-in snippet Tab handler takes over during snippet sessions.
- **Ghost selection fix** — Snippet tab-stop highlights no longer persist and expand after accepting a value completion. Added `cancelSnippetSession()` via `snippetController2.cancel()`: cancels on editor blur and when delimiter characters (`,`, `}`, `]`) are typed.

#### Testing
- **TDD behavior contract tests** — 26 category-based TDD tests verifying completion behavior at each cursor position (EMPTY, KEY, VALUE, OPERATOR, ARRAY-ELEMENT, UNKNOWN). All passing.
- **`isCursorInsideString` tests** — 14 edge-case tests for string-literal detection
- **`extractQuotedKey` tests** — Edge-case coverage for quoted key extraction

### Files Changed
- `src/webviews/documentdbQuery/completions/` — completion knowledge, item creation, mapping
- `src/webviews/documentdbQuery/registerLanguage.ts` — trigger chars, hover provider, quoted key extraction
- `src/webviews/documentdbQuery/documentdbQueryHoverProvider.ts` — field hover, isTrusted, format
- `src/webviews/documentdbQuery/isCursorInsideString.ts` — new module for string detection
- `src/webviews/documentdb/collectionView/components/queryEditor/QueryEditor.tsx` — smart-trigger, link handler
- `src/webviews/components/MonacoEditor.tsx` — ESC context precondition for suggest/snippet mode
- `src/webviews/components/MonacoAutoHeight.tsx` — Tab respects snippet mode via addAction
- `src/documentdb/ClusterSession.ts` — removed schema reset on query change
- `src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts` — bsonTypes/displayTypes threading
- `packages/documentdb-constants/` — standalone flag, int32 BSON type fix, operator overrides
- `src/webviews/documentdbQuery/tdd/` — TDD behavior contract tests
- Test files for all of the above

