### PR TITLE
feat: Shared Schema Cache (SchemaStore) — Step 6.1

### DIFF
--- a/src/commands/deleteCollection/deleteCollection.ts
+++ b/src/commands/deleteCollection/deleteCollection.ts
@@ -6,6 +6,7 @@
 import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
 import { ClustersClient } from '../../documentdb/ClustersClient';
+import { SchemaStore } from '../../documentdb/SchemaStore';
 import { ext } from '../../extensionVariables';
 import { checkCanProceedAndInformUser } from '../../services/taskService/resourceUsageHelper';
 import { type CollectionItem } from '../../tree/documentdb/CollectionItem';
@@ -59,6 +60,11 @@ export async function deleteCollection(context: IActionContext, node: Collection
         });
 
         if (success) {
+            SchemaStore.getInstance().clearSchema(
+                node.cluster.clusterId,
+                node.databaseInfo.name,
+                node.collectionInfo.name,
+            );
             showConfirmationAsInSettings(successMessage);
         }
     } finally {

--- a/src/commands/deleteDatabase/deleteDatabase.ts
+++ b/src/commands/deleteDatabase/deleteDatabase.ts
@@ -6,6 +6,7 @@
 import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
 import { ClustersClient } from '../../documentdb/ClustersClient';
+import { SchemaStore } from '../../documentdb/SchemaStore';
 import { ext } from '../../extensionVariables';
 import { checkCanProceedAndInformUser } from '../../services/taskService/resourceUsageHelper';
 import { type DatabaseItem } from '../../tree/documentdb/DatabaseItem';
@@ -58,6 +59,7 @@ export async function deleteDatabase(context: IActionContext, node: DatabaseItem
         });
 
         if (success) {
+            SchemaStore.getInstance().clearDatabase(node.cluster.clusterId, node.databaseInfo.name);
             showConfirmationAsInSettings(l10n.t('The "{databaseId}" database has been deleted.', { databaseId }));
         }
     } finally {

--- a/src/commands/removeConnection/removeConnection.ts
+++ b/src/commands/removeConnection/removeConnection.ts
@@ -6,6 +6,7 @@
 import { UserCancelledError, type IActionContext } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
 import { CredentialCache } from '../../documentdb/CredentialCache';
+import { SchemaStore } from '../../documentdb/SchemaStore';
 import { ext } from '../../extensionVariables';
 import { ConnectionStorageService, ConnectionType } from '../../services/connectionStorageService';
 import { checkCanProceedAndInformUser } from '../../services/taskService/resourceUsageHelper';
@@ -65,6 +66,9 @@ export async function removeConnection(context: IActionContext, node: DocumentDB
 
         // delete cached credentials from memory using stable clusterId (not treeId)
         CredentialCache.deleteCredentials(node.cluster.clusterId);
+
+        // clear cached schema data for this cluster
+        SchemaStore.getInstance().clearCluster(node.cluster.clusterId);
 
         refreshParentInConnectionsView(node.id);
     });

--- a/src/commands/scratchpad/executeScratchpadCode.ts
+++ b/src/commands/scratchpad/executeScratchpadCode.ts
@@ -5,13 +5,13 @@
 
 import { openReadOnlyContent } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
-import type { Document, WithId } from 'mongodb';
+import { type Document, type WithId } from 'mongodb';
 import * as vscode from 'vscode';
 import { SchemaStore } from '../../documentdb/SchemaStore';
 import { ScratchpadEvaluator } from '../../documentdb/scratchpad/ScratchpadEvaluator';
 import { ScratchpadService } from '../../documentdb/scratchpad/ScratchpadService';
 import { formatError, formatResult } from '../../documentdb/scratchpad/resultFormatter';
-import type { ExecutionResult, ScratchpadConnection } from '../../documentdb/scratchpad/types';
+import { type ExecutionResult, type ScratchpadConnection } from '../../documentdb/scratchpad/types';
 
 /** Shared evaluator instance — lazily created, reused across runs. */
 let evaluator: ScratchpadEvaluator | undefined;
@@ -99,7 +99,7 @@ function feedResultToSchemaStore(result: ExecutionResult, connection: Scratchpad
     }
 
     const printable = result.printable;
-    if (printable == null) {
+    if (printable === null || printable === undefined) {
         return;
     }
 
@@ -108,7 +108,7 @@ function feedResultToSchemaStore(result: ExecutionResult, connection: Scratchpad
 
     // Filter to actual document objects (not primitives, not nested arrays)
     const docs = items.filter(
-        (d): d is WithId<Document> => d != null && typeof d === 'object' && !Array.isArray(d),
+        (d): d is WithId<Document> => d !== null && d !== undefined && typeof d === 'object' && !Array.isArray(d),
     );
 
     if (docs.length > 0) {

--- a/src/commands/scratchpad/executeScratchpadCode.ts
+++ b/src/commands/scratchpad/executeScratchpadCode.ts
@@ -106,9 +106,11 @@ function feedResultToSchemaStore(result: ExecutionResult, connection: Scratchpad
     // Normalize to array
     const items: unknown[] = Array.isArray(printable) ? printable : [printable];
 
-    // Filter to actual document objects (not primitives, not nested arrays)
+    // Filter to actual document objects with _id (not primitives, not nested arrays,
+    // not projection results with _id: 0 which have artificial shapes)
     const docs = items.filter(
-        (d): d is WithId<Document> => d !== null && d !== undefined && typeof d === 'object' && !Array.isArray(d),
+        (d): d is WithId<Document> =>
+            d !== null && d !== undefined && typeof d === 'object' && !Array.isArray(d) && '_id' in d,
     );
 
     if (docs.length > 0) {

--- a/src/commands/scratchpad/executeScratchpadCode.ts
+++ b/src/commands/scratchpad/executeScratchpadCode.ts
@@ -5,10 +5,13 @@
 
 import { openReadOnlyContent } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
+import type { Document, WithId } from 'mongodb';
 import * as vscode from 'vscode';
+import { SchemaStore } from '../../documentdb/SchemaStore';
 import { ScratchpadEvaluator } from '../../documentdb/scratchpad/ScratchpadEvaluator';
 import { ScratchpadService } from '../../documentdb/scratchpad/ScratchpadService';
 import { formatError, formatResult } from '../../documentdb/scratchpad/resultFormatter';
+import type { ExecutionResult, ScratchpadConnection } from '../../documentdb/scratchpad/types';
 
 /** Shared evaluator instance — lazily created, reused across runs. */
 let evaluator: ScratchpadEvaluator | undefined;
@@ -47,6 +50,9 @@ export async function executeScratchpadCode(code: string): Promise<void> {
                 const result = await evaluator!.evaluate(connection, code);
                 const formattedOutput = formatResult(result, code, connection);
 
+                // Feed document results to SchemaStore for cross-tab schema sharing
+                feedResultToSchemaStore(result, connection);
+
                 const resultLabel = l10n.t('{0}/{1} — Results', connection.clusterDisplayName, connection.databaseName);
 
                 await openReadOnlyContent(
@@ -75,4 +81,37 @@ export async function executeScratchpadCode(code: string): Promise<void> {
             }
         },
     );
+}
+
+/**
+ * Very conservative schema feeding: only feed 'Cursor' and 'Document' result types.
+ * Extracts documents from the printable result and adds them to SchemaStore.
+ */
+function feedResultToSchemaStore(result: ExecutionResult, connection: ScratchpadConnection): void {
+    // Only feed known document-producing result types
+    if (result.type !== 'Cursor' && result.type !== 'Document') {
+        return;
+    }
+
+    const ns = result.source?.namespace;
+    if (!ns?.collection) {
+        return;
+    }
+
+    const printable = result.printable;
+    if (printable == null) {
+        return;
+    }
+
+    // Normalize to array
+    const items: unknown[] = Array.isArray(printable) ? printable : [printable];
+
+    // Filter to actual document objects (not primitives, not nested arrays)
+    const docs = items.filter(
+        (d): d is WithId<Document> => d != null && typeof d === 'object' && !Array.isArray(d),
+    );
+
+    if (docs.length > 0) {
+        SchemaStore.getInstance().addDocuments(connection.clusterId, ns.db, ns.collection, docs);
+    }
 }

--- a/src/documentdb/ClusterSession.ts
+++ b/src/documentdb/ClusterSession.ts
@@ -4,12 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ParseMode, parse as parseShellBSON } from '@mongodb-js/shell-bson-parser';
-import {
-    SchemaAnalyzer,
-    getPropertyNamesAtLevel,
-    type FieldEntry,
-    type JSONSchema,
-} from '@vscode-documentdb/schema-analyzer';
+import { type FieldEntry } from '@vscode-documentdb/schema-analyzer';
 import * as l10n from '@vscode/l10n';
 import { EJSON } from 'bson';
 import { ObjectId, type Document, type Filter, type WithId } from 'mongodb';
@@ -17,6 +12,7 @@ import { ext } from '../extensionVariables';
 import { getDataAtPath } from '../utils/slickgrid/mongo/toSlickGridTable';
 import { toSlickGridTree, type TreeData } from '../utils/slickgrid/mongo/toSlickGridTree';
 import { ClustersClient, type FindQueryParams } from './ClustersClient';
+import { SchemaStore } from './SchemaStore';
 import { toFilterQueryObj } from './utils/toFilterQuery';
 
 export type TableDataEntry = {
@@ -71,7 +67,10 @@ export class ClusterSession {
      * Private constructor to enforce the use of `initNewSession` for creating new sessions.
      * This ensures that sessions are properly initialized and managed.
      */
-    private constructor(private _client: ClustersClient) {
+    private constructor(
+        private _client: ClustersClient,
+        private readonly _clusterId: string,
+    ) {
         return;
     }
 
@@ -80,19 +79,16 @@ export class ClusterSession {
     }
 
     /**
-     * Accumulated JSON schema across all pages seen for the current query.
-     * Updates progressively as users navigate through different pages.
-     * Reset when the query or page size changes.
+     * Database name for the current collection view.
+     * Set on the first runFindQueryWithCache call.
      */
-    private _schemaAnalyzer: SchemaAnalyzer = new SchemaAnalyzer();
+    private _databaseName: string | undefined;
 
     /**
-     * Tracks the highest page number that has been accumulated into the schema.
-     * Users navigate sequentially starting from page 1, so any page ≤ this value
-     * has already been accumulated and should be skipped.
-     * Reset when the query or page size changes.
+     * Collection name for the current collection view.
+     * Set on the first runFindQueryWithCache call.
      */
-    private _highestPageAccumulated: number = 0;
+    private _collectionName: string | undefined;
 
     /**
      * Stores the user's original query parameters (filter, project, sort, skip, limit).
@@ -169,16 +165,12 @@ export class ClusterSession {
 
         // The user's query has changed, invalidate all caches.
         //
-        // NOTE: We intentionally do NOT reset the SchemaAnalyzer here.
+        // NOTE: We intentionally do NOT reset schema here.
+        // Schema data is accumulated monotonically in the shared SchemaStore.
         // When a new query returns 0 results, preserving field knowledge from
         // previous queries is more valuable for autocompletion than having an
-        // empty field list. The SchemaAnalyzer accumulates field data
-        // monotonically — new fields are added, existing field type statistics
-        // are enriched with each query. This means type statistics represent
-        // aggregated observations across queries, not a single query snapshot.
-        // Consumers should treat type frequency data as approximate/relative
-        // (e.g., "mostly String") rather than absolute percentages.
-        this._highestPageAccumulated = 0;
+        // empty field list. Consumers should treat type frequency data as
+        // approximate/relative (e.g., "mostly String").
         this._currentPageSize = null;
         this._currentRawDocuments = [];
         this._lastExecutionTimeMs = undefined;
@@ -199,10 +191,9 @@ export class ClusterSession {
      */
     private resetAccumulationIfPageSizeChanged(newPageSize: number): void {
         if (this._currentPageSize !== null && this._currentPageSize !== newPageSize) {
-            // Page size changed, reset accumulation tracking
-            this._schemaAnalyzer.reset();
-            ext.outputChannel.trace('[SchemaAnalyzer] Reset — page size changed');
-            this._highestPageAccumulated = 0;
+            // Page size changed — schema data in SchemaStore is still valid
+            // (accumulated monotonically), just note the size change
+            ext.outputChannel.trace('[SchemaStore] Page size changed');
         }
         this._currentPageSize = newPageSize;
     }
@@ -310,15 +301,17 @@ export class ClusterSession {
         // Update current page documents (always replace, not accumulate)
         this._currentRawDocuments = documents;
 
-        // Accumulate schema only if this page hasn't been seen before
-        // Since navigation is sequential and starts at page 1, we only need to track
-        // the highest page number accumulated
-        if (pageNumber > this._highestPageAccumulated) {
-            this._schemaAnalyzer.addDocuments(this._currentRawDocuments);
-            this._highestPageAccumulated = pageNumber;
+        // Store database/collection context for schema operations
+        this._databaseName = databaseName;
+        this._collectionName = collectionName;
+
+        // Feed documents to the shared SchemaStore
+        if (documents.length > 0) {
+            const store = SchemaStore.getInstance();
+            store.addDocuments(this._clusterId, databaseName, collectionName, documents);
 
             ext.outputChannel.trace(
-                `[SchemaAnalyzer] Analyzed ${String(this._schemaAnalyzer.getDocumentCount())} documents, ${String(this._schemaAnalyzer.getKnownFields().length)} known fields`,
+                `[SchemaStore] Fed ${String(documents.length)} documents, ${String(store.getDocumentCount(this._clusterId, databaseName, collectionName))} total, ${String(store.getKnownFields(this._clusterId, databaseName, collectionName).length)} known fields`,
             );
         }
 
@@ -373,25 +366,28 @@ export class ClusterSession {
     }
 
     public getCurrentPageAsTable(path: string[]): TableData {
+        const store = SchemaStore.getInstance();
         const responsePack: TableData = {
             path: path,
-            headers: getPropertyNamesAtLevel(this._schemaAnalyzer.getSchema(), path),
+            headers:
+                this._databaseName && this._collectionName
+                    ? store.getPropertyNamesAtLevel(this._clusterId, this._databaseName, this._collectionName, path)
+                    : [],
             data: getDataAtPath(this._currentRawDocuments, path),
         };
 
         return responsePack;
     }
 
-    public getCurrentSchema(): JSONSchema {
-        return this._schemaAnalyzer.getSchema();
-    }
-
     /**
-     * Returns the cached list of known fields from the accumulated schema.
-     * Uses SchemaAnalyzer's version-based caching — only recomputed when the schema changes.
+     * Returns the cached list of known fields from the shared SchemaStore.
+     * Delegates to SchemaStore which provides cross-tab schema sharing.
      */
     public getKnownFields(): FieldEntry[] {
-        return this._schemaAnalyzer.getKnownFields();
+        if (!this._databaseName || !this._collectionName) {
+            return [];
+        }
+        return SchemaStore.getInstance().getKnownFields(this._clusterId, this._databaseName, this._collectionName);
     }
 
     // ============================================================================
@@ -690,7 +686,7 @@ export class ClusterSession {
 
         const sessionId = Math.random().toString(16).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 
-        const session = new ClusterSession(client);
+        const session = new ClusterSession(client, credentialId);
 
         ClusterSession._sessions.set(sessionId, session);
 

--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -38,6 +38,7 @@ import { NativeAuthHandler } from './auth/NativeAuthHandler';
 import { QueryInsightsApis, type ExplainVerbosity } from './client/QueryInsightsApis';
 import { CredentialCache, type CachedClusterCredentials } from './CredentialCache';
 import { QueryError } from './errors/QueryError';
+import { SchemaStore } from './SchemaStore';
 import {
     llmEnhancedFeatureApis,
     type CollectionStats,
@@ -320,8 +321,6 @@ export class ClustersClient {
             ClustersClient._clients.delete(credentialId);
 
             // Clear cached schema data for this cluster
-            // Lazy import to avoid circular dependency (SchemaStore imports from schema-analyzer)
-            const { SchemaStore } = await import('./SchemaStore');
             SchemaStore.getInstance().clearCluster(credentialId);
         }
     }

--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -38,7 +38,6 @@ import { NativeAuthHandler } from './auth/NativeAuthHandler';
 import { QueryInsightsApis, type ExplainVerbosity } from './client/QueryInsightsApis';
 import { CredentialCache, type CachedClusterCredentials } from './CredentialCache';
 import { QueryError } from './errors/QueryError';
-import { SchemaStore } from './SchemaStore';
 import {
     llmEnhancedFeatureApis,
     type CollectionStats,
@@ -49,6 +48,7 @@ import {
     type IndexSpecification,
     type IndexStats,
 } from './LlmEnhancedFeatureApis';
+import { SchemaStore } from './SchemaStore';
 import { getHostsFromConnectionString, hasAzureDomain } from './utils/connectionStringHelpers';
 import { getClusterMetadata, type ClusterMetadata } from './utils/getClusterMetadata';
 import { toFilterQueryObj } from './utils/toFilterQuery';

--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -318,6 +318,11 @@ export class ClustersClient {
             const client = ClustersClient._clients.get(credentialId) as ClustersClient;
             await client._mongoClient.close(true);
             ClustersClient._clients.delete(credentialId);
+
+            // Clear cached schema data for this cluster
+            // Lazy import to avoid circular dependency (SchemaStore imports from schema-analyzer)
+            const { SchemaStore } = await import('./SchemaStore');
+            SchemaStore.getInstance().clearCluster(credentialId);
         }
     }
 

--- a/src/documentdb/SchemaStore.test.ts
+++ b/src/documentdb/SchemaStore.test.ts
@@ -143,6 +143,18 @@ describe('SchemaStore', () => {
         expect(store.hasSchema('other-cluster', db, 'users')).toBe(true);
     });
 
+    it('clearDatabase removes schemas for a specific database', () => {
+        store.addDocuments(clusterId, 'db1', 'users', makeDocs([{ name: 'Alice' }]));
+        store.addDocuments(clusterId, 'db1', 'orders', makeDocs([{ total: 99 }]));
+        store.addDocuments(clusterId, 'db2', 'products', makeDocs([{ sku: 'X' }]));
+
+        store.clearDatabase(clusterId, 'db1');
+
+        expect(store.hasSchema(clusterId, 'db1', 'users')).toBe(false);
+        expect(store.hasSchema(clusterId, 'db1', 'orders')).toBe(false);
+        expect(store.hasSchema(clusterId, 'db2', 'products')).toBe(true);
+    });
+
     it('reset clears everything', () => {
         store.addDocuments('c1', db, 'a', makeDocs([{ x: 1 }]));
         store.addDocuments('c2', db, 'b', makeDocs([{ y: 2 }]));

--- a/src/documentdb/SchemaStore.test.ts
+++ b/src/documentdb/SchemaStore.test.ts
@@ -1,0 +1,280 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ObjectId } from 'bson';
+import { SchemaStore, type SchemaChangeEvent } from './SchemaStore';
+
+describe('SchemaStore', () => {
+    let store: SchemaStore;
+
+    beforeEach(() => {
+        // Reset singleton between tests
+        SchemaStore.getInstance().dispose();
+        store = SchemaStore.getInstance();
+    });
+
+    afterEach(() => {
+        store.dispose();
+        jest.useRealTimers();
+    });
+
+    // ── Helpers ──
+
+    const clusterId = 'cluster-1';
+    const db = 'testDb';
+    const coll = 'testColl';
+
+    function makeDocs(fields: Record<string, unknown>[]) {
+        return fields.map((f) => ({ _id: new ObjectId(), ...f }));
+    }
+
+    // ── Read/Write operations ──
+
+    it('returns empty results for unknown keys', () => {
+        expect(store.hasSchema(clusterId, db, coll)).toBe(false);
+        expect(store.getKnownFields(clusterId, db, coll)).toEqual([]);
+        expect(store.getDocumentCount(clusterId, db, coll)).toBe(0);
+        expect(store.getSchema(clusterId, db, coll)).toEqual({ type: 'object' });
+        expect(store.getPropertyNamesAtLevel(clusterId, db, coll, [])).toEqual([]);
+    });
+
+    it('creates analyzer and exposes fields after addDocuments', () => {
+        const docs = makeDocs([{ name: 'Alice', age: 30 }]);
+        store.addDocuments(clusterId, db, coll, docs);
+
+        expect(store.hasSchema(clusterId, db, coll)).toBe(true);
+        expect(store.getDocumentCount(clusterId, db, coll)).toBe(1);
+
+        const fields = store.getKnownFields(clusterId, db, coll);
+        const fieldNames = fields.map((f) => f.path);
+        expect(fieldNames).toContain('_id');
+        expect(fieldNames).toContain('name');
+        expect(fieldNames).toContain('age');
+    });
+
+    it('accumulates schema across multiple addDocuments calls', () => {
+        store.addDocuments(clusterId, db, coll, makeDocs([{ name: 'Alice' }]));
+        store.addDocuments(clusterId, db, coll, makeDocs([{ email: 'a@b.com' }]));
+
+        const fields = store.getKnownFields(clusterId, db, coll);
+        const fieldNames = fields.map((f) => f.path);
+        expect(fieldNames).toContain('name');
+        expect(fieldNames).toContain('email');
+        expect(store.getDocumentCount(clusterId, db, coll)).toBe(2);
+    });
+
+    it('does not create analyzer for empty document array', () => {
+        store.addDocuments(clusterId, db, coll, []);
+        expect(store.hasSchema(clusterId, db, coll)).toBe(false);
+    });
+
+    it('returns property names at root level', () => {
+        store.addDocuments(clusterId, db, coll, makeDocs([{ name: 'Alice', age: 30 }]));
+        const props = store.getPropertyNamesAtLevel(clusterId, db, coll, []);
+        expect(props).toContain('_id');
+        expect(props).toContain('name');
+        expect(props).toContain('age');
+    });
+
+    it('returns property names at nested level', () => {
+        store.addDocuments(clusterId, db, coll, makeDocs([{ address: { city: 'NYC', zip: '10001' } }]));
+        const props = store.getPropertyNamesAtLevel(clusterId, db, coll, ['address']);
+        expect(props).toContain('city');
+        expect(props).toContain('zip');
+    });
+
+    // ── Multiple keys are independent ──
+
+    it('keeps schemas independent per collection', () => {
+        store.addDocuments(clusterId, db, 'users', makeDocs([{ name: 'Alice' }]));
+        store.addDocuments(clusterId, db, 'orders', makeDocs([{ total: 99 }]));
+
+        const userFields = store.getKnownFields(clusterId, db, 'users').map((f) => f.path);
+        const orderFields = store.getKnownFields(clusterId, db, 'orders').map((f) => f.path);
+
+        expect(userFields).toContain('name');
+        expect(userFields).not.toContain('total');
+        expect(orderFields).toContain('total');
+        expect(orderFields).not.toContain('name');
+    });
+
+    it('keeps schemas independent per cluster', () => {
+        store.addDocuments('cluster-a', db, coll, makeDocs([{ fieldA: 1 }]));
+        store.addDocuments('cluster-b', db, coll, makeDocs([{ fieldB: 2 }]));
+
+        const fieldsA = store.getKnownFields('cluster-a', db, coll).map((f) => f.path);
+        const fieldsB = store.getKnownFields('cluster-b', db, coll).map((f) => f.path);
+
+        expect(fieldsA).toContain('fieldA');
+        expect(fieldsA).not.toContain('fieldB');
+        expect(fieldsB).toContain('fieldB');
+        expect(fieldsB).not.toContain('fieldA');
+    });
+
+    // ── Clear operations ──
+
+    it('clearSchema removes a single collection', () => {
+        store.addDocuments(clusterId, db, 'users', makeDocs([{ name: 'Alice' }]));
+        store.addDocuments(clusterId, db, 'orders', makeDocs([{ total: 99 }]));
+
+        store.clearSchema(clusterId, db, 'users');
+
+        expect(store.hasSchema(clusterId, db, 'users')).toBe(false);
+        expect(store.hasSchema(clusterId, db, 'orders')).toBe(true);
+    });
+
+    it('clearSchema is a no-op for unknown keys', () => {
+        // Should not throw
+        store.clearSchema(clusterId, db, 'nonexistent');
+        expect(store.hasSchema(clusterId, db, 'nonexistent')).toBe(false);
+    });
+
+    it('clearCluster removes all schemas for a cluster', () => {
+        store.addDocuments(clusterId, db, 'users', makeDocs([{ name: 'Alice' }]));
+        store.addDocuments(clusterId, db, 'orders', makeDocs([{ total: 99 }]));
+        store.addDocuments('other-cluster', db, 'users', makeDocs([{ name: 'Bob' }]));
+
+        store.clearCluster(clusterId);
+
+        expect(store.hasSchema(clusterId, db, 'users')).toBe(false);
+        expect(store.hasSchema(clusterId, db, 'orders')).toBe(false);
+        expect(store.hasSchema('other-cluster', db, 'users')).toBe(true);
+    });
+
+    it('reset clears everything', () => {
+        store.addDocuments('c1', db, 'a', makeDocs([{ x: 1 }]));
+        store.addDocuments('c2', db, 'b', makeDocs([{ y: 2 }]));
+
+        store.reset();
+
+        expect(store.hasSchema('c1', db, 'a')).toBe(false);
+        expect(store.hasSchema('c2', db, 'b')).toBe(false);
+    });
+
+    // ── Singleton ──
+
+    it('getInstance returns the same instance', () => {
+        const a = SchemaStore.getInstance();
+        const b = SchemaStore.getInstance();
+        expect(a).toBe(b);
+    });
+
+    it('dispose resets the singleton', () => {
+        const before = SchemaStore.getInstance();
+        before.dispose();
+        const after = SchemaStore.getInstance();
+        expect(after).not.toBe(before);
+    });
+
+    // ── Events (debounced) ──
+
+    describe('onDidChangeSchema', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        it('fires after debounce delay on addDocuments', () => {
+            const events: SchemaChangeEvent[] = [];
+            store.onDidChangeSchema((e) => events.push(e));
+
+            store.addDocuments(clusterId, db, coll, makeDocs([{ name: 'Alice' }]));
+
+            // Should not have fired yet
+            expect(events).toHaveLength(0);
+
+            // Advance past the 1-second debounce
+            jest.advanceTimersByTime(1000);
+
+            expect(events).toHaveLength(1);
+            expect(events[0]).toEqual({
+                clusterId,
+                databaseName: db,
+                collectionName: coll,
+            });
+        });
+
+        it('coalesces rapid addDocuments calls into a single event', () => {
+            const events: SchemaChangeEvent[] = [];
+            store.onDidChangeSchema((e) => events.push(e));
+
+            // Rapid successive calls
+            store.addDocuments(clusterId, db, coll, makeDocs([{ a: 1 }]));
+            store.addDocuments(clusterId, db, coll, makeDocs([{ b: 2 }]));
+            store.addDocuments(clusterId, db, coll, makeDocs([{ c: 3 }]));
+
+            jest.advanceTimersByTime(1000);
+
+            // Only one event, not three
+            expect(events).toHaveLength(1);
+        });
+
+        it('fires separate events for different collections', () => {
+            const events: SchemaChangeEvent[] = [];
+            store.onDidChangeSchema((e) => events.push(e));
+
+            store.addDocuments(clusterId, db, 'users', makeDocs([{ name: 'Alice' }]));
+            store.addDocuments(clusterId, db, 'orders', makeDocs([{ total: 99 }]));
+
+            jest.advanceTimersByTime(1000);
+
+            expect(events).toHaveLength(2);
+            expect(events.map((e) => e.collectionName)).toEqual(expect.arrayContaining(['users', 'orders']));
+        });
+
+        it('fires immediately on clearSchema (not debounced)', () => {
+            store.addDocuments(clusterId, db, coll, makeDocs([{ name: 'Alice' }]));
+            jest.advanceTimersByTime(1000); // flush addDocuments event
+
+            const events: SchemaChangeEvent[] = [];
+            store.onDidChangeSchema((e) => events.push(e));
+
+            store.clearSchema(clusterId, db, coll);
+
+            // Should fire immediately, not after debounce
+            expect(events).toHaveLength(1);
+            expect(events[0]).toEqual({
+                clusterId,
+                databaseName: db,
+                collectionName: coll,
+            });
+        });
+
+        it('does not fire clearSchema for unknown keys', () => {
+            const events: SchemaChangeEvent[] = [];
+            store.onDidChangeSchema((e) => events.push(e));
+
+            store.clearSchema(clusterId, db, 'nonexistent');
+
+            expect(events).toHaveLength(0);
+        });
+
+        it('does not fire on addDocuments with empty array', () => {
+            const events: SchemaChangeEvent[] = [];
+            store.onDidChangeSchema((e) => events.push(e));
+
+            store.addDocuments(clusterId, db, coll, []);
+
+            jest.advanceTimersByTime(1000);
+
+            expect(events).toHaveLength(0);
+        });
+
+        it('cancels pending debounced event when clearSchema is called', () => {
+            const events: SchemaChangeEvent[] = [];
+            store.onDidChangeSchema((e) => events.push(e));
+
+            store.addDocuments(clusterId, db, coll, makeDocs([{ name: 'Alice' }]));
+            // Pending debounced event exists
+            store.clearSchema(clusterId, db, coll);
+
+            // clearSchema fires immediately
+            expect(events).toHaveLength(1);
+
+            // Advance timers — no additional event from the cancelled addDocuments debounce
+            jest.advanceTimersByTime(1000);
+            expect(events).toHaveLength(1);
+        });
+    });
+});

--- a/src/documentdb/SchemaStore.ts
+++ b/src/documentdb/SchemaStore.ts
@@ -137,6 +137,21 @@ export class SchemaStore implements vscode.Disposable {
         }
     }
 
+    /** Clear all schemas for a database within a cluster (e.g., on database drop). */
+    public clearDatabase(clusterId: string, db: string): void {
+        const prefix = `${clusterId}::${db}::`;
+        for (const key of this._analyzers.keys()) {
+            if (key.startsWith(prefix)) {
+                this._analyzers.delete(key);
+                const pending = this._pendingNotifications.get(key);
+                if (pending !== undefined) {
+                    clearTimeout(pending);
+                    this._pendingNotifications.delete(key);
+                }
+            }
+        }
+    }
+
     /** Clear all schemas (e.g., for testing). */
     public reset(): void {
         this._analyzers.clear();

--- a/src/documentdb/SchemaStore.ts
+++ b/src/documentdb/SchemaStore.ts
@@ -11,7 +11,7 @@ import {
 } from '@vscode-documentdb/schema-analyzer';
 import * as vscode from 'vscode';
 
-import type { Document, WithId } from 'mongodb';
+import { type Document, type WithId } from 'mongodb';
 
 export interface SchemaChangeEvent {
     readonly clusterId: string;
@@ -87,12 +87,7 @@ export class SchemaStore implements vscode.Disposable {
     // ── Write operations ──
 
     /** Feed documents to the schema store (from any source). */
-    public addDocuments(
-        clusterId: string,
-        db: string,
-        coll: string,
-        documents: ReadonlyArray<WithId<Document>>,
-    ): void {
+    public addDocuments(clusterId: string, db: string, coll: string, documents: ReadonlyArray<WithId<Document>>): void {
         if (documents.length === 0) return;
 
         const key = SchemaStore.key(clusterId, db, coll);

--- a/src/documentdb/SchemaStore.ts
+++ b/src/documentdb/SchemaStore.ts
@@ -1,0 +1,174 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+    SchemaAnalyzer,
+    getPropertyNamesAtLevel,
+    type FieldEntry,
+    type JSONSchema,
+} from '@vscode-documentdb/schema-analyzer';
+import * as vscode from 'vscode';
+
+import type { Document, WithId } from 'mongodb';
+
+export interface SchemaChangeEvent {
+    readonly clusterId: string;
+    readonly databaseName: string;
+    readonly collectionName: string;
+}
+
+/**
+ * Shared, cluster-scoped schema cache.
+ *
+ * Accumulates schema data per `{clusterId, databaseName, collectionName}` triple,
+ * enabling cross-tab and scratchpad schema sharing. All schema consumers
+ * (Collection View tabs, scratchpad, future shell) read from and contribute
+ * to the same store.
+ *
+ * Schema change notifications are debounced per key (1 second) to avoid
+ * excessive churn when pages are navigated rapidly.
+ */
+export class SchemaStore implements vscode.Disposable {
+    private static _instance: SchemaStore | undefined;
+    private readonly _analyzers = new Map<string, SchemaAnalyzer>();
+    private readonly _onDidChangeSchema = new vscode.EventEmitter<SchemaChangeEvent>();
+    private readonly _pendingNotifications = new Map<string, ReturnType<typeof setTimeout>>();
+
+    /** Fires when schema data changes for any collection (debounced, 1 second). */
+    public readonly onDidChangeSchema: vscode.Event<SchemaChangeEvent> = this._onDidChangeSchema.event;
+
+    /** Get the singleton instance. */
+    public static getInstance(): SchemaStore {
+        if (!SchemaStore._instance) {
+            SchemaStore._instance = new SchemaStore();
+        }
+        return SchemaStore._instance;
+    }
+
+    // ── Key construction ──
+
+    private static key(clusterId: string, db: string, coll: string): string {
+        return `${clusterId}::${db}::${coll}`;
+    }
+
+    // ── Read operations ──
+
+    /** Check if schema data exists for a collection. */
+    public hasSchema(clusterId: string, db: string, coll: string): boolean {
+        const analyzer = this._analyzers.get(SchemaStore.key(clusterId, db, coll));
+        return analyzer !== undefined && analyzer.getDocumentCount() > 0;
+    }
+
+    /** Get known fields for a collection (empty array if no schema). */
+    public getKnownFields(clusterId: string, db: string, coll: string): FieldEntry[] {
+        const analyzer = this._analyzers.get(SchemaStore.key(clusterId, db, coll));
+        return analyzer?.getKnownFields() ?? [];
+    }
+
+    /** Get the raw JSON Schema for a collection (empty schema if none). */
+    public getSchema(clusterId: string, db: string, coll: string): JSONSchema {
+        const analyzer = this._analyzers.get(SchemaStore.key(clusterId, db, coll));
+        return analyzer?.getSchema() ?? { type: 'object' };
+    }
+
+    /** Get schema document count for a collection. */
+    public getDocumentCount(clusterId: string, db: string, coll: string): number {
+        return this._analyzers.get(SchemaStore.key(clusterId, db, coll))?.getDocumentCount() ?? 0;
+    }
+
+    /** Get property names at a given schema path (for table headers). */
+    public getPropertyNamesAtLevel(clusterId: string, db: string, coll: string, path: string[]): string[] {
+        const schema = this.getSchema(clusterId, db, coll);
+        return getPropertyNamesAtLevel(schema, path);
+    }
+
+    // ── Write operations ──
+
+    /** Feed documents to the schema store (from any source). */
+    public addDocuments(
+        clusterId: string,
+        db: string,
+        coll: string,
+        documents: ReadonlyArray<WithId<Document>>,
+    ): void {
+        if (documents.length === 0) return;
+
+        const key = SchemaStore.key(clusterId, db, coll);
+        let analyzer = this._analyzers.get(key);
+        if (!analyzer) {
+            analyzer = new SchemaAnalyzer();
+            this._analyzers.set(key, analyzer);
+        }
+
+        analyzer.addDocuments(documents);
+        this._fireSchemaChanged(key, { clusterId, databaseName: db, collectionName: coll });
+    }
+
+    // ── Lifecycle ──
+
+    /** Clear schema for a specific collection (e.g., after collection drop). Fires immediately (not debounced). */
+    public clearSchema(clusterId: string, db: string, coll: string): void {
+        const key = SchemaStore.key(clusterId, db, coll);
+        if (this._analyzers.delete(key)) {
+            // Cancel any pending debounced notification for this key
+            const pending = this._pendingNotifications.get(key);
+            if (pending !== undefined) {
+                clearTimeout(pending);
+                this._pendingNotifications.delete(key);
+            }
+            this._onDidChangeSchema.fire({ clusterId, databaseName: db, collectionName: coll });
+        }
+    }
+
+    /** Clear all schemas for a cluster (e.g., on disconnect). */
+    public clearCluster(clusterId: string): void {
+        const prefix = `${clusterId}::`;
+        for (const key of this._analyzers.keys()) {
+            if (key.startsWith(prefix)) {
+                this._analyzers.delete(key);
+                const pending = this._pendingNotifications.get(key);
+                if (pending !== undefined) {
+                    clearTimeout(pending);
+                    this._pendingNotifications.delete(key);
+                }
+            }
+        }
+    }
+
+    /** Clear all schemas (e.g., for testing). */
+    public reset(): void {
+        this._analyzers.clear();
+        for (const timer of this._pendingNotifications.values()) {
+            clearTimeout(timer);
+        }
+        this._pendingNotifications.clear();
+    }
+
+    public dispose(): void {
+        for (const timer of this._pendingNotifications.values()) {
+            clearTimeout(timer);
+        }
+        this._pendingNotifications.clear();
+        this._onDidChangeSchema.dispose();
+        this._analyzers.clear();
+        SchemaStore._instance = undefined;
+    }
+
+    // ── Debounced notification (1 second per key) ──
+
+    private _fireSchemaChanged(key: string, event: SchemaChangeEvent): void {
+        const existing = this._pendingNotifications.get(key);
+        if (existing !== undefined) {
+            clearTimeout(existing);
+        }
+        this._pendingNotifications.set(
+            key,
+            setTimeout(() => {
+                this._pendingNotifications.delete(key);
+                this._onDidChangeSchema.fire(event);
+            }, 1000),
+        );
+    }
+}

--- a/src/documentdb/scratchpad/ScratchpadEvaluator.ts
+++ b/src/documentdb/scratchpad/ScratchpadEvaluator.ts
@@ -93,7 +93,12 @@ export class ScratchpadEvaluator {
             printable: shellResult.printable,
             durationMs,
             source: shellResult.source?.namespace
-                ? { namespace: { db: shellResult.source.namespace.db, collection: shellResult.source.namespace.collection } }
+                ? {
+                      namespace: {
+                          db: shellResult.source.namespace.db,
+                          collection: shellResult.source.namespace.collection,
+                      },
+                  }
                 : undefined,
         };
     }

--- a/src/documentdb/scratchpad/ScratchpadEvaluator.ts
+++ b/src/documentdb/scratchpad/ScratchpadEvaluator.ts
@@ -81,13 +81,20 @@ export class ScratchpadEvaluator {
         const durationMs = Date.now() - startTime;
 
         // customEval already runs toShellResult() internally via resultHandler,
-        // so `result` is already a ShellResult { type, printable, rawValue }.
-        const shellResult = result as { type: string | null; printable: unknown };
+        // so `result` is already a ShellResult { type, printable, rawValue, source? }.
+        const shellResult = result as {
+            type: string | null;
+            printable: unknown;
+            source?: { namespace?: { db: string; collection: string } };
+        };
 
         return {
             type: shellResult.type,
             printable: shellResult.printable,
             durationMs,
+            source: shellResult.source?.namespace
+                ? { namespace: { db: shellResult.source.namespace.db, collection: shellResult.source.namespace.collection } }
+                : undefined,
         };
     }
 

--- a/src/documentdb/scratchpad/types.ts
+++ b/src/documentdb/scratchpad/types.ts
@@ -26,4 +26,11 @@ export interface ExecutionResult {
     readonly printable: unknown;
     /** Execution duration in milliseconds. */
     readonly durationMs: number;
+    /** Source namespace from the `@mongosh` ShellResult, if available. */
+    readonly source?: {
+        readonly namespace?: {
+            readonly db: string;
+            readonly collection: string;
+        };
+    };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import {
 import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
 import { ClustersExtension } from './documentdb/ClustersExtension';
+import { SchemaStore } from './documentdb/SchemaStore';
 import { ext } from './extensionVariables';
 import { globalUriHandler } from './vscodeUriHandler';
 // Import the DocumentDB Extension API interfaces
@@ -58,6 +59,7 @@ export async function activateInternal(
 
         const clustersSupport: ClustersExtension = new ClustersExtension();
         context.subscriptions.push(clustersSupport); // to be disposed when extension is deactivated.
+        context.subscriptions.push(SchemaStore.getInstance());
         await clustersSupport.activateClustersSupport();
 
         context.subscriptions.push(


### PR DESCRIPTION
## Step 6.1: Shared Schema Cache (`SchemaStore`)

Introduces a `SchemaStore` singleton that accumulates schema data per `{clusterId, databaseName, collectionName}`, enabling cross-tab and scratchpad schema sharing.

### What Changed

**New: `SchemaStore` singleton** ([src/documentdb/SchemaStore.ts](src/documentdb/SchemaStore.ts))
- `Map<"clusterId::db::coll", SchemaAnalyzer>` — shared schema cache
- Debounced `onDidChangeSchema` event (1s per key) to avoid excessive consumer churn
- `clearSchema()` / `clearCluster()` / `clearDatabase()` for lifecycle cleanup
- Registered as VS Code `Disposable` in `extension.ts`

**Refactored: `ClusterSession` delegates to `SchemaStore`**
- Removed private `_schemaAnalyzer` and `_highestPageAccumulated` fields
- `getKnownFields()` and `getCurrentPageAsTable()` now delegate to `SchemaStore`
- Removed unused `getCurrentSchema()` method
- Added `_clusterId`, `_databaseName`, `_collectionName` for SchemaStore key construction
- Page-based dedup dropped — stats are already documented as approximate

**New: Scratchpad results feed `SchemaStore`**
- Extended `ExecutionResult` with `source.namespace` (extracted from `@mongosh` `ShellResult.source`)
- `executeScratchpadCode.ts` feeds document results (very conservative: only `Cursor` and `Document` types)
- Running `db.users.find()` in the scratchpad now populates field completions for the `users` collection across all Collection View tabs

**Wired: Schema cleanup on disconnect/drop**
- `removeConnection` → `clearCluster()`
- `deleteCollection` → `clearSchema()`  
- `deleteDatabase` → `clearDatabase()`
- `ClustersClient.deleteClient` → `clearCluster()` (lazy import to avoid circular dep)

### Tests

- 22 unit tests covering read/write ops, key isolation, event debouncing, lifecycle, singleton behavior
- All existing scratchpad tests pass (52 tests across 4 suites)
- Manual test plan (6 scenarios) in [docs/plan/06.1-shared-schema-cache.md](docs/plan/06.1-shared-schema-cache.md)

### Key Behaviors

| Scenario | Before | After |
|----------|--------|-------|
| Two tabs on same collection | Independent schemas | Shared — Tab B gets Tab A's field completions |
| Scratchpad `find()` result | Documents discarded | Fed to SchemaStore → completions available |
| Tab closed, new tab opened | Schema lost | Schema persists in SchemaStore |
| Connection removed | Schema leaked | Schema cleared via `clearCluster()` |
| Collection dropped | Schema leaked | Schema cleared via `clearSchema()` |

### Plan

Full design doc with architecture, decisions (D1–D7), resolved questions (Q1–Q3), deviations log: [docs/plan/06.1-shared-schema-cache.md](docs/plan/06.1-shared-schema-cache.md) (gitignored, local only)