### PR TITLE
Simplify telemetry for connection and discovery actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1385,9 +1385,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1483,9 +1483,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6905,9 +6905,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7591,9 +7591,9 @@
       ]
     },
     "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11069,9 +11069,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11173,9 +11173,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11297,9 +11297,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11402,9 +11402,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12436,9 +12436,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12592,9 +12592,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
-      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14461,9 +14461,9 @@
       }
     },
     "node_modules/jest-haste-map/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14544,9 +14544,9 @@
       }
     },
     "node_modules/jest-message-util/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14864,9 +14864,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16369,9 +16369,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17727,9 +17727,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20993,9 +20993,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/commands/addConnectionFromRegistry/addConnectionFromRegistry.ts
+++ b/src/commands/addConnectionFromRegistry/addConnectionFromRegistry.ts
@@ -43,6 +43,8 @@ export async function addConnectionFromRegistry(context: IActionContext, node: C
             ? Views.AzureResourcesView
             : Views.DiscoveryView;
 
+    context.telemetry.properties.sourceView = sourceViewId;
+
     if (sourceViewId === Views.AzureResourcesView) {
         // Show a modal dialog informing the user that the details will be saved for future use
         const continueButton = l10n.t('Yes, continue');

--- a/src/commands/addDiscoveryRegistry/ExecuteStep.ts
+++ b/src/commands/addDiscoveryRegistry/ExecuteStep.ts
@@ -16,6 +16,9 @@ export class ExecuteStep extends AzureWizardExecuteStep<AddRegistryWizardContext
         activeDiscoveryProviderIds.push(context.discoveryProviderId!);
         await ext.context.globalState.update('activeDiscoveryProviderIds', activeDiscoveryProviderIds);
 
+        context.telemetry.properties.discoveryProviderId = context.discoveryProviderId!;
+        context.telemetry.measurements.activeDiscoveryProviders = activeDiscoveryProviderIds.length;
+
         // Refresh the discovery branch data provider to show the newly added provider
         ext.discoveryBranchDataProvider.refresh();
     }

--- a/src/commands/removeDiscoveryRegistry/removeDiscoveryRegistry.ts
+++ b/src/commands/removeDiscoveryRegistry/removeDiscoveryRegistry.ts
@@ -10,7 +10,7 @@ import { ext } from '../../extensionVariables';
 import { DiscoveryService } from '../../services/discoveryServices';
 import { type TreeElement } from '../../tree/TreeElement';
 
-export async function removeDiscoveryRegistry(_context: IActionContext, node: TreeElement): Promise<void> {
+export async function removeDiscoveryRegistry(context: IActionContext, node: TreeElement): Promise<void> {
     if (!node) {
         throw new Error(l10n.t('No node selected.'));
     }
@@ -47,6 +47,9 @@ export async function removeDiscoveryRegistry(_context: IActionContext, node: Tr
 
     // Update global state with the filtered list
     await ext.context.globalState.update('activeDiscoveryProviderIds', updatedProviderIds);
+
+    context.telemetry.properties.discoveryProviderId = provider.id;
+    context.telemetry.measurements.activeDiscoveryProviders = updatedProviderIds.length;
 
     // Refresh the discovery branch data provider to show the updated list
     ext.discoveryBranchDataProvider.refresh();

--- a/src/commands/updateCredentials/updateCredentials.ts
+++ b/src/commands/updateCredentials/updateCredentials.ts
@@ -74,6 +74,8 @@ export async function updateCredentials(context: IActionContext, node: DocumentD
 
     const isErrorState = node.id ? ext.connectionsBranchDataProvider.hasNodeErrorState(node.id) : false;
 
+    context.telemetry.properties.calledFrom = isErrorState ? 'errorNode' : 'contextMenu';
+
     const wizardContext: UpdateCredentialsWizardContext = {
         ...context,
         nativeAuthConfig: connectionCredentials?.secrets.nativeAuthConfig,

--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -17,6 +17,7 @@ import {
 } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
 import { EJSON } from 'bson';
+import { randomUUID } from 'crypto';
 import {
     MongoBulkWriteError,
     MongoClient,
@@ -149,6 +150,12 @@ export class ClustersClient {
     private _clusterMetadataPromise: Promise<ClusterMetadata> | null = null;
 
     /**
+     * Correlation ID linking the `connect` and `connect.getmetadata` telemetry events
+     * for the same connection attempt. Generated once per `initClient` call.
+     */
+    public connectionCorrelationId?: string;
+
+    /**
      * Private constructor - use getClient() instead.
      * Connections/Clients are being cached and reused.
      *
@@ -217,6 +224,22 @@ export class ClustersClient {
             options.appName = userAgentString;
         }
 
+        // Generate a correlation ID to link connect + connect.getmetadata telemetry
+        this.connectionCorrelationId = randomUUID();
+
+        // Emit static metadata (domain info) BEFORE the connection attempt.
+        // This ensures destination telemetry is available even when connections fail.
+        const correlationId = this.connectionCorrelationId;
+        void callWithTelemetryAndErrorHandling('connect.staticmetadata', async (context) => {
+            const { getDomainMetadata } = await import('./utils/getClusterMetadata');
+            const domainMetadata = getDomainMetadata(hosts);
+            context.telemetry.properties = {
+                connectioncorrelationid: correlationId,
+                ...context.telemetry.properties,
+                ...domainMetadata,
+            };
+        });
+
         // Connect with the configured options
         await this.connect(connectionString, options, credentials.emulatorConfiguration, abortSignal);
 
@@ -228,6 +251,7 @@ export class ClustersClient {
             const metadata: ClusterMetadata = await this._clusterMetadataPromise!;
             context.telemetry.properties = {
                 authmethod: authMethod,
+                connectioncorrelationid: correlationId,
                 ...context.telemetry.properties,
                 ...metadata,
             };

--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -150,8 +150,8 @@ export class ClustersClient {
     private _clusterMetadataPromise: Promise<ClusterMetadata> | null = null;
 
     /**
-     * Correlation ID linking the `connect` and `connect.getmetadata` telemetry events
-     * for the same connection attempt. Generated once per `initClient` call.
+     * Correlation ID linking the `connect`, `connect.staticmetadata`, and `connect.getmetadata`
+     * telemetry events for the same connection attempt. Generated once per `initClient` call.
      */
     public connectionCorrelationId?: string;
 
@@ -234,7 +234,7 @@ export class ClustersClient {
             const { getDomainMetadata } = await import('./utils/getClusterMetadata');
             const domainMetadata = getDomainMetadata(hosts);
             context.telemetry.properties = {
-                connectioncorrelationid: correlationId,
+                connectionCorrelationId: correlationId,
                 ...context.telemetry.properties,
                 ...domainMetadata,
             };
@@ -251,7 +251,7 @@ export class ClustersClient {
             const metadata: ClusterMetadata = await this._clusterMetadataPromise!;
             context.telemetry.properties = {
                 authmethod: authMethod,
-                connectioncorrelationid: correlationId,
+                connectionCorrelationId: correlationId,
                 ...context.telemetry.properties,
                 ...metadata,
             };

--- a/src/documentdb/utils/getClusterMetadata.ts
+++ b/src/documentdb/utils/getClusterMetadata.ts
@@ -17,6 +17,20 @@ export interface ClusterMetadata {
 }
 
 /**
+ * Retrieves domain-only metadata from hosts without requiring a server connection.
+ * This can be called before the actual MongoDB connection to capture destination info
+ * even when the connection fails.
+ *
+ * @param hosts An array of host strings from the connection string.
+ * @returns An object containing domain metadata (isAzure, api, hashed domain segments).
+ */
+export function getDomainMetadata(hosts: string[]): ClusterMetadata {
+    const result: ClusterMetadata = {};
+    processDomainInfo(hosts, result);
+    return result;
+}
+
+/**
  * Retrieves non-sensitive metadata for a MongoDB cluster.
  * Telemetry-friendly techniques (such as hashing parts of a host) are used to avoid exposing sensitive data.
  *

--- a/src/plugins/service-azure-mongo-ru/discovery-tree/documentdb/MongoRUResourceItem.ts
+++ b/src/plugins/service-azure-mongo-ru/discovery-tree/documentdb/MongoRUResourceItem.ts
@@ -118,7 +118,7 @@ export class MongoRUResourceItem extends ClusterItemBase<AzureClusterModel> {
                 // Add success telemetry
                 context.telemetry.measurements.connectionEstablishmentTimeMs = Date.now() - connectionStartTime;
                 context.telemetry.properties.connectionResult = 'success';
-                context.telemetry.properties.connectioncorrelationid = clustersClient.connectionCorrelationId ?? '';
+                context.telemetry.properties.connectionCorrelationId = clustersClient.connectionCorrelationId ?? '';
 
                 return clustersClient;
             } catch (error) {

--- a/src/plugins/service-azure-mongo-ru/discovery-tree/documentdb/MongoRUResourceItem.ts
+++ b/src/plugins/service-azure-mongo-ru/discovery-tree/documentdb/MongoRUResourceItem.ts
@@ -118,6 +118,7 @@ export class MongoRUResourceItem extends ClusterItemBase<AzureClusterModel> {
                 // Add success telemetry
                 context.telemetry.measurements.connectionEstablishmentTimeMs = Date.now() - connectionStartTime;
                 context.telemetry.properties.connectionResult = 'success';
+                context.telemetry.properties.connectioncorrelationid = clustersClient.connectionCorrelationId ?? '';
 
                 return clustersClient;
             } catch (error) {

--- a/src/plugins/service-azure-mongo-vcore/discovery-tree/documentdb/DocumentDBResourceItem.ts
+++ b/src/plugins/service-azure-mongo-vcore/discovery-tree/documentdb/DocumentDBResourceItem.ts
@@ -167,6 +167,7 @@ export class DocumentDBResourceItem extends ClusterItemBase<AzureClusterModel> {
                 // Add success telemetry
                 context.telemetry.measurements.connectionEstablishmentTimeMs = Date.now() - connectionStartTime;
                 context.telemetry.properties.connectionResult = 'success';
+                context.telemetry.properties.connectioncorrelationid = clustersClient.connectionCorrelationId ?? '';
 
                 return clustersClient;
             } catch (error) {

--- a/src/plugins/service-azure-mongo-vcore/discovery-tree/documentdb/DocumentDBResourceItem.ts
+++ b/src/plugins/service-azure-mongo-vcore/discovery-tree/documentdb/DocumentDBResourceItem.ts
@@ -167,7 +167,7 @@ export class DocumentDBResourceItem extends ClusterItemBase<AzureClusterModel> {
                 // Add success telemetry
                 context.telemetry.measurements.connectionEstablishmentTimeMs = Date.now() - connectionStartTime;
                 context.telemetry.properties.connectionResult = 'success';
-                context.telemetry.properties.connectioncorrelationid = clustersClient.connectionCorrelationId ?? '';
+                context.telemetry.properties.connectionCorrelationId = clustersClient.connectionCorrelationId ?? '';
 
                 return clustersClient;
             } catch (error) {

--- a/src/plugins/service-azure-vm/discovery-tree/vm/AzureVMResourceItem.ts
+++ b/src/plugins/service-azure-vm/discovery-tree/vm/AzureVMResourceItem.ts
@@ -256,6 +256,8 @@ export class AzureVMResourceItem extends ClusterItemBase<VirtualMachineModel> {
                 }),
             );
 
+            context.telemetry.properties.connectioncorrelationid = clustersClient.connectionCorrelationId ?? '';
+
             return clustersClient;
         });
         return result ?? null;

--- a/src/plugins/service-azure-vm/discovery-tree/vm/AzureVMResourceItem.ts
+++ b/src/plugins/service-azure-vm/discovery-tree/vm/AzureVMResourceItem.ts
@@ -256,7 +256,7 @@ export class AzureVMResourceItem extends ClusterItemBase<VirtualMachineModel> {
                 }),
             );
 
-            context.telemetry.properties.connectioncorrelationid = clustersClient.connectionCorrelationId ?? '';
+            context.telemetry.properties.connectionCorrelationId = clustersClient.connectionCorrelationId ?? '';
 
             return clustersClient;
         });

--- a/src/services/ai/QueryInsightsAIService.ts
+++ b/src/services/ai/QueryInsightsAIService.ts
@@ -113,20 +113,31 @@ export class QueryInsightsAIService {
                 // Parse the AI response to extract structured recommendations
                 const parsedResponse = this.parseAIResponse(optimizationResult.recommendations);
 
-                // count all actionable recommendations like create, drop, modify..
-                const actionableRecommendationCount = parsedResponse.improvements.filter(
-                    (improvement) => improvement.action !== 'none',
-                ).length;
+                // Count all actionable recommendations by action type in a single pass
+                let actionableRecommendationCount = 0;
+                let createRecommendationCount = 0;
+                let dropRecommendationCount = 0;
+                let modifyRecommendationCount = 0;
+                for (const improvement of parsedResponse.improvements) {
+                    switch (improvement.action) {
+                        case 'create':
+                            createRecommendationCount++;
+                            actionableRecommendationCount++;
+                            break;
+                        case 'drop':
+                            dropRecommendationCount++;
+                            actionableRecommendationCount++;
+                            break;
+                        case 'modify':
+                            modifyRecommendationCount++;
+                            actionableRecommendationCount++;
+                            break;
+                    }
+                }
                 context.telemetry.measurements.actionableRecommendationCount = actionableRecommendationCount;
-                context.telemetry.measurements.createRecommendationCount = parsedResponse.improvements.filter(
-                    (improvement) => improvement.action === 'create',
-                ).length;
-                context.telemetry.measurements.dropRecommendationCount = parsedResponse.improvements.filter(
-                    (improvement) => improvement.action === 'drop',
-                ).length;
-                context.telemetry.measurements.modifyRecommendationCount = parsedResponse.improvements.filter(
-                    (improvement) => improvement.action === 'modify',
-                ).length;
+                context.telemetry.measurements.createRecommendationCount = createRecommendationCount;
+                context.telemetry.measurements.dropRecommendationCount = dropRecommendationCount;
+                context.telemetry.measurements.modifyRecommendationCount = modifyRecommendationCount;
 
                 return parsedResponse;
             },

--- a/src/services/ai/QueryInsightsAIService.ts
+++ b/src/services/ai/QueryInsightsAIService.ts
@@ -118,6 +118,15 @@ export class QueryInsightsAIService {
                     (improvement) => improvement.action !== 'none',
                 ).length;
                 context.telemetry.measurements.actionableRecommendationCount = actionableRecommendationCount;
+                context.telemetry.measurements.createRecommendationCount = parsedResponse.improvements.filter(
+                    (improvement) => improvement.action === 'create',
+                ).length;
+                context.telemetry.measurements.dropRecommendationCount = parsedResponse.improvements.filter(
+                    (improvement) => improvement.action === 'drop',
+                ).length;
+                context.telemetry.measurements.modifyRecommendationCount = parsedResponse.improvements.filter(
+                    (improvement) => improvement.action === 'modify',
+                ).length;
 
                 return parsedResponse;
             },

--- a/src/services/ai/QueryInsightsAIService.ts
+++ b/src/services/ai/QueryInsightsAIService.ts
@@ -119,21 +119,21 @@ export class QueryInsightsAIService {
                 let dropRecommendationCount = 0;
                 let modifyRecommendationCount = 0;
                 for (const improvement of parsedResponse.improvements) {
+                    actionableRecommendationCount++;
+
                     switch (improvement.action) {
                         case 'create':
                             createRecommendationCount++;
-                            actionableRecommendationCount++;
                             break;
                         case 'drop':
                             dropRecommendationCount++;
-                            actionableRecommendationCount++;
                             break;
                         case 'modify':
                             modifyRecommendationCount++;
-                            actionableRecommendationCount++;
                             break;
                     }
                 }
+
                 context.telemetry.measurements.actionableRecommendationCount = actionableRecommendationCount;
                 context.telemetry.measurements.createRecommendationCount = createRecommendationCount;
                 context.telemetry.measurements.dropRecommendationCount = dropRecommendationCount;

--- a/src/tree/azure-resources-view/documentdb/VCoreResourceItem.ts
+++ b/src/tree/azure-resources-view/documentdb/VCoreResourceItem.ts
@@ -80,6 +80,7 @@ export class VCoreResourceItem extends ClusterItemBase<AzureClusterModel> {
         const result = await callWithTelemetryAndErrorHandling('connect', async (context: IActionContext) => {
             context.telemetry.properties.view = Views.AzureResourcesView;
             context.telemetry.properties.branch = 'documentdb';
+            context.telemetry.properties.connectionInitiatedFrom = Views.AzureResourcesView;
 
             ext.outputChannel.appendLine(
                 l10n.t('Attempting to authenticate with "{cluster}"…', {

--- a/src/tree/azure-resources-view/documentdb/VCoreResourceItem.ts
+++ b/src/tree/azure-resources-view/documentdb/VCoreResourceItem.ts
@@ -156,6 +156,8 @@ export class VCoreResourceItem extends ClusterItemBase<AzureClusterModel> {
                     }),
                 );
 
+                context.telemetry.properties.connectioncorrelationid = clustersClient.connectionCorrelationId ?? '';
+
                 return clustersClient;
             } catch (error) {
                 if (error instanceof UserCancelledError) {

--- a/src/tree/azure-resources-view/documentdb/VCoreResourceItem.ts
+++ b/src/tree/azure-resources-view/documentdb/VCoreResourceItem.ts
@@ -156,7 +156,7 @@ export class VCoreResourceItem extends ClusterItemBase<AzureClusterModel> {
                     }),
                 );
 
-                context.telemetry.properties.connectioncorrelationid = clustersClient.connectionCorrelationId ?? '';
+                context.telemetry.properties.connectionCorrelationId = clustersClient.connectionCorrelationId ?? '';
 
                 return clustersClient;
             } catch (error) {

--- a/src/tree/azure-resources-view/mongo-ru/RUCoreResourceItem.ts
+++ b/src/tree/azure-resources-view/mongo-ru/RUCoreResourceItem.ts
@@ -108,7 +108,7 @@ export class RUResourceItem extends ClusterItemBase<AzureClusterModel> {
                     }),
                 );
 
-                context.telemetry.properties.connectioncorrelationid = clustersClient.connectionCorrelationId ?? '';
+                context.telemetry.properties.connectionCorrelationId = clustersClient.connectionCorrelationId ?? '';
 
                 return clustersClient;
             } catch (error) {

--- a/src/tree/azure-resources-view/mongo-ru/RUCoreResourceItem.ts
+++ b/src/tree/azure-resources-view/mongo-ru/RUCoreResourceItem.ts
@@ -108,6 +108,8 @@ export class RUResourceItem extends ClusterItemBase<AzureClusterModel> {
                     }),
                 );
 
+                context.telemetry.properties.connectioncorrelationid = clustersClient.connectionCorrelationId ?? '';
+
                 return clustersClient;
             } catch (error) {
                 if (error instanceof UserCancelledError) {

--- a/src/tree/azure-resources-view/mongo-ru/RUCoreResourceItem.ts
+++ b/src/tree/azure-resources-view/mongo-ru/RUCoreResourceItem.ts
@@ -70,6 +70,7 @@ export class RUResourceItem extends ClusterItemBase<AzureClusterModel> {
         const result = await callWithTelemetryAndErrorHandling('connect', async (context: IActionContext) => {
             context.telemetry.properties.view = Views.AzureResourcesView;
             context.telemetry.properties.branch = 'ru';
+            context.telemetry.properties.connectionInitiatedFrom = Views.AzureResourcesView;
 
             ext.outputChannel.appendLine(
                 l10n.t('Attempting to authenticate with "{cluster}"…', {

--- a/src/tree/connections-view/DocumentDBClusterItem.ts
+++ b/src/tree/connections-view/DocumentDBClusterItem.ts
@@ -258,7 +258,7 @@ export class DocumentDBClusterItem extends ClusterItemBase<ConnectionClusterMode
                 }),
             );
 
-            context.telemetry.properties.connectioncorrelationid = clustersClient.connectionCorrelationId ?? '';
+            context.telemetry.properties.connectionCorrelationId = clustersClient.connectionCorrelationId ?? '';
 
             return clustersClient;
         });

--- a/src/tree/connections-view/DocumentDBClusterItem.ts
+++ b/src/tree/connections-view/DocumentDBClusterItem.ts
@@ -87,6 +87,8 @@ export class DocumentDBClusterItem extends ClusterItemBase<ConnectionClusterMode
                 ? ConnectionType.Emulators
                 : ConnectionType.Clusters;
 
+            context.telemetry.properties.connectionType = connectionType;
+
             const connectionCredentials = await ConnectionStorageService.get(this.storageId, connectionType);
 
             if (!connectionCredentials || !isConnection(connectionCredentials)) {

--- a/src/tree/connections-view/DocumentDBClusterItem.ts
+++ b/src/tree/connections-view/DocumentDBClusterItem.ts
@@ -258,6 +258,8 @@ export class DocumentDBClusterItem extends ClusterItemBase<ConnectionClusterMode
                 }),
             );
 
+            context.telemetry.properties.connectioncorrelationid = clustersClient.connectionCorrelationId ?? '';
+
             return clustersClient;
         });
         return result ?? null;

--- a/src/tree/connections-view/DocumentDBClusterItem.ts
+++ b/src/tree/connections-view/DocumentDBClusterItem.ts
@@ -75,6 +75,7 @@ export class DocumentDBClusterItem extends ClusterItemBase<ConnectionClusterMode
     protected async authenticateAndConnect(): Promise<ClustersClient | null> {
         const result = await callWithTelemetryAndErrorHandling('connect', async (context: IActionContext) => {
             context.telemetry.properties.view = Views.ConnectionsView;
+            context.telemetry.properties.connectionInitiatedFrom = Views.ConnectionsView;
 
             ext.outputChannel.appendLine(
                 l10n.t('Attempting to authenticate with "{cluster}"…', {

--- a/src/webviews/documentdb/collectionView/collectionViewRouter.ts
+++ b/src/webviews/documentdb/collectionView/collectionViewRouter.ts
@@ -801,18 +801,30 @@ export const collectionsViewRouter = router({
             );
 
             ctx.telemetry.measurements.recommendationCount = aiRecommendations.improvements.length;
-            ctx.telemetry.measurements.actionableRecommendationCount = aiRecommendations.improvements.filter(
-                (rec) => rec.action !== 'none',
-            ).length;
-            ctx.telemetry.measurements.createRecommendationCount = aiRecommendations.improvements.filter(
-                (rec) => rec.action === 'create',
-            ).length;
-            ctx.telemetry.measurements.dropRecommendationCount = aiRecommendations.improvements.filter(
-                (rec) => rec.action === 'drop',
-            ).length;
-            ctx.telemetry.measurements.modifyRecommendationCount = aiRecommendations.improvements.filter(
-                (rec) => rec.action === 'modify',
-            ).length;
+            let actionableRecommendationCount = 0;
+            let createRecommendationCount = 0;
+            let dropRecommendationCount = 0;
+            let modifyRecommendationCount = 0;
+            for (const rec of aiRecommendations.improvements) {
+                switch (rec.action) {
+                    case 'create':
+                        createRecommendationCount++;
+                        actionableRecommendationCount++;
+                        break;
+                    case 'drop':
+                        dropRecommendationCount++;
+                        actionableRecommendationCount++;
+                        break;
+                    case 'modify':
+                        modifyRecommendationCount++;
+                        actionableRecommendationCount++;
+                        break;
+                }
+            }
+            ctx.telemetry.measurements.actionableRecommendationCount = actionableRecommendationCount;
+            ctx.telemetry.measurements.createRecommendationCount = createRecommendationCount;
+            ctx.telemetry.measurements.dropRecommendationCount = dropRecommendationCount;
+            ctx.telemetry.measurements.modifyRecommendationCount = modifyRecommendationCount;
 
             // Transform AI response to UI format with button payloads
             const transformed = transformAIResponseForUI(aiRecommendations, {

--- a/src/webviews/documentdb/collectionView/collectionViewRouter.ts
+++ b/src/webviews/documentdb/collectionView/collectionViewRouter.ts
@@ -806,21 +806,21 @@ export const collectionsViewRouter = router({
             let dropRecommendationCount = 0;
             let modifyRecommendationCount = 0;
             for (const rec of aiRecommendations.improvements) {
+                actionableRecommendationCount++;
+
                 switch (rec.action) {
                     case 'create':
                         createRecommendationCount++;
-                        actionableRecommendationCount++;
                         break;
                     case 'drop':
                         dropRecommendationCount++;
-                        actionableRecommendationCount++;
                         break;
                     case 'modify':
                         modifyRecommendationCount++;
-                        actionableRecommendationCount++;
                         break;
                 }
             }
+
             ctx.telemetry.measurements.actionableRecommendationCount = actionableRecommendationCount;
             ctx.telemetry.measurements.createRecommendationCount = createRecommendationCount;
             ctx.telemetry.measurements.dropRecommendationCount = dropRecommendationCount;

--- a/src/webviews/documentdb/collectionView/collectionViewRouter.ts
+++ b/src/webviews/documentdb/collectionView/collectionViewRouter.ts
@@ -804,6 +804,15 @@ export const collectionsViewRouter = router({
             ctx.telemetry.measurements.actionableRecommendationCount = aiRecommendations.improvements.filter(
                 (rec) => rec.action !== 'none',
             ).length;
+            ctx.telemetry.measurements.createRecommendationCount = aiRecommendations.improvements.filter(
+                (rec) => rec.action === 'create',
+            ).length;
+            ctx.telemetry.measurements.dropRecommendationCount = aiRecommendations.improvements.filter(
+                (rec) => rec.action === 'drop',
+            ).length;
+            ctx.telemetry.measurements.modifyRecommendationCount = aiRecommendations.improvements.filter(
+                (rec) => rec.action === 'modify',
+            ).length;
 
             // Transform AI response to UI format with button payloads
             const transformed = transformAIResponseForUI(aiRecommendations, {


### PR DESCRIPTION
## Summary

This PR focuses the telemetry instrumentation for the connection and discovery workflows — adding specific, actionable properties to existing telemetry events rather than broad coverage.

## Changes

### Connection commands
- **`addConnectionFromRegistry`** — records which view the connection was initiated from (`sourceView`: Azure Resources or Discovery).
- **`updateCredentials`** — records whether the credentials update was triggered from an error-state node or the context menu (`calledFrom`).

### Discovery registry commands
- **`addDiscoveryRegistry`** / **`removeDiscoveryRegistry`** — record the provider ID that was added/removed and the resulting count of active discovery providers.

### Connection telemetry correlation
- A `connectionCorrelationId` (UUID) is generated per `initClient` call in `ClustersClient`, linking the `connect` and `connect.staticmetadata` telemetry events for the same connection attempt.
- A new `getDomainMetadata` helper extracts domain-level info (Azure indicator, hashed host segments) from the connection string **before** the connection attempt, so destination metadata is captured even when connections fail.
- The correlation ID and domain metadata are attached to the main `connect` event as well.

### Tree items
- `VCoreResourceItem`, `RUCoreResourceItem`, `DocumentDBClusterItem`, `MongoRUResourceItem`, `DocumentDBResourceItem`, `AzureVMResourceItem` — each now passes the `connectionCorrelationId` from `ClustersClient` into the `connect` telemetry event, enabling end-to-end tracing of a connection attempt across tree items.

### Collection view
- The `collectionViewRouter` captures the `connectionCorrelationId` from the active `ClustersClient` when a collection view is opened.

### Query Insights AI service
- Breaks down index recommendation counts by action type (`create`, `drop`, `modify`) in addition to the existing total actionable count.

### `getCredentials` (tree item)
- Records the connection type (`connectionType`) on the `getCredentials` telemetry event.
