### PR TITLE
feat: add Copy Reference context menu for databases and collections

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -986,6 +986,7 @@
   "The name must be between {0} and {1} characters.": "The name must be between {0} and {1} characters.",
   "The output window may contain additional information.": "The output window may contain additional information.",
   "The process exited prematurely.": "The process exited prematurely.",
+  "The reference has been copied to the clipboard": "The reference has been copied to the clipboard",
   "The selected authentication method is not supported.": "The selected authentication method is not supported.",
   "The selected connection has been removed.": "The selected connection has been removed.",
   "The selected folder has been removed.": "The selected folder has been removed.",

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -986,7 +986,7 @@
   "The name must be between {0} and {1} characters.": "The name must be between {0} and {1} characters.",
   "The output window may contain additional information.": "The output window may contain additional information.",
   "The process exited prematurely.": "The process exited prematurely.",
-  "The reference has been copied to the clipboard": "The reference has been copied to the clipboard",
+  "The reference has been copied to the clipboard.": "The reference has been copied to the clipboard.",
   "The selected authentication method is not supported.": "The selected authentication method is not supported.",
   "The selected connection has been removed.": "The selected connection has been removed.",
   "The selected folder has been removed.": "The selected folder has been removed.",

--- a/package.json
+++ b/package.json
@@ -538,13 +538,13 @@
         "//": "Copy Database Reference",
         "category": "DocumentDB",
         "command": "vscode-documentdb.command.copyDatabaseReference",
-        "title": "Copy Reference"
+        "title": "Copy Database Reference"
       },
       {
         "//": "Copy Collection Reference",
         "category": "DocumentDB",
         "command": "vscode-documentdb.command.copyCollectionReference",
-        "title": "Copy Reference"
+        "title": "Copy Collection Reference"
       }
     ],
     "submenus": [

--- a/package.json
+++ b/package.json
@@ -533,6 +533,18 @@
         "category": "DocumentDB",
         "command": "vscode-documentdb.command.pasteCollection",
         "title": "Paste Collection…"
+      },
+      {
+        "//": "Copy Database Reference",
+        "category": "DocumentDB",
+        "command": "vscode-documentdb.command.copyDatabaseReference",
+        "title": "Copy Reference"
+      },
+      {
+        "//": "Copy Collection Reference",
+        "category": "DocumentDB",
+        "command": "vscode-documentdb.command.copyCollectionReference",
+        "title": "Copy Reference"
       }
     ],
     "submenus": [
@@ -864,6 +876,18 @@
           "command": "vscode-documentdb.command.pasteCollection",
           "when": "view =~ /connectionsView|discoveryView|azure(ResourceGroups|FocusView)/ && viewItem =~ /\\btreeitem_collection\\b/i && viewItem =~ /\\bexperience_(documentDB|mongoRU)\\b/i",
           "group": "3@4"
+        },
+        {
+          "//": "[Database] Copy Reference",
+          "command": "vscode-documentdb.command.copyDatabaseReference",
+          "when": "view =~ /connectionsView|discoveryView|azure(ResourceGroups|FocusView)/ && viewItem =~ /\\btreeitem_database\\b/i && viewItem =~ /\\bexperience_(documentDB|mongoRU)\\b/i",
+          "group": "6@1"
+        },
+        {
+          "//": "[Collection] Copy Reference",
+          "command": "vscode-documentdb.command.copyCollectionReference",
+          "when": "view =~ /connectionsView|discoveryView|azure(ResourceGroups|FocusView)/ && viewItem =~ /\\btreeitem_collection\\b/i && viewItem =~ /\\bexperience_(documentDB|mongoRU)\\b/i",
+          "group": "6@1"
         }
       ],
       "explorer/context": [],
@@ -926,6 +950,14 @@
         },
         {
           "command": "vscode-documentdb.command.azureResourcesView.addConnectionToConnectionsView",
+          "when": "never"
+        },
+        {
+          "command": "vscode-documentdb.command.copyDatabaseReference",
+          "when": "never"
+        },
+        {
+          "command": "vscode-documentdb.command.copyCollectionReference",
           "when": "never"
         },
         {

--- a/src/commands/copyReference/copyReference.ts
+++ b/src/commands/copyReference/copyReference.ts
@@ -9,22 +9,23 @@ import * as vscode from 'vscode';
 import { type CollectionItem } from '../../tree/documentdb/CollectionItem';
 import { type DatabaseItem } from '../../tree/documentdb/DatabaseItem';
 
-export async function copyDatabaseReference(_context: IActionContext, node: DatabaseItem): Promise<void> {
+async function copyReferenceInternal<T extends DatabaseItem | CollectionItem>(
+    node: T | undefined,
+    getReference: (node: T) => string,
+): Promise<void> {
     if (!node) {
         throw new Error(l10n.t('No node selected.'));
     }
 
-    const reference = node.databaseInfo.name;
+    const reference = getReference(node);
     await vscode.env.clipboard.writeText(reference);
-    void vscode.window.showInformationMessage(l10n.t('The reference has been copied to the clipboard'));
+    void vscode.window.showInformationMessage(l10n.t('The reference has been copied to the clipboard.'));
+}
+
+export async function copyDatabaseReference(_context: IActionContext, node: DatabaseItem): Promise<void> {
+    await copyReferenceInternal(node, (n) => n.databaseInfo.name);
 }
 
 export async function copyCollectionReference(_context: IActionContext, node: CollectionItem): Promise<void> {
-    if (!node) {
-        throw new Error(l10n.t('No node selected.'));
-    }
-
-    const reference = `${node.databaseInfo.name}.${node.collectionInfo.name}`;
-    await vscode.env.clipboard.writeText(reference);
-    void vscode.window.showInformationMessage(l10n.t('The reference has been copied to the clipboard'));
+    await copyReferenceInternal(node, (n) => `${n.databaseInfo.name}.${n.collectionInfo.name}`);
 }

--- a/src/commands/copyReference/copyReference.ts
+++ b/src/commands/copyReference/copyReference.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type IActionContext } from '@microsoft/vscode-azext-utils';
+import * as l10n from '@vscode/l10n';
+import * as vscode from 'vscode';
+import { type CollectionItem } from '../../tree/documentdb/CollectionItem';
+import { type DatabaseItem } from '../../tree/documentdb/DatabaseItem';
+
+export async function copyDatabaseReference(
+    _context: IActionContext,
+    node: DatabaseItem,
+): Promise<void> {
+    if (!node) {
+        throw new Error(l10n.t('No node selected.'));
+    }
+
+    const reference = node.databaseInfo.name;
+    await vscode.env.clipboard.writeText(reference);
+    void vscode.window.showInformationMessage(l10n.t('The reference has been copied to the clipboard'));
+}
+
+export async function copyCollectionReference(
+    _context: IActionContext,
+    node: CollectionItem,
+): Promise<void> {
+    if (!node) {
+        throw new Error(l10n.t('No node selected.'));
+    }
+
+    const reference = `${node.databaseInfo.name}.${node.collectionInfo.name}`;
+    await vscode.env.clipboard.writeText(reference);
+    void vscode.window.showInformationMessage(l10n.t('The reference has been copied to the clipboard'));
+}

--- a/src/commands/copyReference/copyReference.ts
+++ b/src/commands/copyReference/copyReference.ts
@@ -9,10 +9,7 @@ import * as vscode from 'vscode';
 import { type CollectionItem } from '../../tree/documentdb/CollectionItem';
 import { type DatabaseItem } from '../../tree/documentdb/DatabaseItem';
 
-export async function copyDatabaseReference(
-    _context: IActionContext,
-    node: DatabaseItem,
-): Promise<void> {
+export async function copyDatabaseReference(_context: IActionContext, node: DatabaseItem): Promise<void> {
     if (!node) {
         throw new Error(l10n.t('No node selected.'));
     }
@@ -22,10 +19,7 @@ export async function copyDatabaseReference(
     void vscode.window.showInformationMessage(l10n.t('The reference has been copied to the clipboard'));
 }
 
-export async function copyCollectionReference(
-    _context: IActionContext,
-    node: CollectionItem,
-): Promise<void> {
+export async function copyCollectionReference(_context: IActionContext, node: CollectionItem): Promise<void> {
     if (!node) {
         throw new Error(l10n.t('No node selected.'));
     }

--- a/src/documentdb/ClustersExtension.ts
+++ b/src/documentdb/ClustersExtension.ts
@@ -29,6 +29,7 @@ import { renameConnection } from '../commands/connections-view/renameConnection/
 import { renameFolder } from '../commands/connections-view/renameFolder/renameFolder';
 import { copyCollection } from '../commands/copyCollection/copyCollection';
 import { copyAzureConnectionString } from '../commands/copyConnectionString/copyConnectionString';
+import { copyCollectionReference, copyDatabaseReference } from '../commands/copyReference/copyReference';
 import { createCollection } from '../commands/createCollection/createCollection';
 import { createAzureDatabase } from '../commands/createDatabase/createDatabase';
 import { createMongoDocument } from '../commands/createDocument/createDocument';
@@ -385,6 +386,15 @@ export class ClustersExtension implements vscode.Disposable {
                 registerCommandWithTreeNodeUnwrapping(
                     'vscode-documentdb.command.dropDatabase',
                     withTreeNodeCommandCorrelation(deleteAzureDatabase),
+                );
+
+                registerCommandWithTreeNodeUnwrapping(
+                    'vscode-documentdb.command.copyDatabaseReference',
+                    withTreeNodeCommandCorrelation(copyDatabaseReference),
+                );
+                registerCommandWithTreeNodeUnwrapping(
+                    'vscode-documentdb.command.copyCollectionReference',
+                    withTreeNodeCommandCorrelation(copyCollectionReference),
                 );
 
                 registerCommandWithTreeNodeUnwrapping(


### PR DESCRIPTION
Adds a "Copy Reference" right-click option to database and collection nodes in the sidebar. Database copies the db name, collection copies db.collection dot notation.