### PR TITLE
Preparing the `0.7.3` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## 0.7.3
 
-### New Features & Improvements
+### New Features
 
 - **Cancellable Connection**: Users can now cancel in-progress cluster connection attempts via the progress notification. [#529](https://github.com/microsoft/vscode-documentdb/pull/529)
+
+### Improvements
+
 - **Dependency Updates**: Upgrades Node.js from 20 to 22 and bumps `undici`, `handlebars`, `brace-expansion`, `picomatch`, and `flatted` to their latest versions. [#523](https://github.com/microsoft/vscode-documentdb/pull/523), [#534](https://github.com/microsoft/vscode-documentdb/pull/534), [#537](https://github.com/microsoft/vscode-documentdb/pull/537), [#539](https://github.com/microsoft/vscode-documentdb/pull/539), [#541](https://github.com/microsoft/vscode-documentdb/pull/541), [#542](https://github.com/microsoft/vscode-documentdb/pull/542)
 - **Telemetry Improvements**: Refines connection and discovery action telemetry with more specific, actionable diagnostic properties. [#544](https://github.com/microsoft/vscode-documentdb/pull/544)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.7.3
+
+### New Features & Improvements
+
+- **Cancellable Connection**: Users can now cancel in-progress cluster connection attempts via the progress notification. [#529](https://github.com/microsoft/vscode-documentdb/pull/529)
+- **Dependency Updates**: Upgrades Node.js from 20 to 22 and bumps `undici`, `handlebars`, `brace-expansion`, `picomatch`, and `flatted` to their latest versions. [#523](https://github.com/microsoft/vscode-documentdb/pull/523), [#534](https://github.com/microsoft/vscode-documentdb/pull/534), [#537](https://github.com/microsoft/vscode-documentdb/pull/537), [#539](https://github.com/microsoft/vscode-documentdb/pull/539), [#541](https://github.com/microsoft/vscode-documentdb/pull/541), [#542](https://github.com/microsoft/vscode-documentdb/pull/542)
+- **Telemetry Improvements**: Refines connection and discovery action telemetry with more specific, actionable diagnostic properties. [#544](https://github.com/microsoft/vscode-documentdb/pull/544)
+
 ## 0.7.2
 
 ### Improvements

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ The User Manual provides guidance on using DocumentDB for VS Code. It contains d
 
 Explore the history of updates and improvements to the DocumentDB for VS Code extension. Each release brings new features, enhancements, and fixes to improve your experience.
 
-- [0.7](./release-notes/0.7), [0.7.2](./release-notes/0.7#patch-release-v072)
+- [0.7](./release-notes/0.7), [0.7.2](./release-notes/0.7#patch-release-v072), [0.7.3](./release-notes/0.7#patch-release-v073)
 - [0.6](./release-notes/0.6), [0.6.1](./release-notes/0.6#patch-release-v061), [0.6.2](./release-notes/0.6#patch-release-v062), [0.6.3](./release-notes/0.6#patch-release-v063)
 - [0.5](./release-notes/0.5), [0.5.1](./release-notes/0.5#patch-release-v051), [0.5.2](./release-notes/0.5#patch-release-v052)
 - [0.4](./release-notes/0.4), [0.4.1](./release-notes/0.4#patch-release-v041)

--- a/docs/release-notes/0.7.md
+++ b/docs/release-notes/0.7.md
@@ -245,3 +245,28 @@ Updated `minimatch` (3.1.2 → 3.1.4), `qs` and `body-parser` to address securit
 
 See the full changelog entry for this release:
 ➡️ [CHANGELOG.md#072](https://github.com/microsoft/vscode-documentdb/blob/main/CHANGELOG.md#072)
+
+---
+
+## Patch Release v0.7.3
+
+This patch introduces connection cancellation, a Node.js 22 upgrade with dependency refreshes, and internal telemetry refinements.
+
+### What's Changed in v0.7.3
+
+#### 💠 **Cancel In-Progress Connection** ([#529](https://github.com/microsoft/vscode-documentdb/pull/529))
+
+You can now cancel a connection attempt that is taking too long. When the extension is connecting to a cluster, a **Cancel** button appears in the progress notification — clicking it aborts the operation gracefully, so you no longer need to wait or restart VS Code.
+
+#### 💠 **Dependency Updates & Node.js 22** ([#523](https://github.com/microsoft/vscode-documentdb/pull/523), [#534](https://github.com/microsoft/vscode-documentdb/pull/534), [#537](https://github.com/microsoft/vscode-documentdb/pull/537), [#539](https://github.com/microsoft/vscode-documentdb/pull/539), [#541](https://github.com/microsoft/vscode-documentdb/pull/541), [#542](https://github.com/microsoft/vscode-documentdb/pull/542))
+
+The extension's runtime has been upgraded from Node.js 20 to Node.js 22. Several packages — `undici`, `handlebars`, `brace-expansion`, `picomatch`, and `flatted` — have been bumped to their latest versions, bringing security patches and compatibility improvements.
+
+#### 💠 **Telemetry Refinements** ([#544](https://github.com/microsoft/vscode-documentdb/pull/544))
+
+Internal telemetry for connection and discovery actions has been improved to capture more specific, actionable properties — helping the team diagnose issues and improve workflows faster.
+
+### Changelog
+
+See the full changelog entry for this release:
+➡️ [CHANGELOG.md#073](https://github.com/microsoft/vscode-documentdb/blob/main/CHANGELOG.md#073)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-documentdb",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-documentdb",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@azure/arm-compute": "^22.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-documentdb",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "releaseNotesUrl": "https://github.com/microsoft/vscode-documentdb/discussions/489",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "publisher": "ms-azuretools",


### PR DESCRIPTION
This pull request documents and prepares the release of version 0.7.3 of the DocumentDB for VS Code extension. It updates the version number, changelogs, and documentation to reflect new features, dependency upgrades, and telemetry improvements.

Release documentation and versioning:

* Bumped the extension version to `0.7.3` in `package.json`.
* Added a new section for version 0.7.3 in `CHANGELOG.md`, highlighting the cancellable connection feature, Node.js 22 and dependency upgrades, and telemetry improvements.
* Updated the release notes in `docs/release-notes/0.7.md` to describe the new features, improvements, and provide links to the relevant changelog entries.
* Updated `docs/index.md` to include a link to the 0.7.3 release notes.