### PR TITLE
[on hold until 0.8.0 release] fix: rename credentialId to clusterId in ClustersClient methods

### DIFF
--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -398,15 +398,15 @@ export class ClustersClient {
     /**
      * Determines whether a client for the given credential identifier is present in the internal cache.
      */
-    public static exists(credentialId: string): boolean {
-        return ClustersClient._clients.has(credentialId);
+    public static exists(clusterId: string): boolean {
+        return ClustersClient._clients.has(clusterId);
     }
 
-    public static async deleteClient(credentialId: string): Promise<void> {
-        if (ClustersClient._clients.has(credentialId)) {
-            const client = ClustersClient._clients.get(credentialId) as ClustersClient;
+    public static async deleteClient(clusterId: string): Promise<void> {
+        if (ClustersClient._clients.has(clusterId)) {
+            const client = ClustersClient._clients.get(clusterId) as ClustersClient;
             await client._mongoClient.close(true);
-            ClustersClient._clients.delete(credentialId);
+            ClustersClient._clients.delete(clusterId);
         }
     }
 

--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -396,17 +396,17 @@ export class ClustersClient {
     }
 
     /**
-     * Determines whether a client for the given credential identifier is present in the internal cache.
+     * Determines whether a client for the given cluster identifier is present in the internal cache.
      */
-    public static exists(credentialId: string): boolean {
-        return ClustersClient._clients.has(credentialId);
+    public static exists(clusterId: string): boolean {
+        return ClustersClient._clients.has(clusterId);
     }
 
-    public static async deleteClient(credentialId: string): Promise<void> {
-        if (ClustersClient._clients.has(credentialId)) {
-            const client = ClustersClient._clients.get(credentialId) as ClustersClient;
+    public static async deleteClient(clusterId: string): Promise<void> {
+        if (ClustersClient._clients.has(clusterId)) {
+            const client = ClustersClient._clients.get(clusterId) as ClustersClient;
             await client._mongoClient.close(true);
-            ClustersClient._clients.delete(credentialId);
+            ClustersClient._clients.delete(clusterId);
         }
     }
 


### PR DESCRIPTION
Good day,

This PR addresses issue #567 by renaming the parameter from `credentialId` to `clusterId` in the `exists()` and `deleteClient()` methods of `ClustersClient.ts`.

This is a purely cosmetic rename with no functional impact but improves code clarity and alignment with:
- The Cluster ID Architecture documented in copilot-instructions.md
- Other ClustersClient methods: `getClient(clusterId)`, `getExistingClient(clusterId)`
- All methods in `CredentialCache.ts` which consistently use `clusterId`

The inconsistency appears to be a naming oversight — functionally, both parameters are used as keys into the same `_clients` Map which is keyed by clusterId.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof