### PR TITLE
Fix extra newline in playground print() output

### DIFF
--- a/src/documentdb/playground/PlaygroundEvaluator.ts
+++ b/src/documentdb/playground/PlaygroundEvaluator.ts
@@ -88,7 +88,8 @@ export class PlaygroundEvaluator implements vscode.Disposable {
             onConsoleOutput: (output: string) => {
                 this._lastEvalConsoleOutputCount++;
                 ext.playgroundOutputChannel.show(true);
-                ext.playgroundOutputChannel.appendLine(output);
+                // Use append(), not appendLine() — the runtime already includes a trailing newline.
+                ext.playgroundOutputChannel.append(output);
             },
             onLog: (level: 'trace' | 'debug' | 'info' | 'warn' | 'error', message: string) => {
                 switch (level) {


### PR DESCRIPTION
## The bug

Every `print()` call from the playground was followed by an unwanted blank line in the output channel.

## What happened

Commit 5597f57b ("Remove unused trailing newline tracking") simplified the shell's newline handling by moving the trailing `\n` from the PTY layer into `DocumentDBShellRuntime.onPrint()`. The interactive shell's `writeOutput()` digests this just fine, but `PlaygroundEvaluator` was still calling `appendLine()` — which tacks on its *own* newline — producing a double newline after every print.

## The fix

`appendLine()` → `append()`, plus a comment so the next person doesn't re-introduce the same issue.