### PR TITLE
fix: standardize telemetry property conventions

### DIFF
--- a/src/commands/discoveryService.manageCredentials/manageCredentials.ts
+++ b/src/commands/discoveryService.manageCredentials/manageCredentials.ts
@@ -45,15 +45,9 @@ export async function manageCredentials(context: IActionContext, node: TreeEleme
         return;
     }
 
-    try {
-        // Call the filter function provided by the provider
-        await provider.configureCredentials(context, node as TreeElement);
+    // Call the filter function provided by the provider
+    await provider.configureCredentials(context, node as TreeElement);
 
-        // Refresh the discovery branch data provider to show the updated list
-        ext.discoveryBranchDataProvider.refresh(node as TreeElement);
-    } catch (error) {
-        context.telemetry.properties.result = 'Failed';
-        context.telemetry.properties.errorReason = 'configureCredentialsThrew';
-        throw error;
-    }
+    // Refresh the discovery branch data provider to show the updated list
+    ext.discoveryBranchDataProvider.refresh(node as TreeElement);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,10 +94,9 @@ export async function activateInternal(
 
         const enableAIQueryGeneration = vscode.workspace
             .getConfiguration()
-            .get<boolean>(ext.settingsKeys.enableAIQueryGeneration, false)
-            .toString();
+            .get<boolean>(ext.settingsKeys.enableAIQueryGeneration, false);
 
-        telemetryContext.telemetry.properties.enableAIQueryGeneration = enableAIQueryGeneration;
+        telemetryContext.telemetry.properties.enableAIQueryGeneration = enableAIQueryGeneration ? 'true' : 'false';
     });
 
     // Create the DocumentDB Extension API v0.2.0

--- a/src/plugins/api-shared/azure/subscriptionFiltering/FilterTenantSubStep.ts
+++ b/src/plugins/api-shared/azure/subscriptionFiltering/FilterTenantSubStep.ts
@@ -79,10 +79,9 @@ export class FilterTenantSubStep extends AzureWizardPromptStep<FilteringWizardCo
         const totalTenants = context.availableTenants?.length ?? 0;
         context.telemetry.measurements.selectedTenantsForFilteringCount = selectedItems.length;
         context.telemetry.measurements.unselectedTenantsForFilteringCount = totalTenants - selectedItems.length;
-        context.telemetry.properties.allTenantsSelectedForFiltering = (
-            selectedItems.length === totalTenants
-        ).toString();
-        context.telemetry.properties.noTenantsSelectedForFiltering = (selectedItems.length === 0).toString();
+        context.telemetry.properties.allTenantsSelectedForFiltering =
+            selectedItems.length === totalTenants ? 'true' : 'false';
+        context.telemetry.properties.noTenantsSelectedForFiltering = selectedItems.length === 0 ? 'true' : 'false';
     }
 
     public shouldPrompt(): boolean {

--- a/src/plugins/api-shared/azure/subscriptionFiltering/InitializeFilteringStep.ts
+++ b/src/plugins/api-shared/azure/subscriptionFiltering/InitializeFilteringStep.ts
@@ -119,7 +119,7 @@ export class InitializeFilteringStep extends AzureWizardPromptStep<FilteringWiza
         // Determine the flow based on tenant count, but let's look at the actual subscriptions,
         // so that in case of a tenant without subscriptions, we don't bother the user with these.
         const uniqueTenants = this.getUniqueTenants(context.allSubscriptions);
-        context.telemetry.properties.tenantCountFromSubscriptions = uniqueTenants.length.toString();
+        context.telemetry.measurements.tenantCountFromSubscriptions = uniqueTenants.length;
 
         if (uniqueTenants.length > 1) {
             context.telemetry.properties.filteringFlow = 'multiTenant';

--- a/src/plugins/service-azure-mongo-ru/utils/ruClusterHelpers.ts
+++ b/src/plugins/service-azure-mongo-ru/utils/ruClusterHelpers.ts
@@ -95,7 +95,7 @@ export async function extractCredentialsFromRUAccount(
     };
 
     // Add telemetry properties from subscription
-    context.telemetry.properties.isCustomCloud = subscription.isCustomCloud.toString();
+    context.telemetry.properties.isCustomCloud = subscription.isCustomCloud ? 'true' : 'false';
 
     return clusterCredentials;
 }

--- a/src/plugins/service-azure-mongo-vcore/utils/clusterHelpers.ts
+++ b/src/plugins/service-azure-mongo-vcore/utils/clusterHelpers.ts
@@ -100,7 +100,7 @@ export function extractCredentialsFromCluster(
 
     const allowedModes = clusterInformation.properties?.authConfig?.allowedModes ?? [];
     context.telemetry.properties.receivedAuthMethods = allowedModes.join(',');
-    context.telemetry.properties.receivedAuthMethodsCount = allowedModes.length.toString();
+    context.telemetry.measurements.receivedAuthMethodsCount = allowedModes.length;
 
     credentials.availableAuthMethods = allowedModes.filter(isSupportedAuthMethod);
 
@@ -115,7 +115,7 @@ export function extractCredentialsFromCluster(
     }
 
     // Add telemetry properties from subscription
-    context.telemetry.properties.isCustomCloud = subscription.isCustomCloud.toString();
+    context.telemetry.properties.isCustomCloud = subscription.isCustomCloud ? 'true' : 'false';
 
     return credentials;
 }

--- a/src/services/taskService/tasks/copy-and-paste/CopyPasteCollectionTask.ts
+++ b/src/services/taskService/tasks/copy-and-paste/CopyPasteCollectionTask.ts
@@ -189,9 +189,8 @@ export class CopyPasteCollectionTask extends Task implements ResourceTrackingTas
         // Add copy-paste specific telemetry properties
         if (context) {
             context.telemetry.properties.onConflict = this.config.onConflict;
-            context.telemetry.properties.isCrossConnection = (
-                this.config.source.clusterId !== this.config.target.clusterId
-            ).toString();
+            context.telemetry.properties.isCrossConnection =
+                this.config.source.clusterId !== this.config.target.clusterId ? 'true' : 'false';
 
             // Collect cluster metadata for source and target connections and await their completion (non-blocking for errors)
             const metadataPromises = [this.collectClusterMetadata(this.config.source.clusterId, 'source', context)];
@@ -229,7 +228,7 @@ export class CopyPasteCollectionTask extends Task implements ResourceTrackingTas
 
             // Add telemetry about whether the target was created
             if (context) {
-                context.telemetry.properties.targetWasCreated = ensureTargetResult.targetWasCreated.toString();
+                context.telemetry.properties.targetWasCreated = ensureTargetResult.targetWasCreated ? 'true' : 'false';
             }
         } catch (error) {
             throw new Error(vscode.l10n.t('Failed to ensure the target collection exists.'), {

--- a/src/utils/survey.ts
+++ b/src/utils/survey.ts
@@ -108,12 +108,12 @@ export function countUsageForSurvey(score: UsageImpact | number): void {
  */
 export async function promptAfterActionEventually(score: UsageImpact | number, triggerAction?: string): Promise<void> {
     await callWithTelemetryAndErrorHandling('survey.measure-score', async (context: IActionContext) => {
-        context.telemetry.properties.triggerActionScore = score.toString();
+        context.telemetry.measurements.triggerActionScore = typeof score === 'number' ? score : Number(score);
         context.telemetry.properties.triggerAction = triggerAction;
 
         const globalOptOut = getIsSurveyDisabledGlobally();
-        context.telemetry.properties.isSurveyDisabledGlobally = globalOptOut.toString();
-        context.telemetry.properties.wasPromptedInSession = surveyState.wasPromptedInSession.toString();
+        context.telemetry.properties.isSurveyDisabledGlobally = globalOptOut ? 'true' : 'false';
+        context.telemetry.properties.wasPromptedInSession = surveyState.wasPromptedInSession ? 'true' : 'false';
 
         if (globalOptOut || surveyState.wasPromptedInSession) {
             return;
@@ -122,14 +122,14 @@ export async function promptAfterActionEventually(score: UsageImpact | number, t
         countUsageForSurvey(score);
 
         const fullScore = surveyState.usageScore;
-        context.telemetry.properties.fullScore = fullScore.toString();
+        context.telemetry.measurements.fullScore = fullScore;
 
         const scoreTargetReached = fullScore >= SurveyConfig.scoring.REQUIRED_SCORE;
-        context.telemetry.properties.scoreTargetReached = scoreTargetReached.toString();
+        context.telemetry.properties.scoreTargetReached = scoreTargetReached ? 'true' : 'false';
 
         if (scoreTargetReached) {
             const isCandidate = await getIsSurveyCandidate();
-            context.telemetry.properties.isCandidate = isCandidate.toString();
+            context.telemetry.properties.isCandidate = isCandidate ? 'true' : 'false';
             await surveyPromptIfCandidate(triggerAction);
         }
     });
@@ -154,7 +154,7 @@ async function initSurvey(): Promise<void> {
         ): boolean => {
             surveyState.isCandidate = isCandidate;
             context.telemetry.properties.reason = reason;
-            context.telemetry.properties.isCandidate = isCandidate.toString();
+            context.telemetry.properties.isCandidate = isCandidate ? 'true' : 'false';
 
             // Add any additional properties
             Object.entries(extraProps).forEach(([key, value]) => {
@@ -257,7 +257,7 @@ async function initSurvey(): Promise<void> {
                 const acceptedForABTest = normalized < SurveyConfig.settings.A_B_TEST_SELECTION;
 
                 return setCandidateStatus(acceptedForABTest, '07_not_in_ab_test_group', {
-                    acceptedForABTest: acceptedForABTest.toString(),
+                    acceptedForABTest: acceptedForABTest ? 'true' : 'false',
                     normalizedValue: normalized.toFixed(6),
                 });
             } catch (error) {
@@ -277,7 +277,7 @@ async function surveyPromptIfCandidate(triggerAction?: string): Promise<void> {
     }
     await callWithTelemetryAndErrorHandling('survey.prompt', async (context: IActionContext) => {
         const isCandidate = await getIsSurveyCandidate();
-        context.telemetry.properties.isCandidate = isCandidate.toString();
+        context.telemetry.properties.isCandidate = isCandidate ? 'true' : 'false';
         context.telemetry.properties.triggerAction = triggerAction;
         context.telemetry.properties.userAsked = 'false'; // this will be set to 'true' later if the user interacts with the prompt
         surveyState.wasPromptedInSession = true; // disarm for the rest of the session

--- a/src/webviews/documentdb/collectionView/collectionViewRouter.ts
+++ b/src/webviews/documentdb/collectionView/collectionViewRouter.ts
@@ -271,7 +271,7 @@ export const collectionsViewRouter = router({
             void callWithTelemetryAndErrorHandling('documentDB.query.executionIntent', (telemetryCtx) => {
                 telemetryCtx.errorHandling.suppressDisplay = true;
                 telemetryCtx.telemetry.properties.intent = executionIntent;
-                telemetryCtx.telemetry.properties.pageNumber = input.pageNumber.toString();
+                telemetryCtx.telemetry.measurements.pageNumber = input.pageNumber;
                 telemetryCtx.telemetry.measurements.documentCount = size;
             });
 


### PR DESCRIPTION
## Summary

Standardizes telemetry property patterns across the codebase based on the audit from the new `telemetry-instrumentation` skill.

### Changes

**Redundant result override (Issue 3)**
- Removed the try/catch in `manageCredentials.ts` that manually set `result = 'Failed'` before re-throwing — the `callWithTelemetryAndErrorHandling` wrapper handles this automatically.

**Boolean `.toString()` → ternary (Issue 4)**
- Converted all `booleanValue.toString()` patterns to explicit `value ? 'true' : 'false'` ternaries across:
  - `survey.ts` (6 instances: `isSurveyDisabledGlobally`, `wasPromptedInSession`, `scoreTargetReached`, `isCandidate`, `acceptedForABTest`)
  - `CopyPasteCollectionTask.ts` (`isCrossConnection`, `targetWasCreated`)
  - `ruClusterHelpers.ts` / `clusterHelpers.ts` (`isCustomCloud`)
  - `FilterTenantSubStep.ts` (`allTenantsSelectedForFiltering`, `noTenantsSelectedForFiltering`)
  - `extension.ts` (`enableAIQueryGeneration`)

**Numbers as properties → measurements (Issue 5)**
- Moved numeric values from `properties` (string) to `measurements` (number) so they can be aggregated (P50, avg, sum) in analytics:
  - `survey.ts`: `triggerActionScore`, `fullScore`
  - `collectionViewRouter.ts`: `pageNumber`
  - `InitializeFilteringStep.ts`: `tenantCountFromSubscriptions`
  - `clusterHelpers.ts`: `receivedAuthMethodsCount`

### Not changed
- **Naming split** (Issue 1): `domainInfo_*` / `serverInfo_*` snake_case naming is intentional (prefix-as-namespace for metadata spread) and matched by existing dashboard queries.
- **`connectioncorrelationid`** (Issue 2): Already camelCase on this branch.

### Validation
- `npm run prettier-fix` ✅
- `npm run lint` ✅ (596 pre-existing errors in `packages/`, none introduced)
- No TypeScript errors in changed files