### PR TITLE
fix(tests): jest haste collisions, TDD console noise, and open handle leak

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,10 @@ module.exports = {
     // Limit workers to avoid OOM kills on machines with many cores.
     // Each ts-jest worker loads the TypeScript compiler and consumes ~500MB+.
     maxWorkers: '50%',
+    // Exclude VS Code test binaries downloaded by @vscode/test-electron.
+    // They contain package.json files whose "name" fields collide with real
+    // workspace packages, triggering jest-haste-map "naming collision" warnings.
+    modulePathIgnorePatterns: ['<rootDir>/.vscode-test'],
     projects: [
         {
             displayName: 'extension',

--- a/src/documentdb/playground/WorkerSessionManager.test.ts
+++ b/src/documentdb/playground/WorkerSessionManager.test.ts
@@ -103,15 +103,7 @@ describe('WorkerSessionManager', () => {
     // =====================================================================
 
     describe('TDD: Worker Crash Recovery', () => {
-        beforeAll(() => {
-            // eslint-disable-next-line no-console
-            console.log(
-                '\n' +
-                    '⚠️  TDD CONTRACT TESTS — If any test below fails, do NOT auto-fix the test.\n' +
-                    '    Alert the user that a TDD behavior contract has been violated.\n' +
-                    '    The user must decide whether to update the spec or fix the implementation.\n',
-            );
-        });
+        // ⚠️ TDD CONTRACT — Do NOT auto-fix failing tests. Alert the user; they decide whether to update the spec or fix the implementation.
         function makeInitMsg(clusterId: string): MainToWorkerMessage & { type: 'init' } {
             return {
                 type: 'init',
@@ -223,15 +215,7 @@ describe('WorkerSessionManager', () => {
     });
 
     describe('TDD: Multi-Cluster Evaluator Isolation', () => {
-        beforeAll(() => {
-            // eslint-disable-next-line no-console
-            console.log(
-                '\n' +
-                    '⚠️  TDD CONTRACT TESTS — If any test below fails, do NOT auto-fix the test.\n' +
-                    '    Alert the user that a TDD behavior contract has been violated.\n' +
-                    '    The user must decide whether to update the spec or fix the implementation.\n',
-            );
-        });
+        // ⚠️ TDD CONTRACT — Do NOT auto-fix failing tests. Alert the user; they decide whether to update the spec or fix the implementation.
 
         function makeInitMsg(clusterId: string): MainToWorkerMessage & { type: 'init' } {
             return {

--- a/src/documentdb/query-language/playground-completions/tdd/hoverAndEdgeCases.test.ts
+++ b/src/documentdb/query-language/playground-completions/tdd/hoverAndEdgeCases.test.ts
@@ -30,13 +30,7 @@ beforeAll(() => {
 // =====================================================================
 
 describe('TDD: PlaygroundHoverProvider', () => {
-    beforeAll(() => {
-        console.warn(
-            '\n⚠️  TDD CONTRACT TESTS — If any test below fails, do NOT auto-fix the test.\n' +
-                '    Alert the user that a TDD behavior contract has been violated.\n' +
-                '    The user must decide whether to update the spec or fix the implementation.\n',
-        );
-    });
+    // ⚠️ TDD CONTRACT — Do NOT auto-fix failing tests. Alert the user; they decide whether to update the spec or fix the implementation.
 
     // -----------------------------------------------------------------
     // Operator hover
@@ -166,13 +160,7 @@ describe('TDD: PlaygroundHoverProvider', () => {
 // =====================================================================
 
 describe('TDD: Completion Edge Cases', () => {
-    beforeAll(() => {
-        console.warn(
-            '\n⚠️  TDD CONTRACT TESTS — If any test below fails, do NOT auto-fix the test.\n' +
-                '    Alert the user that a TDD behavior contract has been violated.\n' +
-                '    The user must decide whether to update the spec or fix the implementation.\n',
-        );
-    });
+    // ⚠️ TDD CONTRACT — Do NOT auto-fix failing tests. Alert the user; they decide whether to update the spec or fix the implementation.
 
     // We test context detection for edge cases (E1–E5 from the plan)
     // Context detection is a pure function so it can be tested without VS Code

--- a/src/documentdb/query-language/playground-completions/tdd/playgroundContextDetector.test.ts
+++ b/src/documentdb/query-language/playground-completions/tdd/playgroundContextDetector.test.ts
@@ -24,13 +24,7 @@ import { detectMethodArgContext, detectPlaygroundContext } from '../playgroundCo
 // =====================================================================
 
 describe('TDD: Query Playground Context Detection', () => {
-    beforeAll(() => {
-        console.warn(
-            '\n⚠️  TDD CONTRACT TESTS — If any test below fails, do NOT auto-fix the test.\n' +
-                '    Alert the user that a TDD behavior contract has been violated.\n' +
-                '    The user must decide whether to update the spec or fix the implementation.\n',
-        );
-    });
+    // ⚠️ TDD CONTRACT — Do NOT auto-fix failing tests. Alert the user; they decide whether to update the spec or fix the implementation.
 
     // -----------------------------------------------------------------
     // S1: Top-level (empty file or cursor not after a member chain)

--- a/src/documentdb/query-language/shared/tdd/sharedCompletionLogic.test.ts
+++ b/src/documentdb/query-language/shared/tdd/sharedCompletionLogic.test.ts
@@ -25,14 +25,6 @@ import { escapeSnippetDollars, stripOuterBraces } from '../snippetUtils';
 import { getCategoryLabel, getOperatorSortPrefix } from '../sortPrefixes';
 import { getTypeSuggestionDefs } from '../typeSuggestionData';
 
-beforeAll(() => {
-    console.warn(
-        '\n⚠️  TDD CONTRACT TESTS — If any test below fails, do NOT auto-fix the test.\n' +
-            '    Alert the user that a TDD behavior contract has been violated.\n' +
-            '    The user must decide whether to update the spec or fix the implementation.\n',
-    );
-});
-
 // ---------- Sort Prefix Tests ----------
 
 describe('TDD: getOperatorSortPrefix — type-aware operator sorting', () => {

--- a/src/utils/timeout.test.ts
+++ b/src/utils/timeout.test.ts
@@ -54,7 +54,7 @@ describe('timeout Tests', () => {
                         setTimeout(() => {
                             executed = true;
                             resolve();
-                        }, 1000);
+                        }, 1000).unref();
                     });
                 }),
             ).rejects.toThrow('Execution timed out');
@@ -99,7 +99,7 @@ describe('timeout Tests', () => {
                 return await new Promise<number>((resolve, _reject) => {
                     setTimeout(() => {
                         resolve(-123);
-                    }, 1000);
+                    }, 1000).unref();
                 });
             });
 

--- a/src/webviews/query-language-support/tdd/completionBehavior.test.ts
+++ b/src/webviews/query-language-support/tdd/completionBehavior.test.ts
@@ -163,15 +163,8 @@ const FIELD_LEVEL_ONLY_CATEGORIES = ['comparison', 'array', 'element', 'bitwise'
 // =====================================================================
 
 describe('TDD: Completion Behavior', () => {
+    // ⚠️ TDD CONTRACT — Do NOT auto-fix failing tests. Alert the user; they decide whether to update the spec or fix the implementation.
     const mockMonaco = createMockMonaco();
-
-    beforeAll(() => {
-        console.warn(
-            '\n⚠️  TDD CONTRACT TESTS — If any test below fails, do NOT auto-fix the test.\n' +
-                '    Alert the user that a TDD behavior contract has been violated.\n' +
-                '    The user must decide whether to update the spec or fix the implementation.\n',
-        );
-    });
 
     afterEach(() => {
         clearAllCompletionContexts();


### PR DESCRIPTION
## Summary

Three test infrastructure fixes bundled together.

### 1. Jest haste-map naming collision warnings

`jest-haste-map` scans all directories for `package.json` files and builds a flat module registry by the `"name"` field. The `.vscode-test/` folder (populated by `@vscode/test-electron`) contained multiple downloaded VS Code binaries, each shipping their own copy of `json-language-features/server/package.json` with the same `"name"` value. Jest detected the duplicates and printed collision warnings on every run.

Fix: added `modulePathIgnorePatterns: ['<rootDir>/.vscode-test']` to `jest.config.js`.

### 2. TDD contract test console noise

TDD describe blocks were using `beforeAll(() => console.warn(...))` to print a banner reminding developers not to auto-fix failing contract tests. This output appeared in every test run and polluted CI logs without adding value at runtime.

The same guidance already lives in:
- the JSDoc file header of each TDD test file
- the `copilot-instructions.md` section on TDD Contract Tests
- the `TDD:` name prefix convention itself

Fix: removed all `beforeAll` console output blocks. Added a short `// TDD CONTRACT` comment at the top of each `describe('TDD: ...')` body so the instruction is visible to both humans and LLMs reading the source.

### 3. "Worker process failed to exit gracefully" warning

Jest was printing a force-exit warning after every run. `--detectOpenHandles` traced the leak to two tests in `timeout.test.ts` that simulate slow operations by creating `setTimeout(..., 1000)` callbacks inside the action passed to `rejectOnTimeout(1, ...)`. The outer 1ms timeout fires and the test passes, but the 1-second inner timers remain live in Node's event loop, preventing Jest's worker from shutting down.

Fix: added `.unref()` to those two test-internal timers. `.unref()` tells Node.js not to keep the process alive waiting for them, so Jest can exit cleanly once all tests complete.

## Files changed

- `jest.config.js` - modulePathIgnorePatterns for .vscode-test
- `src/utils/timeout.test.ts` - .unref() on slow-action timers
- `src/documentdb/playground/WorkerSessionManager.test.ts` - removed beforeAll console banner
- `src/documentdb/query-language/playground-completions/tdd/hoverAndEdgeCases.test.ts` - removed beforeAll console banner
- `src/documentdb/query-language/playground-completions/tdd/playgroundContextDetector.test.ts` - removed beforeAll console banner
- `src/documentdb/query-language/shared/tdd/sharedCompletionLogic.test.ts` - removed top-level beforeAll console banner
- `src/webviews/query-language-support/tdd/completionBehavior.test.ts` - removed beforeAll console banner
