### PR TITLE
feat(shell): add visible underline to clickable links in terminal output

### DIFF
--- a/docs/ai-and-plans/PRs/631-visible-underline-shell-links.md
+++ b/docs/ai-and-plans/PRs/631-visible-underline-shell-links.md
@@ -1,0 +1,46 @@
+# PR #631: Visible Underline for Shell Terminal Links
+
+## Why
+
+The Interactive Shell emits clickable action sentinels after query results (Collection View, Query Playground) and on certain error hints (Settings links). These sentinels are registered with VS Code's `TerminalLinkProvider` API, which provides hover/Ctrl+click interactivity. However, VS Code's API does not offer a way to make extension-provided terminal links visually distinct at rest. There is no flag, no style property, and no decoration API for terminal links. The only visual feedback is a highlight that appears on hover.
+
+This means users see plain gray text and have no indication that it is clickable. The links are effectively invisible until discovered by accident.
+
+## What was done
+
+Added ANSI underline escape codes (`\x1b[4m` to start, `\x1b[24m` to stop) around each link sentinel at the point where it is written to the terminal. This gives users a persistent visual cue that the text is interactive, without requiring any hover.
+
+### Files changed
+
+- **`ShellOutputFormatter.ts`**: Extended the ANSI constants table with `underline` and `noUnderline` entries. Added a `formatLinkSentinel(text)` helper that wraps text in underline codes.
+- **`DocumentDBShellPty.ts`**: Updated three emission sites to use `formatLinkSentinel()`:
+  - `maybeWriteActionLine` (Collection View and Query Playground links after query results)
+  - `initializeSession` (settings link on connection failure)
+  - `handleEvalError` (settings link on eval errors)
+- **`ShellTerminalLinkProvider.test.ts`**: Added four test cases verifying that link detection regex patterns match sentinels wrapped in underline codes, both standalone and combined with gray color wrapping.
+
+## Key decisions and rationale
+
+### Use `\x1b[24m` (underline-off), not `\x1b[0m` (full reset)
+
+The action sentinels are wrapped inside `formatSystemMessage`, which applies gray color (`\x1b[90m ... \x1b[0m`). If we used a full reset (`\x1b[0m`) to end the underline, it would also kill the gray styling for any text following the link on the same line. Using the specific underline-off escape (`\x1b[24m`) only disables underline while preserving the surrounding color context.
+
+### Underline is not gated by the `colorSupport` setting
+
+The `documentDB.shell.display.colorSupport` setting controls decorative styling (syntax colors, JSON colorization). Underline on links serves a different purpose: it communicates that the text is interactive. Users who disable colors to reduce visual noise still benefit from knowing what is clickable. Treating clickability as a separate concern from decoration keeps the UX accessible.
+
+### The entire sentinel is underlined, not just the `[db.collection]` portion
+
+The `ShellTerminalLinkProvider` reports each link's clickable region via `startIndex` and `length`, which span the entire sentinel text (e.g., the full `↗ Collection View [mydb.users]`). Underlining only a substring would create a mismatch between what looks clickable and what actually responds to click. Aligning the visual and interactive boundaries avoids confusion.
+
+### No markup-tag abstraction layer
+
+A structured markup system (where styled strings are built with tags like `[underline]...[/]` and converted to ANSI in a separate pass) is a powerful pattern for tools with many styled token types. This extension has a small ANSI constants table and only three link types. Adding a markup parser would introduce complexity (parsing, tag nesting, escaping) without proportional benefit. The direct approach (call a helper at each emission site) is simpler, easier to audit, and sufficient for the current scope.
+
+### No changes to `ShellTerminalLinkProvider` regex patterns
+
+The existing regex patterns already tolerate arbitrary ANSI escape sequences at link boundaries via `(?:\x1b\[\d+m)*`. The underline codes (`\x1b[4m`, `\x1b[24m`) match this pattern, so link detection continues to work with zero regex changes. This was verified with four new test cases covering standalone underline wrapping, combined gray+underline wrapping, and multi-link lines with individual underline wrapping.
+
+## Scope
+
+Only the three existing extension-provided link sentinels are affected. Auto-detected URLs in arbitrary command output are handled separately by VS Code's built-in URL detector and are out of scope.

--- a/src/documentdb/shell/DocumentDBShellPty.ts
+++ b/src/documentdb/shell/DocumentDBShellPty.ts
@@ -535,10 +535,7 @@ export class DocumentDBShellPty implements vscode.Pseudoterminal {
 
             // Show a hint line and clickable settings link for errors that reference a VS Code setting
             if (error instanceof SettingsHintError) {
-                const settingsLink = this._outputFormatter.formatLinkSentinel(
-                    `${SETTINGS_ACTION_PREFIX}[${error.settingKey}]`,
-                );
-                this.writeLine(this._outputFormatter.formatSystemMessage(`${error.settingsHint} ${settingsLink}`));
+                this.writeSettingsHintLine(error);
             }
 
             this._inputHandler.setEnabled(true);
@@ -690,10 +687,7 @@ export class DocumentDBShellPty implements vscode.Pseudoterminal {
 
         // Show a hint line and clickable settings link for errors that reference a VS Code setting
         if (error instanceof SettingsHintError) {
-            const settingsLink = this._outputFormatter.formatLinkSentinel(
-                `${SETTINGS_ACTION_PREFIX}[${error.settingKey}]`,
-            );
-            this.writeLine(this._outputFormatter.formatSystemMessage(`${error.settingsHint} ${settingsLink}`));
+            this.writeSettingsHintLine(error);
         }
 
         // Detect query timeout errors (error code 50: MaxTimeMSExpired / ExceededTimeLimit)
@@ -864,6 +858,14 @@ export class DocumentDBShellPty implements vscode.Pseudoterminal {
     }
 
     // ─── Private: Action line ("Open in Collection View") ────────────────────
+
+    /**
+     * Write a hint line with a clickable settings link for a {@link SettingsHintError}.
+     */
+    private writeSettingsHintLine(error: SettingsHintError): void {
+        const settingsLink = this._outputFormatter.formatLinkSentinel(`${SETTINGS_ACTION_PREFIX}[${error.settingKey}]`);
+        this.writeLine(this._outputFormatter.formatSystemMessage(`${error.settingsHint} ${settingsLink}`));
+    }
 
     /**
      * If the result came from a query with a known namespace (db + collection),

--- a/src/documentdb/shell/DocumentDBShellPty.ts
+++ b/src/documentdb/shell/DocumentDBShellPty.ts
@@ -535,11 +535,10 @@ export class DocumentDBShellPty implements vscode.Pseudoterminal {
 
             // Show a hint line and clickable settings link for errors that reference a VS Code setting
             if (error instanceof SettingsHintError) {
-                this.writeLine(
-                    this._outputFormatter.formatSystemMessage(
-                        `${error.settingsHint} ${SETTINGS_ACTION_PREFIX}[${error.settingKey}]`,
-                    ),
+                const settingsLink = this._outputFormatter.formatLinkSentinel(
+                    `${SETTINGS_ACTION_PREFIX}[${error.settingKey}]`,
                 );
+                this.writeLine(this._outputFormatter.formatSystemMessage(`${error.settingsHint} ${settingsLink}`));
             }
 
             this._inputHandler.setEnabled(true);
@@ -691,11 +690,10 @@ export class DocumentDBShellPty implements vscode.Pseudoterminal {
 
         // Show a hint line and clickable settings link for errors that reference a VS Code setting
         if (error instanceof SettingsHintError) {
-            this.writeLine(
-                this._outputFormatter.formatSystemMessage(
-                    `${error.settingsHint} ${SETTINGS_ACTION_PREFIX}[${error.settingKey}]`,
-                ),
+            const settingsLink = this._outputFormatter.formatLinkSentinel(
+                `${SETTINGS_ACTION_PREFIX}[${error.settingKey}]`,
             );
+            this.writeLine(this._outputFormatter.formatSystemMessage(`${error.settingsHint} ${settingsLink}`));
         }
 
         // Detect query timeout errors (error code 50: MaxTimeMSExpired / ExceededTimeLimit)
@@ -894,7 +892,9 @@ export class DocumentDBShellPty implements vscode.Pseudoterminal {
         }
 
         const nsLabel = `[${ns.db}.${ns.collection}]`;
-        const actionText = `${ACTION_LINE_PREFIX}${nsLabel}  ${PLAYGROUND_ACTION_PREFIX}${nsLabel}`;
+        const collectionLink = this._outputFormatter.formatLinkSentinel(`${ACTION_LINE_PREFIX}${nsLabel}`);
+        const playgroundLink = this._outputFormatter.formatLinkSentinel(`${PLAYGROUND_ACTION_PREFIX}${nsLabel}`);
+        const actionText = `${collectionLink}  ${playgroundLink}`;
         this.writeLine(this._outputFormatter.formatSystemMessage(actionText));
     }
 

--- a/src/documentdb/shell/ShellOutputFormatter.ts
+++ b/src/documentdb/shell/ShellOutputFormatter.ts
@@ -15,6 +15,8 @@ import { type SerializableExecutionResult } from '../playground/workerTypes';
 const ANSI = {
     reset: '\x1b[0m',
     bold: '\x1b[1m',
+    underline: '\x1b[4m',
+    noUnderline: '\x1b[24m',
     red: '\x1b[31m',
     green: '\x1b[32m',
     yellow: '\x1b[33m',
@@ -327,6 +329,20 @@ export class ShellOutputFormatter {
                 return line;
             })
             .join('\r\n');
+    }
+
+    /**
+     * Wrap text with ANSI underline codes to visually indicate a clickable link.
+     *
+     * Uses `\x1b[4m` (underline on) and `\x1b[24m` (underline off) instead of
+     * a full reset, so that surrounding styles (e.g., gray from {@link formatSystemMessage})
+     * are preserved.
+     *
+     * Underline is applied regardless of the `colorSupport` setting because it
+     * communicates clickability, not decoration.
+     */
+    formatLinkSentinel(text: string): string {
+        return `${ANSI.underline}${text}${ANSI.noUnderline}`;
     }
 
     // ─── Private: Settings ───────────────────────────────────────────────────

--- a/src/documentdb/shell/ShellTerminalLinkProvider.test.ts
+++ b/src/documentdb/shell/ShellTerminalLinkProvider.test.ts
@@ -176,6 +176,8 @@ describe('ShellTerminalLinkProvider', () => {
             expect(links).toHaveLength(1);
             expect(links[0]).toMatchObject({
                 linkType: 'collectionView',
+                startIndex: 0,
+                length: actionLine.length,
                 databaseName: 'mydb',
                 collectionName: 'users',
             });
@@ -195,6 +197,8 @@ describe('ShellTerminalLinkProvider', () => {
             expect(links).toHaveLength(1);
             expect(links[0]).toMatchObject({
                 linkType: 'collectionView',
+                startIndex: 0,
+                length: actionLine.length,
                 databaseName: 'mydb',
                 collectionName: 'users',
             });
@@ -294,6 +298,8 @@ describe('ShellTerminalLinkProvider', () => {
             expect(links).toHaveLength(1);
             expect(links[0]).toMatchObject({
                 linkType: 'settings',
+                startIndex: 0,
+                length: actionLine.length,
                 settingKey: 'documentDB.shell.initTimeout',
             });
         });
@@ -377,10 +383,9 @@ describe('ShellTerminalLinkProvider', () => {
             registerShellTerminal(mockTerminal, () => mockShellInfo('test-cluster-id'));
 
             // Matches real output: gray wraps the whole line, each link segment is underlined separately
-            const actionLine =
-                `\x1b[90m\x1b[4m${ACTION_LINE_PREFIX}[mydb.orders]\x1b[24m` +
-                `  ` +
-                `\x1b[4m${PLAYGROUND_ACTION_PREFIX}[mydb.orders]\x1b[24m\x1b[0m`;
+            const collectionPart = `\x1b[90m\x1b[4m${ACTION_LINE_PREFIX}[mydb.orders]\x1b[24m`;
+            const playgroundPart = `\x1b[4m${PLAYGROUND_ACTION_PREFIX}[mydb.orders]\x1b[24m\x1b[0m`;
+            const actionLine = `${collectionPart}  ${playgroundPart}`;
             const context = {
                 terminal: mockTerminal,
                 line: actionLine,
@@ -390,11 +395,15 @@ describe('ShellTerminalLinkProvider', () => {
             expect(links).toHaveLength(2);
             expect(links[0]).toMatchObject({
                 linkType: 'collectionView',
+                startIndex: 0,
+                length: collectionPart.length,
                 databaseName: 'mydb',
                 collectionName: 'orders',
             });
             expect(links[1]).toMatchObject({
                 linkType: 'playground',
+                startIndex: collectionPart.length + 2, // +2 for "  " separator
+                length: playgroundPart.length,
                 databaseName: 'mydb',
                 collectionName: 'orders',
             });

--- a/src/documentdb/shell/ShellTerminalLinkProvider.test.ts
+++ b/src/documentdb/shell/ShellTerminalLinkProvider.test.ts
@@ -162,6 +162,44 @@ describe('ShellTerminalLinkProvider', () => {
             });
         });
 
+        it('should handle underline-wrapped action line', () => {
+            registerShellTerminal(mockTerminal, () => mockShellInfo('test-id'));
+
+            // Underline wrapping: \x1b[4m ... \x1b[24m
+            const actionLine = `\x1b[4m${ACTION_LINE_PREFIX}[mydb.users]\x1b[24m`;
+            const context = {
+                terminal: mockTerminal,
+                line: actionLine,
+            } as vscode.TerminalLinkContext;
+
+            const links = provider.provideTerminalLinks(context);
+            expect(links).toHaveLength(1);
+            expect(links[0]).toMatchObject({
+                linkType: 'collectionView',
+                databaseName: 'mydb',
+                collectionName: 'users',
+            });
+        });
+
+        it('should handle gray + underline wrapped action line', () => {
+            registerShellTerminal(mockTerminal, () => mockShellInfo('test-id'));
+
+            // Gray wrapping outside, underline inside (matches real output)
+            const actionLine = `\x1b[90m\x1b[4m${ACTION_LINE_PREFIX}[mydb.users]\x1b[24m\x1b[0m`;
+            const context = {
+                terminal: mockTerminal,
+                line: actionLine,
+            } as vscode.TerminalLinkContext;
+
+            const links = provider.provideTerminalLinks(context);
+            expect(links).toHaveLength(1);
+            expect(links[0]).toMatchObject({
+                linkType: 'collectionView',
+                databaseName: 'mydb',
+                collectionName: 'users',
+            });
+        });
+
         it('should not match partial action line text', () => {
             registerShellTerminal(mockTerminal, () => mockShellInfo('test-id'));
 
@@ -243,6 +281,23 @@ describe('ShellTerminalLinkProvider', () => {
             });
         });
 
+        it('should handle underline-wrapped settings action line', () => {
+            registerShellTerminal(mockTerminal, () => mockShellInfo('test-id'));
+
+            const actionLine = `\x1b[90m\x1b[4m${SETTINGS_ACTION_PREFIX}[documentDB.shell.initTimeout]\x1b[24m\x1b[0m`;
+            const context = {
+                terminal: mockTerminal,
+                line: actionLine,
+            } as vscode.TerminalLinkContext;
+
+            const links = provider.provideTerminalLinks(context);
+            expect(links).toHaveLength(1);
+            expect(links[0]).toMatchObject({
+                linkType: 'settings',
+                settingKey: 'documentDB.shell.initTimeout',
+            });
+        });
+
         it('should not match settings line for non-shell terminals', () => {
             const context = {
                 terminal: { name: 'bash' } as unknown as vscode.Terminal,
@@ -299,6 +354,33 @@ describe('ShellTerminalLinkProvider', () => {
             registerShellTerminal(mockTerminal, () => mockShellInfo('test-cluster-id'));
 
             const actionLine = `${ACTION_LINE_PREFIX}[mydb.orders]  ${PLAYGROUND_ACTION_PREFIX}[mydb.orders]`;
+            const context = {
+                terminal: mockTerminal,
+                line: actionLine,
+            } as vscode.TerminalLinkContext;
+
+            const links = provider.provideTerminalLinks(context);
+            expect(links).toHaveLength(2);
+            expect(links[0]).toMatchObject({
+                linkType: 'collectionView',
+                databaseName: 'mydb',
+                collectionName: 'orders',
+            });
+            expect(links[1]).toMatchObject({
+                linkType: 'playground',
+                databaseName: 'mydb',
+                collectionName: 'orders',
+            });
+        });
+
+        it('should detect both links when each is individually underline-wrapped', () => {
+            registerShellTerminal(mockTerminal, () => mockShellInfo('test-cluster-id'));
+
+            // Matches real output: gray wraps the whole line, each link segment is underlined separately
+            const actionLine =
+                `\x1b[90m\x1b[4m${ACTION_LINE_PREFIX}[mydb.orders]\x1b[24m` +
+                `  ` +
+                `\x1b[4m${PLAYGROUND_ACTION_PREFIX}[mydb.orders]\x1b[24m\x1b[0m`;
             const context = {
                 terminal: mockTerminal,
                 line: actionLine,


### PR DESCRIPTION
## Summary

Clickable action links in the Interactive Shell terminal output (Collection View, Query Playground, Settings) are now visually underlined, making them discoverable without requiring a hover.

## Problem

The shell emits clickable sentinels after query results and on error hints. These links are registered with VS Code's `TerminalLinkProvider` API, which only highlights them on hover or Ctrl+click. There is no API flag to make extension-provided terminal links visually distinct at rest. Users had no visual cue that the text was clickable.

## Solution

Emit ANSI underline escape codes (`\x1b[4m` / `\x1b[24m`) around each link sentinel at the point of output. This is a purely visual change; the existing `ShellTerminalLinkProvider` regex patterns already tolerate ANSI escape sequences at link boundaries, so no link detection logic needed to change.

### Key decisions:

- **`\x1b[24m` (underline-off) instead of `\x1b[0m` (full reset):** Preserves surrounding styles (e.g., gray from `formatSystemMessage`) instead of clobbering them.
- **Underline is not gated by `colorSupport` setting:** Underline communicates clickability, not decoration. Users who disable colors still benefit from knowing what is clickable.
- **Entire sentinel is underlined:** The visible underline region matches the clickable hit area reported by `startIndex`/`length` in the link provider, so visual and interactive boundaries align.
- **No markup-tag abstraction:** The extension has a small ANSI constants table and only three link types. A markup parser layer would add complexity without proportional benefit.

## Changes

- **`ShellOutputFormatter.ts`**: Added `underline`/`noUnderline` to the ANSI constants table. Added `formatLinkSentinel(text)` helper.
- **`DocumentDBShellPty.ts`**: Wrapped each link sentinel with `formatLinkSentinel()` at all three emission sites (`maybeWriteActionLine`, `initializeSession` settings hint, `handleEvalError` settings hint).
- **`ShellTerminalLinkProvider.test.ts`**: Added 4 test cases verifying link detection works with underline-wrapped sentinels (standalone, combined with gray, and multi-link lines).

## Testing

- All 1937 tests pass (including 4 new ones).
- Lint, prettier, and build all clean.