### PR TITLE
Pre-release hardening: playground TS bootstrap telemetry and worker exit on uncaught

### DIFF
--- a/src/documentdb/ClustersExtension.ts
+++ b/src/documentdb/ClustersExtension.ts
@@ -318,6 +318,9 @@ export class ClustersExtension implements vscode.Disposable {
                     // from TS server restart failures (timing / api availability).
                     let stage: 'stubInstall' | 'tsActivate' | 'tsWait' | 'tsRestart' | 'complete' = 'stubInstall';
                     let stubCreated = false;
+                    // Disambiguates 'stubCreated=false': either the stub already existed (existed=true)
+                    // or the stub-install branch was never reached at all (existed=false).
+                    let stubExisted = false;
 
                     await callWithTelemetryAndErrorHandling('playground.tsPluginBootstrap', async (context) => {
                         // We do not want a modal error popup if this best-effort
@@ -340,7 +343,9 @@ export class ClustersExtension implements vscode.Disposable {
                                 'documentdb-playground-ts-plugin',
                             );
                             const stubEntry = path.join(stubDir, 'index.js');
-                            if (!fs.existsSync(stubEntry)) {
+                            if (fs.existsSync(stubEntry)) {
+                                stubExisted = true;
+                            } else {
                                 fs.mkdirSync(stubDir, { recursive: true });
                                 // Point to the bundled plugin at the extension root
                                 fs.writeFileSync(
@@ -389,6 +394,7 @@ export class ClustersExtension implements vscode.Disposable {
                         } finally {
                             context.telemetry.properties.stage = stage;
                             context.telemetry.properties.stubCreated = stubCreated ? 'true' : 'false';
+                            context.telemetry.properties.stubExisted = stubExisted ? 'true' : 'false';
                         }
                     });
                 };

--- a/src/documentdb/ClustersExtension.ts
+++ b/src/documentdb/ClustersExtension.ts
@@ -307,47 +307,90 @@ export class ClustersExtension implements vscode.Disposable {
                     if (tsRestarted) {
                         return;
                     }
+                    // Mark attempted up front to prevent concurrent bootstraps from racing.
+                    // If anything throws, the catch block below resets this flag so the
+                    // next playground open will retry (important for read-only extension
+                    // installs that may transiently fail or for slow-init environments).
                     tsRestarted = true;
-                    try {
-                        // TODO: Remove this runtime stub once the TS plugin is published
-                        // as a standalone npm package with its own release pipeline.
-                        // The official VS Code docs say TS server plugins should be normal
-                        // npm `dependencies`. Our plugin is currently bundled inline by
-                        // webpack, and vsce hardcodes `ignore: 'node_modules/**'` in its
-                        // file collection, so the stub can't ship in the VSIX. We create
-                        // it at runtime instead (same pattern as Vue/Volar).
-                        // Tracked by: https://github.com/microsoft/vscode-documentdb/issues/548
-                        const stubDir = path.join(
-                            ext.context.extensionPath,
-                            'node_modules',
-                            'documentdb-playground-ts-plugin',
-                        );
-                        const stubEntry = path.join(stubDir, 'index.js');
-                        if (!fs.existsSync(stubEntry)) {
-                            fs.mkdirSync(stubDir, { recursive: true });
-                            // Point to the bundled plugin at the extension root
-                            fs.writeFileSync(stubEntry, 'module.exports = require("../../playgroundTsPlugin.js");\n');
-                        }
 
-                        const tsExt = vscode.extensions.getExtension('vscode.typescript-language-features');
-                        if (tsExt) {
-                            if (!tsExt.isActive) {
-                                await tsExt.activate();
+                    // Track which phase of the bootstrap we are in so telemetry can
+                    // distinguish stub-install failures (filesystem / read-only installs)
+                    // from TS server restart failures (timing / api availability).
+                    let stage: 'stubInstall' | 'tsActivate' | 'tsWait' | 'tsRestart' | 'complete' = 'stubInstall';
+                    let stubCreated = false;
+
+                    await callWithTelemetryAndErrorHandling('playground.tsPluginBootstrap', async (context) => {
+                        // We do not want a modal error popup if this best-effort
+                        // bootstrap fails. The wrapper still captures result=Failed,
+                        // error name, and error message automatically.
+                        context.errorHandling.suppressDisplay = true;
+
+                        try {
+                            // TODO: Remove this runtime stub once the TS plugin is published
+                            // as a standalone npm package with its own release pipeline.
+                            // The official VS Code docs say TS server plugins should be normal
+                            // npm `dependencies`. Our plugin is currently bundled inline by
+                            // webpack, and vsce hardcodes `ignore: 'node_modules/**'` in its
+                            // file collection, so the stub can't ship in the VSIX. We create
+                            // it at runtime instead (same pattern as Vue/Volar).
+                            // Tracked by: https://github.com/microsoft/vscode-documentdb/issues/548
+                            const stubDir = path.join(
+                                ext.context.extensionPath,
+                                'node_modules',
+                                'documentdb-playground-ts-plugin',
+                            );
+                            const stubEntry = path.join(stubDir, 'index.js');
+                            if (!fs.existsSync(stubEntry)) {
+                                fs.mkdirSync(stubDir, { recursive: true });
+                                // Point to the bundled plugin at the extension root
+                                fs.writeFileSync(
+                                    stubEntry,
+                                    'module.exports = require("../../playgroundTsPlugin.js");\n',
+                                );
+                                stubCreated = true;
                             }
-                            // Wait a moment for the TS server to fully initialize before
-                            // restarting it. Without this delay, the restart command can
-                            // arrive while the server is still starting, causing a crash.
-                            await new Promise((resolve) => setTimeout(resolve, 2000));
-                            // Restart the TS server so it picks up our plugin from
-                            // contributes.typescriptServerPlugins. Without this, the server
-                            // may have started before our extension was loaded and won't
-                            // have our plugin in --globalPlugins.
-                            await vscode.commands.executeCommand('typescript.restartTsServer');
+
+                            stage = 'tsActivate';
+                            const tsExt = vscode.extensions.getExtension('vscode.typescript-language-features');
+                            context.telemetry.properties.tsExtensionFound = tsExt ? 'true' : 'false';
+                            if (tsExt) {
+                                if (!tsExt.isActive) {
+                                    await tsExt.activate();
+                                }
+                                // Wait a moment for the TS server to fully initialize before
+                                // restarting it. Without this delay, the restart command can
+                                // arrive while the server is still starting, causing a crash.
+                                stage = 'tsWait';
+                                await new Promise((resolve) => setTimeout(resolve, 2000));
+                                // Restart the TS server so it picks up our plugin from
+                                // contributes.typescriptServerPlugins. Without this, the server
+                                // may have started before our extension was loaded and won't
+                                // have our plugin in --globalPlugins.
+                                stage = 'tsRestart';
+                                await vscode.commands.executeCommand('typescript.restartTsServer');
+                            }
+
+                            stage = 'complete';
+                        } catch (error) {
+                            // Reset so the next playground open retries the bootstrap.
+                            // This matters for read-only extension installs (Snap, system
+                            // package, locked enterprise) where the first attempt fails
+                            // but a later run after a workspace setting change may succeed,
+                            // and for slow-init environments where the TS server was not
+                            // ready in time.
+                            tsRestarted = false;
+                            const message = error instanceof Error ? error.message : String(error);
+                            ext.outputChannel.debug(
+                                `[Playground] TS server bootstrap failed at stage=${stage}: ${message}`,
+                            );
+                            // Rethrow so the telemetry wrapper records result=Failed
+                            // and captures error name / errorMessage automatically.
+                            throw error;
+                        } finally {
+                            context.telemetry.properties.stage = stage;
+                            context.telemetry.properties.stubCreated = stubCreated ? 'true' : 'false';
                         }
-                    } catch (error) {
-                        const message = error instanceof Error ? error.message : String(error);
-                        ext.outputChannel.debug(`[Playground] TS server restart failed: ${message}`);
-                    }
+                    });
                 };
 
                 ext.context.subscriptions.push(

--- a/src/documentdb/playground/playgroundWorker.ts
+++ b/src/documentdb/playground/playgroundWorker.ts
@@ -331,5 +331,28 @@ process.on('uncaughtException', (error: Error) => {
 
 process.on('unhandledRejection', (reason: unknown) => {
     const message = reason instanceof Error ? reason.message : String(reason);
-    log('error', `Unhandled rejection in worker: ${message}`);
+    const stack = reason instanceof Error ? reason.stack : undefined;
+
+    // If a user-code eval is in flight, surface the rejection as its failure
+    // result so the user sees a meaningful error instead of a generic
+    // "Worker exited unexpectedly" message from the supervisor.
+    if (currentEvalRequestId) {
+        const response: WorkerToMainMessage = {
+            type: 'evalError',
+            requestId: currentEvalRequestId,
+            error: `Unhandled rejection: ${message}`,
+            stack,
+        };
+        parentPort!.postMessage(response);
+        currentEvalRequestId = undefined;
+    }
+
+    log('error', `Unhandled rejection in worker: ${message}\n${stack ?? ''}`);
+
+    // Exit for the same reason uncaughtException does: a rejection that escaped
+    // all eval-scoped catch blocks may have left mongoClient or shellRuntime in
+    // an inconsistent state. The supervisor (WorkerSessionManager) will reject
+    // pending requests, emit worker.unexpectedExit telemetry, and respawn a
+    // fresh worker on the next eval. The 50 ms delay lets postMessage flush.
+    setTimeout(() => process.exit(1), 50);
 });

--- a/src/documentdb/playground/playgroundWorker.ts
+++ b/src/documentdb/playground/playgroundWorker.ts
@@ -316,6 +316,17 @@ process.on('uncaughtException', (error: Error) => {
     }
 
     log('error', `Uncaught exception in worker: ${error.message}\n${error.stack ?? ''}`);
+
+    // Exit so the supervisor (WorkerSessionManager) treats this as an unexpected
+    // exit and respawns a fresh worker on the next eval. Continuing to run after
+    // an uncaught exception risks operating with a corrupted mongoClient or
+    // shellRuntime state. The supervisor emits worker.unexpectedExit telemetry
+    // when this happens, so we keep visibility into the failure.
+    //
+    // Use a short delay so the postMessage above flushes before the worker
+    // terminates. setImmediate is not enough because Node may schedule the exit
+    // before the IPC message is serialized to the parent.
+    setTimeout(() => process.exit(1), 50);
 });
 
 process.on('unhandledRejection', (reason: unknown) => {


### PR DESCRIPTION
Three pre-release hardening fixes identified by the 0.8.0 release audit. All are scoped to the playground worker bootstrap path; nothing in this PR changes connectivity, data handling, or public APIs.

## Changes

### `fix(playground): instrument and retry TS plugin bootstrap` (F-01, F-02)

`ClustersExtension.ensureTsRestart` previously swallowed all errors into `outputChannel.debug` and set `tsRestarted = true` before doing any async work, so a single failure on first playground open left IntelliSense broken for the rest of the session with no signal to operators.

- Wraps the bootstrap in `callWithTelemetryAndErrorHandling('playground.tsPluginBootstrap')` so result, error name, and errorMessage are captured automatically.
- Adds a `stage` property (`stubInstall`, `tsActivate`, `tsWait`, `tsRestart`, `complete`) and `stubCreated` / `tsExtensionFound` so we can tell what failed without parsing messages.
- Resets `tsRestarted` on failure so the next playground open retries. This matters on read-only extension installs (Snap, system package, locked enterprise) where the FS write can fail transiently.

### `fix(playground): exit worker after uncaughtException` (F-04)

`playgroundWorker.ts` previously reported the exception to the main thread and stayed alive with a potentially corrupted `mongoClient` / `shellRuntime`. Now the worker schedules `process.exit(1)` after a 50 ms delay to let the IPC error flush. `WorkerSessionManager` already rejects pending requests, emits `worker.unexpectedExit` telemetry, and respawns on the next eval, so the path is already well covered downstream.

## What this PR does not do

- Does not change the long-term plan to publish the TS plugin as a standalone npm package (#548).
- Does not change the 2 s magic sleep before `typescript.restartTsServer`; the new telemetry will tell us if that timing is actually a problem in the field.
- Does not address sovereign-cloud OIDC `ALLOWED_HOSTS` (tracked separately).

## Follow-up issues

Filed against the remaining audit findings:

- #637 (F-01 long-term hardening), #638 (F-02 sleep), #639 (F-03 sovereign clouds)
- #640 (F-05), #641 (F-06), #642 (F-07), #643 (F-09), #644 (F-11), #645 (F-08)

## Test plan

- Lint and tests should pass unchanged; this is a pure logic refactor of two narrow code paths.
- Manual: open a `.documentdb.js` playground; verify the bootstrap telemetry event fires once with `result=Succeeded`. Force a failure (chmod 0555 on the extension `node_modules/`) and verify `result=Failed` is emitted with `stage=stubInstall` and that opening a second playground retries.
- Manual: throw inside a playground eval (for example `process.nextTick(() => { throw new Error('boom'); })`); verify the worker exits, the error surfaces in the result panel, and the next Run respawns a fresh worker.
