### PR TITLE
docs: clarify getMongoClient caller

### DIFF
--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -341,8 +341,8 @@ export class ClustersClient {
 
     /**
      * Returns the underlying MongoClient instance.
-     * Used by the query playground evaluator to create a `@mongosh` ServiceProvider
-     * that reuses the existing, authenticated connection.
+     * Used by extension-host commands, such as query playground schema scanning,
+     * that need to reuse the existing, authenticated connection.
      */
     public getMongoClient(): MongoClient {
         return this._mongoClient;


### PR DESCRIPTION
## Summary
- update getMongoClient() JSDoc to describe its current extension-host schema-scan usage
- remove the misleading query playground evaluator / ServiceProvider wording

Fixes #643.

## Testing
- git diff --check