### PR TITLE
refactor: rename credentialId to clusterId in ClustersClient methods

### DIFF
--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -425,10 +425,10 @@ export class ClustersClient {
     }
 
     /**
-     * Determines whether a client for the given credential identifier is present in the internal cache.
+     * Determines whether a client for the given cluster ID is present in the internal cache.
      */
-    public static exists(credentialId: string): boolean {
-        return ClustersClient._clients.has(credentialId);
+    public static exists(clusterId: string): boolean {
+        return ClustersClient._clients.has(clusterId);
     }
 
     /**
@@ -441,14 +441,14 @@ export class ClustersClient {
         return ClustersClient._clients.get(clusterId);
     }
 
-    public static async deleteClient(credentialId: string): Promise<void> {
-        if (ClustersClient._clients.has(credentialId)) {
-            const client = ClustersClient._clients.get(credentialId) as ClustersClient;
+    public static async deleteClient(clusterId: string): Promise<void> {
+        if (ClustersClient._clients.has(clusterId)) {
+            const client = ClustersClient._clients.get(clusterId) as ClustersClient;
             await client._mongoClient.close(true);
-            ClustersClient._clients.delete(credentialId);
+            ClustersClient._clients.delete(clusterId);
 
             // Clear cached schema data for this cluster
-            SchemaStore.getInstance().clearCluster(credentialId);
+            SchemaStore.getInstance().clearCluster(clusterId);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #567.

Two methods in `ClustersClient.ts` used `credentialId` as the parameter name for what is semantically and architecturally a `clusterId`:

- `exists(credentialId: string)` → `exists(clusterId: string)`
- `deleteClient(credentialId: string)` → `deleteClient(clusterId: string)`

This was inconsistent with:
- The rest of `ClustersClient.ts`, which uses `clusterId` throughout
- `CredentialCache.ts`, which uses `clusterId` across all its methods
- The documented Cluster ID Architecture in `copilot-instructions.md`

No logic changes — purely a parameter rename. All existing call sites already passed `cluster.clusterId`, so no callers needed updating.

## Changes

- Renamed `credentialId` → `clusterId` in `exists()` signature and body
- Renamed `credentialId` → `clusterId` in `deleteClient()` signature and body (4 references)
- Updated JSDoc on `exists()` to reflect the correct parameter name

## Test plan

- [ ] No functional change — confirm existing tests pass
- [ ] Verify no remaining `credentialId` references in `ClustersClient.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)