### PR TITLE
refactor(ClustersClient): rename credentialId parameter to clusterId [reviewed]

### DIFF
--- a/src/documentdb/ClusterSession.ts
+++ b/src/documentdb/ClusterSession.ts
@@ -644,17 +644,17 @@ export class ClusterSession {
      * Initializes a new session for the MongoDB DocumentDB cluster.
      * Initializes a new session for the MongoDB DocumentDB cluster.
      *
-     * @param credentialId - The stable cluster identifier (clusterId) used to
+     * @param clusterId - The stable cluster identifier used to
      *   look up credentials and create a MongoDB client.
      *   - Connections View: storageId (UUID from ConnectionStorageService)
      *   - Azure Resources View: Azure Resource ID
      *   ⚠️ This is NOT the tree item ID - it must be the stable clusterId.
      * @returns A promise that resolves to the session ID of the newly created session.
      *
-     * @throws Will throw an error if the client cannot be obtained using the provided credential ID.
+     * @throws Will throw an error if the client cannot be obtained using the provided cluster ID.
      */
-    public static async initNewSession(credentialId: string): Promise<string> {
-        const client = await ClustersClient.getClient(credentialId);
+    public static async initNewSession(clusterId: string): Promise<string> {
+        const client = await ClustersClient.getClient(clusterId);
 
         const sessionId = Math.random().toString(16).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 

--- a/src/documentdb/ClusterSession.ts
+++ b/src/documentdb/ClusterSession.ts
@@ -712,7 +712,7 @@ export class ClusterSession {
 
         const sessionId = Math.random().toString(16).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 
-        const session = new ClusterSession(client, credentialId);
+        const session = new ClusterSession(client, clusterId);
 
         ClusterSession._sessions.set(sessionId, session);
 

--- a/src/documentdb/ClusterSession.ts
+++ b/src/documentdb/ClusterSession.ts
@@ -696,7 +696,6 @@ export class ClusterSession {
 
     /**
      * Initializes a new session for the MongoDB DocumentDB cluster.
-     * Initializes a new session for the MongoDB DocumentDB cluster.
      *
      * @param clusterId - The stable cluster identifier used to
      *   look up credentials and create a MongoDB client.

--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -396,17 +396,17 @@ export class ClustersClient {
     }
 
     /**
-     * Determines whether a client for the given credential identifier is present in the internal cache.
+     * Determines whether a client for the given cluster identifier is present in the internal cache.
      */
-    public static exists(credentialId: string): boolean {
-        return ClustersClient._clients.has(credentialId);
+    public static exists(clusterId: string): boolean {
+        return ClustersClient._clients.has(clusterId);
     }
 
-    public static async deleteClient(credentialId: string): Promise<void> {
-        if (ClustersClient._clients.has(credentialId)) {
-            const client = ClustersClient._clients.get(credentialId) as ClustersClient;
+    public static async deleteClient(clusterId: string): Promise<void> {
+        if (ClustersClient._clients.has(clusterId)) {
+            const client = ClustersClient._clients.get(clusterId) as ClustersClient;
             await client._mongoClient.close(true);
-            ClustersClient._clients.delete(credentialId);
+            ClustersClient._clients.delete(clusterId);
         }
     }
 

--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -425,7 +425,7 @@ export class ClustersClient {
     }
 
     /**
-     * Determines whether a client for the given cluster identifier is present in the internal cache.
+     * Determines whether a client for the given cluster ID is present in the internal cache.
      */
     public static exists(clusterId: string): boolean {
         return ClustersClient._clients.has(clusterId);


### PR DESCRIPTION
This PR finalizes the review of the contribution originally submitted by @CalvinMagezi in #568.

## What changed

Renames the `credentialId` parameter to `clusterId` in:

- `ClustersClient.exists()` (parameter, body, JSDoc)
- `ClustersClient.deleteClient()` (parameter, 4 body references, SchemaStore call)
- `ClusterSession.initNewSession()` (parameter, 2 body references, JSDoc `@param` and `@throws`)

This is a pure parameter rename with no logic changes. All callers already passed `cluster.clusterId`, so no call-site updates were needed.

## Maintainer additions on top of the original PR

- Resolved merge conflict with `next` (kept `getExistingClient()` and `SchemaStore.clearCluster()` that were added after #568 was opened)
- Fixed a missed rename: `ClusterSession.initNewSession()` body still referenced `credentialId` (caused a lint error)
- Applied more concise "cluster ID" wording in the `exists()` JSDoc (from #651, co-authored by @Enocko)
- Removed a duplicated JSDoc line in `ClusterSession.initNewSession()`

## Community credit

Three contributors independently submitted PRs for #567. All of their work informed the final result:

- #568 by @CalvinMagezi (Apr 11) - original contribution, merged into this branch
- #575 by @Jah-yee (Apr 14) - equivalent fix with thorough documentation
- #651 by @Enocko (May 17) - JSDoc wording improvement incorporated here

## Related

- Original PR: #568
- Duplicate (closed): #575, #651
- Closes #567