### PR TITLE
fix(webviews): resolve TDZ error on extension activation

### DIFF
--- a/src/webviews/_integration/appRouter.ts
+++ b/src/webviews/_integration/appRouter.ts
@@ -8,29 +8,22 @@
  * with a shared `commonRouter` exposing cross-webview procedures (telemetry
  * helpers, dialog helpers, survey hooks).
  *
- * This file is also the DocumentDB-flavoured adapter on top of the tRPC
- * primitives exported by `@microsoft/vscode-ext-react-webview`:
+ * The tRPC primitives (`publicProcedureWithTelemetry`, `WithTelemetry`, and
+ * the re-exports of `publicProcedure` / `router`) live in `./trpc.ts`, a
+ * leaf module that this file and every per-view router import from. Keeping
+ * them in a separate module avoids a circular import: `appRouter.ts`
+ * imports the per-view routers, so the per-view routers must not import
+ * value bindings back from `appRouter.ts`.
  *
- *   - `router` and `publicProcedure` are re-exported below for per-view
- *     routers to import from a single location.
- *   - `publicProcedureWithTelemetry` wraps `publicProcedure` with a
- *     middleware that forwards each call to the VS Code Azure telemetry
- *     pipeline using the `documentDB.rpc.*` event-name namespace.
- *   - `WithTelemetry<T>` re-types the `telemetry` slot on `ctx` to the
- *     richer `ITelemetryContext` so procedure code can access
- *     `suppressAll`, `suppressIfSuccessful`, etc. without ad-hoc casts.
+ * This file also defines the DocumentDB-flavoured `BaseRouterContext` used
+ * across procedures.
  *
  * You can read more about tRPC here:
  * https://trpc.io/docs/quickstart
  */
 
-import { callWithTelemetryAndErrorHandling, type ITelemetryContext } from '@microsoft/vscode-azext-utils';
-import {
-    createMiddleware,
-    publicProcedure,
-    router,
-    type BaseRouterContext as FrameworkBaseRouterContext,
-} from '@microsoft/vscode-ext-react-webview/server';
+import { callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
+import { type BaseRouterContext as FrameworkBaseRouterContext } from '@microsoft/vscode-ext-react-webview/server';
 import * as vscode from 'vscode';
 import { z } from 'zod';
 import { type API } from '../../DocumentDBExperiences';
@@ -40,87 +33,12 @@ import { UsageImpact } from '../../utils/surveyTypes';
 import { collectionsViewRouter as collectionViewRouter } from '../documentdb/collectionView/collectionViewRouter';
 import { documentsViewRouter as documentViewRouter } from '../documentdb/documentView/documentsViewRouter';
 import { WEBVIEW_CONFIG } from './configuration';
+import { publicProcedure, publicProcedureWithTelemetry, router, type WithTelemetry } from './trpc';
 
-/**
- * DocumentDB-flavoured replacement for the package's `WithTelemetry<T>` helper.
- *
- * The package types `telemetry` as its generic `TelemetryContext`
- * (`{ properties; measurements }`). In this extension, the runtime value is
- * always the richer `ITelemetryContext` from `@microsoft/vscode-azext-utils`
- * (provides `suppressAll`, `suppressIfSuccessful`, etc.). Re-typing the helper
- * here lets procedure code access those fields without ad-hoc casts.
- */
-export type WithTelemetry<T extends { telemetry?: unknown }> = Omit<T, 'telemetry'> & {
-    telemetry: ITelemetryContext;
-};
-
-/**
- * Telemetry middleware that forwards every tRPC call to the VS Code Azure
- * telemetry pipeline. Event names follow the `documentDB.rpc.${type}.${path}`
- * convention.
- */
-const trpcToTelemetry = createMiddleware(async (opts) => {
-    const result = await callWithTelemetryAndErrorHandling(
-        `${WEBVIEW_CONFIG.telemetry.rpcEventPrefix}.${opts.type}.${opts.path}`,
-        async (context) => {
-            context.errorHandling.suppressDisplay = true;
-
-            const result = await opts.next({
-                ctx: {
-                    ...opts.ctx,
-                    telemetry: context.telemetry,
-                },
-            });
-
-            // Check if the operation was aborted via AbortSignal
-            const signal = (opts.ctx as FrameworkBaseRouterContext).signal;
-            if (signal?.aborted) {
-                context.telemetry.properties.aborted = 'true';
-                context.telemetry.properties.result = 'Canceled';
-            }
-
-            if (!result.ok) {
-                /**
-                 * we're not handling any error here as we just want to log it here and let the
-                 * caller of the RPC call handle the error there.
-                 */
-
-                if (!signal?.aborted) {
-                    context.telemetry.properties.result = 'Failed';
-                }
-                context.telemetry.properties.error = result.error.name;
-                context.telemetry.properties.errorMessage = result.error.message;
-                context.telemetry.properties.errorStack = result.error.stack ?? '';
-                if (result.error.cause) {
-                    context.telemetry.properties.errorCause = JSON.stringify(result.error.cause, null, 0);
-                }
-            }
-
-            return result;
-        },
-    );
-
-    if (!result) {
-        // This should never happen, but TypeScript requires us to handle the case where result is undefined.
-        throw new Error(`No result returned from tRPC call for ${opts.type} ${opts.path}`);
-    }
-
-    return result;
-});
-
-/**
- * Base procedure that automatically attaches DocumentDB Azure telemetry context.
- *
- * Use this instead of {@link publicProcedure} when you want every call to be
- * tracked. The `telemetry` object is available on `ctx` inside your procedure
- * handlers (cast with `WithTelemetry<YourContext>`).
- */
-export const publicProcedureWithTelemetry = publicProcedure.use(trpcToTelemetry);
-
-// Re-export the unprotected procedure builder and router factory so per-view
-// routers have a single import location for everything they need to declare
-// tRPC procedures.
-export { publicProcedure, router };
+// Re-export tRPC primitives for backward compatibility with existing imports.
+// Prefer importing directly from `./trpc` in new code.
+export { publicProcedure, publicProcedureWithTelemetry, router };
+export type { WithTelemetry };
 
 /**
  * DocumentDB-flavoured router context. Extends the framework's

--- a/src/webviews/_integration/trpc.ts
+++ b/src/webviews/_integration/trpc.ts
@@ -41,7 +41,7 @@
  *     have a single import location for everything they need.
  */
 
-import { callWithTelemetryAndErrorHandling, type ITelemetryContext } from '@microsoft/vscode-azext-utils';
+import { callWithTelemetryAndErrorHandling, parseError, type ITelemetryContext } from '@microsoft/vscode-azext-utils';
 import {
     createMiddleware,
     publicProcedure,
@@ -97,11 +97,17 @@ const trpcToTelemetry = createMiddleware(async (opts) => {
                 if (!signal?.aborted) {
                     context.telemetry.properties.result = 'Failed';
                 }
-                context.telemetry.properties.error = result.error.name;
-                context.telemetry.properties.errorMessage = result.error.message;
+
+                // Use the same `parseError` helper the rest of the codebase uses so that
+                // non-enumerable Error fields (message/name/stack) are read correctly and
+                // we never throw from the telemetry path (e.g. on circular `cause` chains,
+                // which JSON.stringify would have thrown on).
+                const parsed = parseError(result.error);
+                context.telemetry.properties.error = parsed.errorType;
+                context.telemetry.properties.errorMessage = parsed.message;
                 context.telemetry.properties.errorStack = result.error.stack ?? '';
                 if (result.error.cause) {
-                    context.telemetry.properties.errorCause = JSON.stringify(result.error.cause, null, 0);
+                    context.telemetry.properties.errorCause = parseError(result.error.cause).message;
                 }
             }
 

--- a/src/webviews/_integration/trpc.ts
+++ b/src/webviews/_integration/trpc.ts
@@ -1,0 +1,132 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Leaf module that exposes the tRPC primitives every per-view router needs.
+ *
+ * This file is intentionally a leaf in the module graph: it imports from the
+ * framework package and from a few small helpers, but it **must not** import
+ * from `appRouter.ts` or from any per-view router. Doing so would create a
+ * circular import chain:
+ *
+ *   appRouter.ts  ->  collectionViewRouter.ts  ->  appRouter.ts
+ *
+ * which produces the runtime error
+ *
+ *   "Cannot access 'publicProcedureWithTelemetry' before initialization"
+ *
+ * because the per-view router executes at the top level (using
+ * `publicProcedureWithTelemetry` to declare its procedures) while
+ * `appRouter.ts` is still mid-evaluation and has not reached its own
+ * `export const publicProcedureWithTelemetry = ...` line yet.
+ *
+ * Keeping the primitives here breaks the cycle: per-view routers import
+ * value bindings (`publicProcedureWithTelemetry`, `router`) from this file,
+ * `appRouter.ts` also imports from this file, and nothing here imports
+ * back from `appRouter.ts`.
+ *
+ * What lives here:
+ *   - `trpcToTelemetry`: middleware that forwards each call to the VS Code
+ *     Azure telemetry pipeline using the `documentDB.rpc.*` event-name
+ *     namespace.
+ *   - `publicProcedureWithTelemetry`: `publicProcedure.use(trpcToTelemetry)`.
+ *     Use this instead of `publicProcedure` when you want the call to be
+ *     tracked automatically.
+ *   - `WithTelemetry<T>`: re-types the `telemetry` slot on `ctx` to the
+ *     richer `ITelemetryContext` so procedure code can access
+ *     `suppressAll`, `suppressIfSuccessful`, etc. without ad-hoc casts.
+ *   - Re-exports of `publicProcedure` and `router` so per-view routers
+ *     have a single import location for everything they need.
+ */
+
+import { callWithTelemetryAndErrorHandling, type ITelemetryContext } from '@microsoft/vscode-azext-utils';
+import {
+    createMiddleware,
+    publicProcedure,
+    router,
+    type BaseRouterContext as FrameworkBaseRouterContext,
+} from '@microsoft/vscode-ext-react-webview/server';
+import { WEBVIEW_CONFIG } from './configuration';
+
+/**
+ * DocumentDB-flavoured replacement for the package's `WithTelemetry<T>` helper.
+ *
+ * The package types `telemetry` as its generic `TelemetryContext`
+ * (`{ properties; measurements }`). In this extension, the runtime value is
+ * always the richer `ITelemetryContext` from `@microsoft/vscode-azext-utils`
+ * (provides `suppressAll`, `suppressIfSuccessful`, etc.). Re-typing the helper
+ * here lets procedure code access those fields without ad-hoc casts.
+ */
+export type WithTelemetry<T extends { telemetry?: unknown }> = Omit<T, 'telemetry'> & {
+    telemetry: ITelemetryContext;
+};
+
+/**
+ * Telemetry middleware that forwards every tRPC call to the VS Code Azure
+ * telemetry pipeline. Event names follow the `documentDB.rpc.${type}.${path}`
+ * convention.
+ */
+const trpcToTelemetry = createMiddleware(async (opts) => {
+    const result = await callWithTelemetryAndErrorHandling(
+        `${WEBVIEW_CONFIG.telemetry.rpcEventPrefix}.${opts.type}.${opts.path}`,
+        async (context) => {
+            context.errorHandling.suppressDisplay = true;
+
+            const result = await opts.next({
+                ctx: {
+                    ...opts.ctx,
+                    telemetry: context.telemetry,
+                },
+            });
+
+            // Check if the operation was aborted via AbortSignal
+            const signal = (opts.ctx as FrameworkBaseRouterContext).signal;
+            if (signal?.aborted) {
+                context.telemetry.properties.aborted = 'true';
+                context.telemetry.properties.result = 'Canceled';
+            }
+
+            if (!result.ok) {
+                /**
+                 * we're not handling any error here as we just want to log it here and let the
+                 * caller of the RPC call handle the error there.
+                 */
+
+                if (!signal?.aborted) {
+                    context.telemetry.properties.result = 'Failed';
+                }
+                context.telemetry.properties.error = result.error.name;
+                context.telemetry.properties.errorMessage = result.error.message;
+                context.telemetry.properties.errorStack = result.error.stack ?? '';
+                if (result.error.cause) {
+                    context.telemetry.properties.errorCause = JSON.stringify(result.error.cause, null, 0);
+                }
+            }
+
+            return result;
+        },
+    );
+
+    if (!result) {
+        // This should never happen, but TypeScript requires us to handle the case where result is undefined.
+        throw new Error(`No result returned from tRPC call for ${opts.type} ${opts.path}`);
+    }
+
+    return result;
+});
+
+/**
+ * Base procedure that automatically attaches DocumentDB Azure telemetry context.
+ *
+ * Use this instead of {@link publicProcedure} when you want every call to be
+ * tracked. The `telemetry` object is available on `ctx` inside your procedure
+ * handlers (cast with `WithTelemetry<YourContext>`).
+ */
+export const publicProcedureWithTelemetry = publicProcedure.use(trpcToTelemetry);
+
+// Re-export the unprotected procedure builder and router factory so per-view
+// routers have a single import location for everything they need to declare
+// tRPC procedures.
+export { publicProcedure, router };

--- a/src/webviews/documentdb/collectionView/collectionViewRouter.ts
+++ b/src/webviews/documentdb/collectionView/collectionViewRouter.ts
@@ -13,7 +13,7 @@ import { z } from 'zod';
 import { ClusterSession } from '../../../documentdb/ClusterSession';
 import { ShellCommandIds } from '../../../documentdb/shell/constants';
 import { getConfirmationAsInSettings } from '../../../utils/dialogs/getConfirmation';
-import { publicProcedureWithTelemetry, router, type WithTelemetry } from '../../_integration/appRouter';
+import { publicProcedureWithTelemetry, router, type WithTelemetry } from '../../_integration/trpc';
 
 import * as l10n from '@vscode/l10n';
 import { type QueryObject } from '../../../commands/llmEnhancedCommands/indexAdvisorCommands';

--- a/src/webviews/documentdb/documentView/documentsViewRouter.ts
+++ b/src/webviews/documentdb/documentView/documentsViewRouter.ts
@@ -11,13 +11,8 @@ import { ClustersClient } from '../../../documentdb/ClustersClient';
 import { showConfirmationAsInSettings } from '../../../utils/dialogs/showConfirmation';
 import { promptAfterActionEventually } from '../../../utils/survey';
 import { UsageImpact } from '../../../utils/surveyTypes';
-import {
-    publicProcedure,
-    publicProcedureWithTelemetry,
-    router,
-    type BaseRouterContext,
-    type WithTelemetry,
-} from '../../_integration/appRouter';
+import { type BaseRouterContext } from '../../_integration/appRouter';
+import { publicProcedure, publicProcedureWithTelemetry, router, type WithTelemetry } from '../../_integration/trpc';
 
 export type RouterContext = BaseRouterContext & {
     /**


### PR DESCRIPTION
## Problem

After #676 landed, extension activation started failing with:

```
Activating extension 'ms-azuretools.vscode-documentdb' failed: Cannot access 'publicProcedureWithTelemetry' before initialization.
```

That refactor merged the old `trpc.ts` into `appRouter.ts`. The result was a circular module-evaluation chain:

```
appRouter.ts
  -> imports collectionViewRouter (line 41)
       collectionViewRouter.ts
         -> imports publicProcedureWithTelemetry from appRouter.ts (line 16)
            ... appRouter.ts is still mid-evaluation and has not yet reached
                line 118 where publicProcedureWithTelemetry is defined -> TDZ
```

The build did not catch it because TypeScript does not flag circular value imports across modules; the failure only surfaces at runtime when the per-view router accesses the binding at module top-level.

## Fix

Two small commits:

1. **`refactor(webviews): extract tRPC primitives into leaf trpc.ts module`** - moves `trpcToTelemetry`, `publicProcedureWithTelemetry`, `WithTelemetry`, and the `publicProcedure` / `router` re-exports out of `appRouter.ts` into a new leaf module `src/webviews/_integration/trpc.ts`. Nothing else in `_integration/` imports the per-view routers, so this module sits at the bottom of the graph and cannot be in a cycle. `appRouter.ts` still re-exports the same names so this commit is non-breaking on its own.
2. **`fix(webviews): import tRPC value bindings from trpc.ts to break cycle`** - switches `collectionViewRouter.ts` and `documentsViewRouter.ts` to import the value bindings (`publicProcedure`, `publicProcedureWithTelemetry`, `router`) and the `WithTelemetry` type directly from `./trpc` instead of `./appRouter`. The type-only import of `BaseRouterContext` from `appRouter.ts` stays - type-only imports are erased at runtime and do not participate in module-evaluation cycles.

## Validation

- `npm run build` clean
- `npx jest --no-coverage` 1923/1923 tests pass (the two failed suites are unrelated worker SIGKILL flakes, no test assertions failed)
- Manual extension activation succeeds

## Notes

- No behaviour change: same exports, same telemetry middleware, same event-name namespace.
- Related: #676 (Webview API package preview hardening and consumer reshape) introduced commit 45f117f5 which created the cycle.
