### PR TITLE
perf(tree): throttle background document-count fetches

### DIFF
--- a/src/tree/documentdb/CollectionItem.ts
+++ b/src/tree/documentdb/CollectionItem.ts
@@ -46,14 +46,13 @@ function escapeMarkdown(text: string): string {
  * Keyed by `clusterId` (the stable cache key) so each cluster gets an
  * independent pool.
  */
-const DOCUMENT_COUNT_CONCURRENCY = 5;
 const documentCountLimiters = new Map<string, LimitedRunner>();
 
 function getDocumentCountLimiter(clusterId: string): LimitedRunner {
     let limiter = documentCountLimiters.get(clusterId);
     if (!limiter) {
         limiter = createConcurrencyLimiter({
-            concurrency: DOCUMENT_COUNT_CONCURRENCY,
+            concurrency: 5,
         });
         documentCountLimiters.set(clusterId, limiter);
     }

--- a/src/tree/documentdb/CollectionItem.ts
+++ b/src/tree/documentdb/CollectionItem.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import { ClustersClient, type CollectionItemModel, type DatabaseItemModel } from '../../documentdb/ClustersClient';
 import { type Experience } from '../../DocumentDBExperiences';
 import { ext } from '../../extensionVariables';
+import { createConcurrencyLimiter, type LimitedRunner } from '../../utils/concurrencyLimiter';
 import { formatDocumentCount } from '../../utils/formatDocumentCount';
 import { type BaseClusterModel, type TreeCluster } from '../models/BaseClusterModel';
 import { type TreeElement } from '../TreeElement';
@@ -23,6 +24,36 @@ import { IndexesItem } from './IndexesItem';
  */
 function escapeMarkdown(text: string): string {
     return text.replace(/[\\`*_{}[\]()#+\-.!|~]/g, '\\$&');
+}
+
+/**
+ * Per-cluster limiter for background document-count fetches.
+ *
+ * Tree expansion can trigger one `estimateDocumentCount` call per collection,
+ * which for databases with many collections produces a burst of concurrent
+ * requests that:
+ *   - opens many sockets in the MongoDB driver's connection pool, and
+ *   - competes with foreground operations (queries, the collection view) for
+ *     pool slots and server resources.
+ *
+ * We cap concurrent count fetches per cluster and add a small delay between
+ * dispatches so this background work stays unobtrusive. Keyed by `clusterId`
+ * (the stable cache key) so each cluster gets an independent pool.
+ */
+const DOCUMENT_COUNT_CONCURRENCY = 5;
+const DOCUMENT_COUNT_INTER_BATCH_DELAY_MS = 250;
+const documentCountLimiters = new Map<string, LimitedRunner>();
+
+function getDocumentCountLimiter(clusterId: string): LimitedRunner {
+    let limiter = documentCountLimiters.get(clusterId);
+    if (!limiter) {
+        limiter = createConcurrencyLimiter({
+            concurrency: DOCUMENT_COUNT_CONCURRENCY,
+            interBatchDelayMs: DOCUMENT_COUNT_INTER_BATCH_DELAY_MS,
+        });
+        documentCountLimiters.set(clusterId, limiter);
+    }
+    return limiter;
 }
 
 export class CollectionItem implements TreeElement, TreeElementWithExperience, TreeElementWithContextValue {
@@ -75,9 +106,12 @@ export class CollectionItem implements TreeElement, TreeElementWithExperience, T
      * Fetches the document count and triggers a tree refresh when complete.
      */
     private async fetchAndUpdateCount(): Promise<void> {
+        const limit = getDocumentCountLimiter(this.cluster.clusterId);
         try {
-            const client = await ClustersClient.getClient(this.cluster.clusterId);
-            this.documentCount = await client.estimateDocumentCount(this.databaseInfo.name, this.collectionInfo.name);
+            this.documentCount = await limit(async () => {
+                const client = await ClustersClient.getClient(this.cluster.clusterId);
+                return client.estimateDocumentCount(this.databaseInfo.name, this.collectionInfo.name);
+            });
         } catch {
             // On error, set to null to indicate failure (we won't retry automatically)
             this.documentCount = null;

--- a/src/tree/documentdb/CollectionItem.ts
+++ b/src/tree/documentdb/CollectionItem.ts
@@ -81,6 +81,15 @@ export class CollectionItem implements TreeElement, TreeElementWithExperience, T
         readonly cluster: TreeCluster<BaseClusterModel>,
         readonly databaseInfo: DatabaseItemModel,
         readonly collectionInfo: CollectionItemModel,
+        /**
+         * Stale-check predicate. The owning DatabaseItem hands in a function
+         * that returns true only while this CollectionItem belongs to the
+         * current expansion. When the user refreshes / collapses / re-expands
+         * the database, the predicate flips to false and any queued or
+         * in-flight document-count work bails out before mutating state.
+         * Defaults to always-current so direct callers are unaffected.
+         */
+        private readonly isCurrent: () => boolean = () => true,
     ) {
         this.id = `${cluster.treeId}/${databaseInfo.name}/${collectionInfo.name}`;
         this.experience = cluster.dbExperience;
@@ -110,19 +119,34 @@ export class CollectionItem implements TreeElement, TreeElementWithExperience, T
      */
     private async fetchAndUpdateCount(): Promise<void> {
         const limit = getDocumentCountLimiter(this.cluster.clusterId);
+        let result: number | null;
         try {
-            this.documentCount = await limit(async () => {
+            result = await limit(async () => {
+                // Stale-check at dispatch time: if this CollectionItem no
+                // longer belongs to the current expansion (refresh / collapse
+                // / re-expand happened while we were queued), skip the work.
+                if (!this.isCurrent()) {
+                    return null;
+                }
                 const client = await ClustersClient.getClient(this.cluster.clusterId);
                 return client.estimateDocumentCount(this.databaseInfo.name, this.collectionInfo.name);
             });
         } catch {
-            // On error, set to null to indicate failure (we won't retry automatically)
-            this.documentCount = null;
-        } finally {
-            this.isLoadingCount = false;
-            // Trigger a tree item refresh to show the updated description
-            ext.state.notifyChildrenChanged(this.id);
+            // On error, fall through and let the post-await stale-check decide
+            // whether to record the failure on this instance.
+            result = null;
         }
+
+        if (!this.isCurrent()) {
+            // Stale: do not write back to this instance and do not fire a
+            // tree refresh. The current instance owns the UI state.
+            return;
+        }
+
+        this.isLoadingCount = false;
+        this.documentCount = result;
+        // Trigger a tree item refresh to show the updated description
+        ext.state.notifyChildrenChanged(this.id);
     }
 
     async getChildren(): Promise<TreeElement[]> {

--- a/src/tree/documentdb/CollectionItem.ts
+++ b/src/tree/documentdb/CollectionItem.ts
@@ -11,20 +11,13 @@ import { type Experience } from '../../DocumentDBExperiences';
 import { ext } from '../../extensionVariables';
 import { createConcurrencyLimiter, type LimitedRunner } from '../../utils/concurrencyLimiter';
 import { formatDocumentCount } from '../../utils/formatDocumentCount';
+import { escapeMarkdown } from '../../webviews/utils/escapeMarkdown';
 import { type BaseClusterModel, type TreeCluster } from '../models/BaseClusterModel';
 import { type TreeElement } from '../TreeElement';
 import { type TreeElementWithContextValue } from '../TreeElementWithContextValue';
 import { type TreeElementWithExperience } from '../TreeElementWithExperience';
 import { DocumentsItem } from './DocumentsItem';
 import { IndexesItem } from './IndexesItem';
-
-/**
- * Escapes markdown special characters so user-provided text is always rendered
- * as plain text rather than being interpreted as markdown formatting or links.
- */
-function escapeMarkdown(text: string): string {
-    return text.replace(/[\\`*_{}[\]()#+\-.!|~]/g, '\\$&');
-}
 
 /**
  * Per-cluster limiter for background document-count fetches.

--- a/src/tree/documentdb/CollectionItem.ts
+++ b/src/tree/documentdb/CollectionItem.ts
@@ -29,19 +29,13 @@ function escapeMarkdown(text: string): string {
 /**
  * Per-cluster limiter for background document-count fetches.
  *
- * Tree expansion can trigger one `estimateDocumentCount` call per collection,
- * which for databases with many collections produces a burst of concurrent
- * requests that:
- *   - opens many sockets in the MongoDB driver's connection pool, and
- *   - competes with foreground operations (queries, the collection view) for
- *     pool slots and server resources.
+ * Tree expansion can trigger one `estimateDocumentCount` call per collection.
+ * For databases with many collections that produces a burst of concurrent
+ * requests that opens many sockets and competes with foreground operations
+ * (queries, the collection view) for connection pool slots.
  *
- * Strategy: a plain semaphore. We cap the number of in-flight count requests
- * per cluster at `DOCUMENT_COUNT_CONCURRENCY`. As soon as one request
- * completes, the next queued one starts — no batches, no inter-batch delay.
- * This keeps the pipe smoothly busy without ever exceeding the cap, which is
- * what we actually want for slow operations: the server is never hit by more
- * than N concurrent counts, and we never sit idle while there is queued work.
+ * Strategy: a plain semaphore capped at 5 in-flight count requests per
+ * cluster. As soon as one finishes, the next queued one starts.
  *
  * Keyed by `clusterId` (the stable cache key) so each cluster gets an
  * independent pool.

--- a/src/tree/documentdb/CollectionItem.ts
+++ b/src/tree/documentdb/CollectionItem.ts
@@ -118,18 +118,28 @@ export class CollectionItem implements TreeElement, TreeElementWithExperience, T
      * Fetches the document count and triggers a tree refresh when complete.
      */
     private async fetchAndUpdateCount(): Promise<void> {
-        const limit = getDocumentCountLimiter(this.cluster.clusterId);
+        // Capture primitives and the stale-check closure into locals so the
+        // task we hand to the limiter does not capture `this`. The outer
+        // async frame still references `this` (it is an instance method), but
+        // the inner task that the limiter holds while it is queued only pins
+        // these few strings plus the small isCurrent closure.
+        const clusterId = this.cluster.clusterId;
+        const dbName = this.databaseInfo.name;
+        const collName = this.collectionInfo.name;
+        const isCurrent = this.isCurrent;
+        const limit = getDocumentCountLimiter(clusterId);
+
         let result: number | null;
         try {
             result = await limit(async () => {
                 // Stale-check at dispatch time: if this CollectionItem no
                 // longer belongs to the current expansion (refresh / collapse
                 // / re-expand happened while we were queued), skip the work.
-                if (!this.isCurrent()) {
+                if (!isCurrent()) {
                     return null;
                 }
-                const client = await ClustersClient.getClient(this.cluster.clusterId);
-                return client.estimateDocumentCount(this.databaseInfo.name, this.collectionInfo.name);
+                const client = await ClustersClient.getClient(clusterId);
+                return client.estimateDocumentCount(dbName, collName);
             });
         } catch {
             // On error, fall through and let the post-await stale-check decide
@@ -137,7 +147,7 @@ export class CollectionItem implements TreeElement, TreeElementWithExperience, T
             result = null;
         }
 
-        if (!this.isCurrent()) {
+        if (!isCurrent()) {
             // Stale: do not write back to this instance and do not fire a
             // tree refresh. The current instance owns the UI state.
             return;

--- a/src/tree/documentdb/CollectionItem.ts
+++ b/src/tree/documentdb/CollectionItem.ts
@@ -36,12 +36,17 @@ function escapeMarkdown(text: string): string {
  *   - competes with foreground operations (queries, the collection view) for
  *     pool slots and server resources.
  *
- * We cap concurrent count fetches per cluster and add a small delay between
- * dispatches so this background work stays unobtrusive. Keyed by `clusterId`
- * (the stable cache key) so each cluster gets an independent pool.
+ * Strategy: a plain semaphore. We cap the number of in-flight count requests
+ * per cluster at `DOCUMENT_COUNT_CONCURRENCY`. As soon as one request
+ * completes, the next queued one starts — no batches, no inter-batch delay.
+ * This keeps the pipe smoothly busy without ever exceeding the cap, which is
+ * what we actually want for slow operations: the server is never hit by more
+ * than N concurrent counts, and we never sit idle while there is queued work.
+ *
+ * Keyed by `clusterId` (the stable cache key) so each cluster gets an
+ * independent pool.
  */
 const DOCUMENT_COUNT_CONCURRENCY = 5;
-const DOCUMENT_COUNT_INTER_BATCH_DELAY_MS = 250;
 const documentCountLimiters = new Map<string, LimitedRunner>();
 
 function getDocumentCountLimiter(clusterId: string): LimitedRunner {
@@ -49,7 +54,6 @@ function getDocumentCountLimiter(clusterId: string): LimitedRunner {
     if (!limiter) {
         limiter = createConcurrencyLimiter({
             concurrency: DOCUMENT_COUNT_CONCURRENCY,
-            interBatchDelayMs: DOCUMENT_COUNT_INTER_BATCH_DELAY_MS,
         });
         documentCountLimiters.set(clusterId, limiter);
     }

--- a/src/tree/documentdb/DatabaseItem.ts
+++ b/src/tree/documentdb/DatabaseItem.ts
@@ -8,19 +8,12 @@ import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
 import { ClustersClient, type DatabaseItemModel } from '../../documentdb/ClustersClient';
 import { type Experience } from '../../DocumentDBExperiences';
+import { escapeMarkdown } from '../../webviews/utils/escapeMarkdown';
 import { type BaseClusterModel, type TreeCluster } from '../models/BaseClusterModel';
 import { type TreeElement } from '../TreeElement';
 import { type TreeElementWithContextValue } from '../TreeElementWithContextValue';
 import { type TreeElementWithExperience } from '../TreeElementWithExperience';
 import { CollectionItem } from './CollectionItem';
-
-/**
- * Escapes markdown special characters so user-provided text is always rendered
- * as plain text rather than being interpreted as markdown formatting or links.
- */
-function escapeMarkdown(text: string): string {
-    return text.replace(/[\\`*_{}[\]()#+\-.!|~]/g, '\\$&');
-}
 
 export class DatabaseItem implements TreeElement, TreeElementWithExperience, TreeElementWithContextValue {
     public readonly id: string;

--- a/src/tree/documentdb/DatabaseItem.ts
+++ b/src/tree/documentdb/DatabaseItem.ts
@@ -68,19 +68,15 @@ export class DatabaseItem implements TreeElement, TreeElementWithExperience, Tre
             ];
         }
 
-        // Sort collections alphabetically by name BEFORE kicking off background
-        // count loads. This is intentional and important for UI stability:
-        // counts are dispatched through a per-cluster concurrency limiter (FIFO),
-        // so the order in which we enqueue them is the order in which they will
-        // be fetched and displayed. Sorting first means counts populate
-        // predictably from the top of the visible list downward, instead of
-        // appearing "at random" relative to what the user actually sees.
+        // Sort collections alphabetically by name before kicking off background
+        // count loads. The per-cluster limiter dispatches in FIFO order, so
+        // sorting first means counts are requested in alphabetical order.
+        // Completion order still depends on per-request latency and may differ.
         collections.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
 
         return collections.map((collection) => {
             const collectionItem = new CollectionItem(this.cluster, this.databaseInfo, collection, isCurrent);
             // Start loading document count in background (fire-and-forget).
-            // Does not block tree expansion. See sort above: enqueue order = display order.
             collectionItem.loadDocumentCount();
             return collectionItem;
         });

--- a/src/tree/documentdb/DatabaseItem.ts
+++ b/src/tree/documentdb/DatabaseItem.ts
@@ -29,6 +29,14 @@ export class DatabaseItem implements TreeElement, TreeElementWithExperience, Tre
 
     private readonly experienceContextValue: string = '';
 
+    /**
+     * Monotonic counter bumped on every `getChildren` call. Used to invalidate
+     * background document-count work owned by stale CollectionItem instances
+     * (refresh / collapse / re-expand creates fresh instances; we want the
+     * previous ones to bail before mutating UI state or hitting the server).
+     */
+    private expansionGeneration = 0;
+
     constructor(
         readonly cluster: TreeCluster<BaseClusterModel>,
         readonly databaseInfo: DatabaseItemModel,
@@ -40,6 +48,9 @@ export class DatabaseItem implements TreeElement, TreeElementWithExperience, Tre
     }
 
     async getChildren(): Promise<TreeElement[]> {
+        const myGeneration = ++this.expansionGeneration;
+        const isCurrent = (): boolean => this.expansionGeneration === myGeneration;
+
         const client: ClustersClient = await ClustersClient.getClient(this.cluster.clusterId);
         const collections = await client.listCollections(this.databaseInfo.name);
 
@@ -67,7 +78,7 @@ export class DatabaseItem implements TreeElement, TreeElementWithExperience, Tre
         collections.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
 
         return collections.map((collection) => {
-            const collectionItem = new CollectionItem(this.cluster, this.databaseInfo, collection);
+            const collectionItem = new CollectionItem(this.cluster, this.databaseInfo, collection, isCurrent);
             // Start loading document count in background (fire-and-forget).
             // Does not block tree expansion. See sort above: enqueue order = display order.
             collectionItem.loadDocumentCount();

--- a/src/tree/documentdb/DatabaseItem.ts
+++ b/src/tree/documentdb/DatabaseItem.ts
@@ -57,13 +57,19 @@ export class DatabaseItem implements TreeElement, TreeElementWithExperience, Tre
             ];
         }
 
-        // Sort collections alphabetically by name
+        // Sort collections alphabetically by name BEFORE kicking off background
+        // count loads. This is intentional and important for UI stability:
+        // counts are dispatched through a per-cluster concurrency limiter (FIFO),
+        // so the order in which we enqueue them is the order in which they will
+        // be fetched and displayed. Sorting first means counts populate
+        // predictably from the top of the visible list downward, instead of
+        // appearing "at random" relative to what the user actually sees.
         collections.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
 
         return collections.map((collection) => {
             const collectionItem = new CollectionItem(this.cluster, this.databaseInfo, collection);
-            // Start loading document count in background (fire-and-forget)
-            // This does not block tree expansion
+            // Start loading document count in background (fire-and-forget).
+            // Does not block tree expansion. See sort above: enqueue order = display order.
             collectionItem.loadDocumentCount();
             return collectionItem;
         });

--- a/src/utils/concurrencyLimiter.test.ts
+++ b/src/utils/concurrencyLimiter.test.ts
@@ -1,0 +1,248 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createConcurrencyLimiter } from './concurrencyLimiter';
+
+/**
+ * Returns `{ promise, resolve, reject }` for an externally-resolvable promise.
+ * Used to construct tasks whose completion the test controls precisely.
+ */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (err: unknown) => void } {
+    let resolve!: (value: T) => void;
+    let reject!: (err: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+/**
+ * Flush pending microtasks so that synchronously-resolved awaits propagate
+ * through the limiter's state machine before the test inspects counters.
+ */
+async function flush(): Promise<void> {
+    // A couple of macrotask-boundary flushes is plenty: the limiter only uses
+    // promise microtasks, no timers.
+    for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+    }
+}
+
+describe('createConcurrencyLimiter', () => {
+    describe('cap enforcement', () => {
+        it('never lets more than `concurrency` tasks run in parallel', async () => {
+            const limit = createConcurrencyLimiter({ concurrency: 3 });
+            let active = 0;
+            let peak = 0;
+
+            const gates = Array.from({ length: 10 }, () => deferred<void>());
+
+            const runs = gates.map((gate, i) =>
+                limit(async () => {
+                    active++;
+                    if (active > peak) {
+                        peak = active;
+                    }
+                    await gate.promise;
+                    active--;
+                    return i;
+                }),
+            );
+
+            await flush();
+            expect(active).toBe(3);
+            expect(peak).toBe(3);
+
+            // Release tasks one at a time and verify cap stays respected.
+            for (const gate of gates) {
+                gate.resolve();
+                await flush();
+                expect(active).toBeLessThanOrEqual(3);
+                expect(peak).toBe(3);
+            }
+
+            const results = await Promise.all(runs);
+            expect(results).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            expect(peak).toBe(3);
+        });
+
+        it('clamps concurrency to at least 1', async () => {
+            const limit = createConcurrencyLimiter({ concurrency: 0 });
+            let active = 0;
+            let peak = 0;
+
+            const gates = Array.from({ length: 3 }, () => deferred<void>());
+
+            const runs = gates.map((gate) =>
+                limit(async () => {
+                    active++;
+                    if (active > peak) {
+                        peak = active;
+                    }
+                    await gate.promise;
+                    active--;
+                }),
+            );
+
+            await flush();
+            expect(active).toBe(1);
+            expect(peak).toBe(1);
+
+            for (const gate of gates) {
+                gate.resolve();
+                await flush();
+            }
+            await Promise.all(runs);
+            expect(peak).toBe(1);
+        });
+
+        it('rounds fractional concurrency down', async () => {
+            const limit = createConcurrencyLimiter({ concurrency: 2.9 });
+            let active = 0;
+            let peak = 0;
+
+            const gates = Array.from({ length: 4 }, () => deferred<void>());
+
+            const runs = gates.map((gate) =>
+                limit(async () => {
+                    active++;
+                    if (active > peak) {
+                        peak = active;
+                    }
+                    await gate.promise;
+                    active--;
+                }),
+            );
+
+            await flush();
+            expect(peak).toBe(2);
+
+            for (const gate of gates) {
+                gate.resolve();
+                await flush();
+            }
+            await Promise.all(runs);
+        });
+    });
+
+    describe('FIFO dispatch', () => {
+        it('dispatches queued tasks in enqueue order', async () => {
+            const limit = createConcurrencyLimiter({ concurrency: 1 });
+            const dispatchOrder: number[] = [];
+            const gates = Array.from({ length: 5 }, () => deferred<void>());
+
+            const runs = gates.map((gate, i) =>
+                limit(async () => {
+                    dispatchOrder.push(i);
+                    await gate.promise;
+                    return i;
+                }),
+            );
+
+            await flush();
+            expect(dispatchOrder).toEqual([0]);
+
+            for (let i = 0; i < gates.length; i++) {
+                gates[i].resolve();
+                await flush();
+            }
+
+            await Promise.all(runs);
+            expect(dispatchOrder).toEqual([0, 1, 2, 3, 4]);
+        });
+    });
+
+    describe('error handling', () => {
+        it('releases capacity when a task rejects', async () => {
+            const limit = createConcurrencyLimiter({ concurrency: 2 });
+            const gate = deferred<void>();
+            let secondStarted = false;
+
+            const first = limit(async () => {
+                throw new Error('boom');
+            });
+            const second = limit(async () => {
+                throw new Error('also boom');
+            });
+            const third = limit(async () => {
+                secondStarted = true;
+                await gate.promise;
+            });
+
+            await expect(first).rejects.toThrow('boom');
+            await expect(second).rejects.toThrow('also boom');
+            await flush();
+            expect(secondStarted).toBe(true);
+
+            gate.resolve();
+            await third;
+        });
+
+        it('keeps the cap correct after a rejection while others are queued', async () => {
+            const limit = createConcurrencyLimiter({ concurrency: 1 });
+            const gateA = deferred<void>();
+            const gateB = deferred<void>();
+            let bStarted = false;
+
+            const a = limit(async () => {
+                await gateA.promise;
+                throw new Error('a failed');
+            });
+            const b = limit(async () => {
+                bStarted = true;
+                await gateB.promise;
+                return 'b';
+            });
+
+            await flush();
+            expect(bStarted).toBe(false);
+
+            gateA.resolve();
+            await expect(a).rejects.toThrow('a failed');
+            await flush();
+            expect(bStarted).toBe(true);
+
+            gateB.resolve();
+            await expect(b).resolves.toBe('b');
+        });
+    });
+
+    describe('option sanitization', () => {
+        it.each([
+            ['NaN', Number.NaN],
+            ['positive Infinity', Number.POSITIVE_INFINITY],
+            ['negative Infinity', Number.NEGATIVE_INFINITY],
+            ['negative number', -5],
+        ])('treats %s as concurrency=1', async (_label, value) => {
+            const limit = createConcurrencyLimiter({ concurrency: value });
+            let active = 0;
+            let peak = 0;
+
+            const gates = Array.from({ length: 4 }, () => deferred<void>());
+
+            const runs = gates.map((gate) =>
+                limit(async () => {
+                    active++;
+                    if (active > peak) {
+                        peak = active;
+                    }
+                    await gate.promise;
+                    active--;
+                }),
+            );
+
+            await flush();
+            expect(peak).toBe(1);
+
+            for (const gate of gates) {
+                gate.resolve();
+                await flush();
+            }
+            await Promise.all(runs);
+            expect(peak).toBe(1);
+        });
+    });
+});

--- a/src/utils/concurrencyLimiter.ts
+++ b/src/utils/concurrencyLimiter.ts
@@ -9,84 +9,36 @@
  * Caps the number of in-flight async tasks at `concurrency` and supports two
  * independent pacing knobs:
  *
- * - `interTaskDelayMs` — applied after each individual task completes, before
- *   the next queued task is dispatched. Produces a steady trickle: up to
- *   `concurrency` in flight at any time, but each new dispatch is paced.
+ * - `interTaskDelayMs` — applied after each task completes, before the next
+ *   queued task is dispatched. Produces a steady trickle.
+ * - `interBatchDelayMs` — applied only when ALL in-flight tasks have drained
+ *   and more work is queued. Produces a "burst, rest, burst" pattern.
  *
- * - `interBatchDelayMs` — applied only when the *entire* current set of
- *   in-flight tasks has drained (active count drops to 0) and more work is
- *   queued. After the delay, up to `concurrency` queued tasks are released at
- *   once as the next batch. Produces a "burst, rest, burst" pattern.
+ * In practice you usually want exactly one of them (or neither).
  *
- * Both can be combined, but in practice you usually want exactly one of them.
+ * ## Mode selection
  *
- * ## Picking a mode
- *
- * | Want                                                | Use                                              |
- * | --------------------------------------------------- | ------------------------------------------------ |
- * | "Never more than N in flight, refill on completion" | `{ concurrency: N }` (plain semaphore)           |
- * | "Trickle, paced between dispatches"                 | `{ concurrency: N, interTaskDelayMs: ms }`       |
- * | "Burst of N, rest, burst of N"                      | `{ concurrency: N, interBatchDelayMs: ms }`      |
- *
- * ### Plain semaphore — recommended for slow background work
+ * | Want                                                | Use                                          |
+ * | --------------------------------------------------- | -------------------------------------------- |
+ * | "Never more than N in flight, refill on completion" | `{ concurrency: N }` (plain semaphore)       |
+ * | "Trickle, paced between dispatches"                 | `{ concurrency: N, interTaskDelayMs: ms }`   |
+ * | "Burst of N, rest, burst of N"                      | `{ concurrency: N, interBatchDelayMs: ms }`  |
  *
  * ```ts
+ * // Plain semaphore — the right default for slow background work.
+ * // 5 always in flight; a freed slot starts the next queued task immediately.
  * const limit = createConcurrencyLimiter({ concurrency: 5 });
  * await Promise.all(items.map((item) => limit(() => fetchOne(item))));
  * ```
  *
- * Timeline (5 tasks of varying duration, concurrency = 3):
- * ```
- *   t=0   t1┐  t2┐  t3┐                       <- 3 dispatched immediately
- *   t=10        ┘  ┘                          <- t2 finishes; t4 starts
- *   t=10        t4┐
- *   t=15  ┘            <- t1 finishes; t5 starts
- *   t=15  t5┐
- *   t=22                ┘  <- t3 finishes (queue empty)
- *   t=25        t4┘
- *   t=30  t5┘
- * ```
- * Pipe is never idle while there is work queued, never exceeds the cap. This
- * is the right shape when individual tasks vary in latency (a fast task
- * shouldn't be held up by a slow one in the same "batch").
- *
- * ### `interTaskDelayMs` — when the server wants you to slow down
- *
- * ```ts
- * const limit = createConcurrencyLimiter({ concurrency: 5, interTaskDelayMs: 100 });
- * ```
- *
- * After any task completes, the limiter waits 100 ms before pulling the next
- * one from the queue. Up to 5 may still be in flight at any moment, but new
- * dispatches are paced. Useful when a downstream rate-limit is per-request
- * (e.g. "no more than 10 requests per second per user").
- *
- * ### `interBatchDelayMs` — when you want quiet periods
- *
- * ```ts
- * const limit = createConcurrencyLimiter({ concurrency: 5, interBatchDelayMs: 250 });
- * ```
- *
- * Dispatches 5 at once. Waits for ALL 5 to finish. Sleeps 250 ms. Dispatches
- * the next 5. Useful for low-priority background work that should leave gaps
- * for foreground operations — at the cost of latency, since the slowest task
- * in the batch holds up the next batch.
- *
  * ## Implementation notes
  *
- * - This is a small in-house alternative to `p-limit`. The public `p-limit`
- *   package is ESM-only since v4; this extension is bundled as CommonJS, so
- *   pulling it in would require either pinning to v3 or migrating the whole
- *   build to ESM. Rolling our own avoids that and lets us add the pacing
- *   knobs used by low-priority background work.
- * - Tasks are dispatched in **FIFO order** based on when `limit(fn)` was
- *   called. The order in which their promises *resolve* depends on task
- *   duration and can differ from dispatch order.
- * - Batch mode trades parallelism for predictability: the slowest task in a
- *   batch blocks the next batch from starting. With small `concurrency` and
- *   roughly uniform task durations this is usually fine.
- * - The limiter has no internal cancellation. To cancel queued work, race the
- *   `limit(fn)` promise against an `AbortSignal` at the call site.
+ * - In-house alternative to `p-limit`. `p-limit` is ESM-only since v4 and this
+ *   extension is bundled as CommonJS, so we roll our own.
+ * - Tasks are dispatched in FIFO order. Resolution order depends on task
+ *   duration and may differ from dispatch order.
+ * - No internal cancellation. Race against an `AbortSignal` at the call site
+ *   if needed.
  */
 export interface ConcurrencyLimiterOptions {
     /** Maximum number of tasks allowed to run in parallel (and batch size in batch mode). Must be >= 1. */
@@ -122,32 +74,17 @@ export type LimitedRunner = <T>(fn: () => Promise<T>) => Promise<T>;
 /**
  * Creates a new concurrency limiter.
  *
- * Each call to the returned function enqueues the task; the returned promise
- * resolves with the task's result (or rejects with its error). The limiter's
- * internal state is private — there is no `pending`/`active` accessor. If you
- * need that, expose it from the call site.
- *
  * @example Plain cap (semaphore) — recommended default
  *   const limit = createConcurrencyLimiter({ concurrency: 5 });
- *   // 5 always in flight, refill on completion, no idle gaps:
- *   await Promise.all(items.map((x) => limit(() => fetchOne(x))));
  *
- * @example Per-task pacing (5 in parallel, each new dispatch waits 100 ms)
+ * @example Per-task pacing
  *   const limit = createConcurrencyLimiter({ concurrency: 5, interTaskDelayMs: 100 });
  *
- * @example Batched pacing (5 at once, drain, 250 ms rest, next 5, ...)
+ * @example Batched pacing
  *   const limit = createConcurrencyLimiter({ concurrency: 5, interBatchDelayMs: 250 });
  *
- * @example One-at-a-time strict serialization
+ * @example Strict serialization
  *   const limit = createConcurrencyLimiter({ concurrency: 1 });
- *
- * @example Per-key limiters (one independent queue per cluster, user, etc.)
- *   const limiters = new Map<string, LimitedRunner>();
- *   function getLimiter(key: string): LimitedRunner {
- *       let l = limiters.get(key);
- *       if (!l) { l = createConcurrencyLimiter({ concurrency: 5 }); limiters.set(key, l); }
- *       return l;
- *   }
  */
 export function createConcurrencyLimiter(options: ConcurrencyLimiterOptions): LimitedRunner {
     const concurrency = Math.max(1, Math.floor(options.concurrency));

--- a/src/utils/concurrencyLimiter.ts
+++ b/src/utils/concurrencyLimiter.ts
@@ -42,7 +42,11 @@ export type LimitedRunner = <T>(fn: () => Promise<T>) => Promise<T>;
  *   await limit(() => doWork());
  */
 export function createConcurrencyLimiter(options: ConcurrencyLimiterOptions): LimitedRunner {
-    const concurrency = Math.max(1, Math.floor(options.concurrency));
+    // Reject NaN / Infinity / non-numeric inputs explicitly. Math.floor(NaN)
+    // is NaN, and Math.max(1, NaN) is NaN, which would make `active >=
+    // concurrency` always false and silently disable the limit. Clamp to 1
+    // as a safe default.
+    const concurrency = Number.isFinite(options.concurrency) ? Math.max(1, Math.floor(options.concurrency)) : 1;
 
     let active = 0;
     const waiters: Array<() => void> = [];

--- a/src/utils/concurrencyLimiter.ts
+++ b/src/utils/concurrencyLimiter.ts
@@ -1,0 +1,135 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * A lightweight promise-concurrency limiter with optional pacing delays.
+ *
+ * Caps the number of in-flight async tasks at `concurrency` and supports two
+ * independent pacing knobs:
+ *
+ * - `interTaskDelayMs` — applied after each individual task completes, before
+ *   the next queued task is dispatched. Produces a steady trickle: up to
+ *   `concurrency` in flight at any time, but each new dispatch is paced.
+ *
+ * - `interBatchDelayMs` — applied only when the *entire* current set of
+ *   in-flight tasks has drained (active count drops to 0) and more work is
+ *   queued. After the delay, up to `concurrency` queued tasks are released at
+ *   once as the next batch. Produces a "burst, rest, burst" pattern.
+ *
+ * Both can be combined, but in practice you usually want exactly one of them.
+ *
+ * Notes:
+ * - This is a small in-house alternative to `p-limit`. The public `p-limit`
+ *   package is ESM-only since v4; this extension is bundled as CommonJS, so
+ *   pulling it in would require either pinning to v3 or migrating the whole
+ *   build to ESM. Rolling our own avoids that and lets us add the pacing
+ *   knobs used by low-priority background work.
+ * - Tasks are dispatched in FIFO order.
+ * - Batch mode trades parallelism for predictability: the slowest task in a
+ *   batch blocks the next batch from starting. With small `concurrency` and
+ *   roughly uniform task durations this is usually fine.
+ */
+export interface ConcurrencyLimiterOptions {
+    /** Maximum number of tasks allowed to run in parallel (and batch size in batch mode). Must be >= 1. */
+    readonly concurrency: number;
+    /**
+     * Optional delay (in milliseconds) applied before dispatching the next
+     * queued task after a running task finishes. Defaults to 0 (no delay).
+     *
+     * Produces a steady trickle: dispatch rate is roughly capped at
+     * `concurrency / interTaskDelayMs` tasks per ms while still allowing up to
+     * `concurrency` to run in parallel.
+     */
+    readonly interTaskDelayMs?: number;
+    /**
+     * Optional delay (in milliseconds) applied between batches.
+     *
+     * When `> 0`, the limiter dispatches up to `concurrency` tasks, waits for
+     * all of them to finish, sleeps for `interBatchDelayMs`, then dispatches
+     * the next batch.
+     *
+     * Defaults to 0 (no inter-batch delay; behaviour is governed only by
+     * `concurrency` and `interTaskDelayMs`).
+     */
+    readonly interBatchDelayMs?: number;
+}
+
+/**
+ * Function returned by {@link createConcurrencyLimiter}. Wraps an async task so
+ * that it respects the limiter's concurrency cap and any configured pacing.
+ */
+export type LimitedRunner = <T>(fn: () => Promise<T>) => Promise<T>;
+
+/**
+ * Creates a new concurrency limiter.
+ *
+ * @example Plain cap (semaphore):
+ *   const limit = createConcurrencyLimiter({ concurrency: 5 });
+ *
+ * @example Per-task pacing (5 in parallel, each new dispatch waits 250 ms):
+ *   const limit = createConcurrencyLimiter({ concurrency: 5, interTaskDelayMs: 250 });
+ *
+ * @example Batched pacing (5 at once, 250 ms rest, 5 at once, ...):
+ *   const limit = createConcurrencyLimiter({ concurrency: 5, interBatchDelayMs: 250 });
+ */
+export function createConcurrencyLimiter(options: ConcurrencyLimiterOptions): LimitedRunner {
+    const concurrency = Math.max(1, Math.floor(options.concurrency));
+    const interTaskDelayMs = Math.max(0, options.interTaskDelayMs ?? 0);
+    const interBatchDelayMs = Math.max(0, options.interBatchDelayMs ?? 0);
+
+    let active = 0;
+    const waiters: Array<() => void> = [];
+
+    const dispatchOne = (): void => {
+        const resume = waiters.shift();
+        if (resume) {
+            resume();
+        }
+    };
+
+    const dispatchNextBatch = (): void => {
+        // Release up to `concurrency` queued tasks at once as the next batch.
+        const batchSize = Math.min(concurrency, waiters.length);
+        for (let i = 0; i < batchSize; i++) {
+            const resume = waiters.shift();
+            if (resume) {
+                resume();
+            }
+        }
+    };
+
+    const release = (): void => {
+        active--;
+        if (waiters.length === 0) {
+            return;
+        }
+
+        // Inter-batch delay: only when the current batch has fully drained.
+        if (interBatchDelayMs > 0 && active === 0) {
+            setTimeout(dispatchNextBatch, interBatchDelayMs);
+            return;
+        }
+
+        // Inter-task delay: applied before every individual dispatch.
+        if (interTaskDelayMs > 0) {
+            setTimeout(dispatchOne, interTaskDelayMs);
+            return;
+        }
+
+        dispatchOne();
+    };
+
+    return async <T>(fn: () => Promise<T>): Promise<T> => {
+        if (active >= concurrency) {
+            await new Promise<void>((resolve) => waiters.push(resolve));
+        }
+        active++;
+        try {
+            return await fn();
+        } finally {
+            release();
+        }
+    };
+}

--- a/src/utils/concurrencyLimiter.ts
+++ b/src/utils/concurrencyLimiter.ts
@@ -4,133 +4,55 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * A lightweight promise-concurrency limiter with optional pacing delays.
+ * A lightweight promise-concurrency limiter (plain semaphore).
  *
- * Caps the number of in-flight async tasks at `concurrency` and supports two
- * independent pacing knobs:
- *
- * - `interTaskDelayMs` — applied after each task completes, before the next
- *   queued task is dispatched. Produces a steady trickle.
- * - `interBatchDelayMs` — applied only when ALL in-flight tasks have drained
- *   and more work is queued. Produces a "burst, rest, burst" pattern.
- *
- * In practice you usually want exactly one of them (or neither).
- *
- * ## Mode selection
- *
- * | Want                                                | Use                                          |
- * | --------------------------------------------------- | -------------------------------------------- |
- * | "Never more than N in flight, refill on completion" | `{ concurrency: N }` (plain semaphore)       |
- * | "Trickle, paced between dispatches"                 | `{ concurrency: N, interTaskDelayMs: ms }`   |
- * | "Burst of N, rest, burst of N"                      | `{ concurrency: N, interBatchDelayMs: ms }`  |
+ * Caps the number of in-flight async tasks at `concurrency`. As soon as one
+ * task completes, the next queued task is dispatched. FIFO order.
  *
  * ```ts
- * // Plain semaphore — the right default for slow background work.
- * // 5 always in flight; a freed slot starts the next queued task immediately.
  * const limit = createConcurrencyLimiter({ concurrency: 5 });
  * await Promise.all(items.map((item) => limit(() => fetchOne(item))));
  * ```
  *
- * ## Implementation notes
+ * Notes:
  *
  * - In-house alternative to `p-limit`. `p-limit` is ESM-only since v4 and this
  *   extension is bundled as CommonJS, so we roll our own.
- * - Tasks are dispatched in FIFO order. Resolution order depends on task
- *   duration and may differ from dispatch order.
+ * - Tasks dispatch in FIFO order. Resolution order depends on task duration
+ *   and may differ from dispatch order.
  * - No internal cancellation. Race against an `AbortSignal` at the call site
  *   if needed.
  */
 export interface ConcurrencyLimiterOptions {
-    /** Maximum number of tasks allowed to run in parallel (and batch size in batch mode). Must be >= 1. */
+    /** Maximum number of tasks allowed to run in parallel. Must be >= 1. */
     readonly concurrency: number;
-    /**
-     * Optional delay (in milliseconds) applied before dispatching the next
-     * queued task after a running task finishes. Defaults to 0 (no delay).
-     *
-     * Produces a steady trickle: dispatch rate is roughly capped at
-     * `concurrency / interTaskDelayMs` tasks per ms while still allowing up to
-     * `concurrency` to run in parallel.
-     */
-    readonly interTaskDelayMs?: number;
-    /**
-     * Optional delay (in milliseconds) applied between batches.
-     *
-     * When `> 0`, the limiter dispatches up to `concurrency` tasks, waits for
-     * all of them to finish, sleeps for `interBatchDelayMs`, then dispatches
-     * the next batch.
-     *
-     * Defaults to 0 (no inter-batch delay; behaviour is governed only by
-     * `concurrency` and `interTaskDelayMs`).
-     */
-    readonly interBatchDelayMs?: number;
 }
 
 /**
  * Function returned by {@link createConcurrencyLimiter}. Wraps an async task so
- * that it respects the limiter's concurrency cap and any configured pacing.
+ * that it respects the limiter's concurrency cap.
  */
 export type LimitedRunner = <T>(fn: () => Promise<T>) => Promise<T>;
 
 /**
  * Creates a new concurrency limiter.
  *
- * @example Plain cap (semaphore) — recommended default
+ * @example
  *   const limit = createConcurrencyLimiter({ concurrency: 5 });
- *
- * @example Per-task pacing
- *   const limit = createConcurrencyLimiter({ concurrency: 5, interTaskDelayMs: 100 });
- *
- * @example Batched pacing
- *   const limit = createConcurrencyLimiter({ concurrency: 5, interBatchDelayMs: 250 });
- *
- * @example Strict serialization
- *   const limit = createConcurrencyLimiter({ concurrency: 1 });
+ *   await limit(() => doWork());
  */
 export function createConcurrencyLimiter(options: ConcurrencyLimiterOptions): LimitedRunner {
     const concurrency = Math.max(1, Math.floor(options.concurrency));
-    const interTaskDelayMs = Math.max(0, options.interTaskDelayMs ?? 0);
-    const interBatchDelayMs = Math.max(0, options.interBatchDelayMs ?? 0);
 
     let active = 0;
     const waiters: Array<() => void> = [];
 
-    const dispatchOne = (): void => {
+    const release = (): void => {
+        active--;
         const resume = waiters.shift();
         if (resume) {
             resume();
         }
-    };
-
-    const dispatchNextBatch = (): void => {
-        // Release up to `concurrency` queued tasks at once as the next batch.
-        const batchSize = Math.min(concurrency, waiters.length);
-        for (let i = 0; i < batchSize; i++) {
-            const resume = waiters.shift();
-            if (resume) {
-                resume();
-            }
-        }
-    };
-
-    const release = (): void => {
-        active--;
-        if (waiters.length === 0) {
-            return;
-        }
-
-        // Inter-batch delay: only when the current batch has fully drained.
-        if (interBatchDelayMs > 0 && active === 0) {
-            setTimeout(dispatchNextBatch, interBatchDelayMs);
-            return;
-        }
-
-        // Inter-task delay: applied before every individual dispatch.
-        if (interTaskDelayMs > 0) {
-            setTimeout(dispatchOne, interTaskDelayMs);
-            return;
-        }
-
-        dispatchOne();
     };
 
     return async <T>(fn: () => Promise<T>): Promise<T> => {

--- a/src/utils/concurrencyLimiter.ts
+++ b/src/utils/concurrencyLimiter.ts
@@ -53,9 +53,18 @@ export function createConcurrencyLimiter(options: ConcurrencyLimiterOptions): Li
 
     const release = (): void => {
         active--;
-        const resume = waiters.shift();
-        if (resume) {
-            resume();
+        // Defensive: a future change to this dispatch logic might introduce a
+        // throwing call (logging, telemetry, etc.). If `release` ever throws,
+        // the queued waiter would never be resumed and the limiter would
+        // deadlock. Swallow here so a single misbehaving callback can never
+        // wedge the whole limiter.
+        try {
+            const resume = waiters.shift();
+            if (resume) {
+                resume();
+            }
+        } catch {
+            // Intentional no-op: see comment above.
         }
     };
 

--- a/src/utils/concurrencyLimiter.ts
+++ b/src/utils/concurrencyLimiter.ts
@@ -20,16 +20,73 @@
  *
  * Both can be combined, but in practice you usually want exactly one of them.
  *
- * Notes:
+ * ## Picking a mode
+ *
+ * | Want                                                | Use                                              |
+ * | --------------------------------------------------- | ------------------------------------------------ |
+ * | "Never more than N in flight, refill on completion" | `{ concurrency: N }` (plain semaphore)           |
+ * | "Trickle, paced between dispatches"                 | `{ concurrency: N, interTaskDelayMs: ms }`       |
+ * | "Burst of N, rest, burst of N"                      | `{ concurrency: N, interBatchDelayMs: ms }`      |
+ *
+ * ### Plain semaphore — recommended for slow background work
+ *
+ * ```ts
+ * const limit = createConcurrencyLimiter({ concurrency: 5 });
+ * await Promise.all(items.map((item) => limit(() => fetchOne(item))));
+ * ```
+ *
+ * Timeline (5 tasks of varying duration, concurrency = 3):
+ * ```
+ *   t=0   t1┐  t2┐  t3┐                       <- 3 dispatched immediately
+ *   t=10        ┘  ┘                          <- t2 finishes; t4 starts
+ *   t=10        t4┐
+ *   t=15  ┘            <- t1 finishes; t5 starts
+ *   t=15  t5┐
+ *   t=22                ┘  <- t3 finishes (queue empty)
+ *   t=25        t4┘
+ *   t=30  t5┘
+ * ```
+ * Pipe is never idle while there is work queued, never exceeds the cap. This
+ * is the right shape when individual tasks vary in latency (a fast task
+ * shouldn't be held up by a slow one in the same "batch").
+ *
+ * ### `interTaskDelayMs` — when the server wants you to slow down
+ *
+ * ```ts
+ * const limit = createConcurrencyLimiter({ concurrency: 5, interTaskDelayMs: 100 });
+ * ```
+ *
+ * After any task completes, the limiter waits 100 ms before pulling the next
+ * one from the queue. Up to 5 may still be in flight at any moment, but new
+ * dispatches are paced. Useful when a downstream rate-limit is per-request
+ * (e.g. "no more than 10 requests per second per user").
+ *
+ * ### `interBatchDelayMs` — when you want quiet periods
+ *
+ * ```ts
+ * const limit = createConcurrencyLimiter({ concurrency: 5, interBatchDelayMs: 250 });
+ * ```
+ *
+ * Dispatches 5 at once. Waits for ALL 5 to finish. Sleeps 250 ms. Dispatches
+ * the next 5. Useful for low-priority background work that should leave gaps
+ * for foreground operations — at the cost of latency, since the slowest task
+ * in the batch holds up the next batch.
+ *
+ * ## Implementation notes
+ *
  * - This is a small in-house alternative to `p-limit`. The public `p-limit`
  *   package is ESM-only since v4; this extension is bundled as CommonJS, so
  *   pulling it in would require either pinning to v3 or migrating the whole
  *   build to ESM. Rolling our own avoids that and lets us add the pacing
  *   knobs used by low-priority background work.
- * - Tasks are dispatched in FIFO order.
+ * - Tasks are dispatched in **FIFO order** based on when `limit(fn)` was
+ *   called. The order in which their promises *resolve* depends on task
+ *   duration and can differ from dispatch order.
  * - Batch mode trades parallelism for predictability: the slowest task in a
  *   batch blocks the next batch from starting. With small `concurrency` and
  *   roughly uniform task durations this is usually fine.
+ * - The limiter has no internal cancellation. To cancel queued work, race the
+ *   `limit(fn)` promise against an `AbortSignal` at the call site.
  */
 export interface ConcurrencyLimiterOptions {
     /** Maximum number of tasks allowed to run in parallel (and batch size in batch mode). Must be >= 1. */
@@ -65,14 +122,32 @@ export type LimitedRunner = <T>(fn: () => Promise<T>) => Promise<T>;
 /**
  * Creates a new concurrency limiter.
  *
- * @example Plain cap (semaphore):
+ * Each call to the returned function enqueues the task; the returned promise
+ * resolves with the task's result (or rejects with its error). The limiter's
+ * internal state is private — there is no `pending`/`active` accessor. If you
+ * need that, expose it from the call site.
+ *
+ * @example Plain cap (semaphore) — recommended default
  *   const limit = createConcurrencyLimiter({ concurrency: 5 });
+ *   // 5 always in flight, refill on completion, no idle gaps:
+ *   await Promise.all(items.map((x) => limit(() => fetchOne(x))));
  *
- * @example Per-task pacing (5 in parallel, each new dispatch waits 250 ms):
- *   const limit = createConcurrencyLimiter({ concurrency: 5, interTaskDelayMs: 250 });
+ * @example Per-task pacing (5 in parallel, each new dispatch waits 100 ms)
+ *   const limit = createConcurrencyLimiter({ concurrency: 5, interTaskDelayMs: 100 });
  *
- * @example Batched pacing (5 at once, 250 ms rest, 5 at once, ...):
+ * @example Batched pacing (5 at once, drain, 250 ms rest, next 5, ...)
  *   const limit = createConcurrencyLimiter({ concurrency: 5, interBatchDelayMs: 250 });
+ *
+ * @example One-at-a-time strict serialization
+ *   const limit = createConcurrencyLimiter({ concurrency: 1 });
+ *
+ * @example Per-key limiters (one independent queue per cluster, user, etc.)
+ *   const limiters = new Map<string, LimitedRunner>();
+ *   function getLimiter(key: string): LimitedRunner {
+ *       let l = limiters.get(key);
+ *       if (!l) { l = createConcurrencyLimiter({ concurrency: 5 }); limiters.set(key, l); }
+ *       return l;
+ *   }
  */
 export function createConcurrencyLimiter(options: ConcurrencyLimiterOptions): LimitedRunner {
     const concurrency = Math.max(1, Math.floor(options.concurrency));


### PR DESCRIPTION
## Summary

When a database node is expanded in the tree, every `CollectionItem` fires its own `estimateDocumentCount` request in parallel (fire-and-forget, from `DatabaseItem.getChildren`). For databases with many collections this produces a burst of concurrent requests that:

- opens many sockets in the MongoDB driver connection pool (default `maxPoolSize: 100`), and
- competes with foreground operations (queries, the collection view) for pool slots and server resources.

This PR adds a small in-house concurrency limiter and applies it to the background count fetches so this work stays unobtrusive.

## Changes

- **New utility** `src/utils/concurrencyLimiter.ts` exposing `createConcurrencyLimiter({ concurrency, interTaskDelayMs })`. Caps in-flight tasks and optionally inserts a delay before dispatching the next queued task after one completes.
- **`CollectionItem.fetchAndUpdateCount`** now runs through a per-cluster limiter (keyed by `clusterId`) with `concurrency = 5` and `interTaskDelayMs = 250`. Each cluster gets its own pool so different clusters never share a queue.

Behaviour: tree expansion still returns immediately, descriptions still fill in as counts arrive, but at most 5 count requests are in flight per cluster and the next dispatch waits 250 ms after a completion. UX impact is negligible (counts trickle in slightly later for the 6th and later collections), pool/server impact is dramatically reduced.

## Why not `p-limit`?

`p-limit` is the de-facto standard for this and the obvious first choice. It is, however, **pure ESM since v4.0.0**. This extension is built and bundled as **CommonJS** (`tsconfig` `module: "commonjs"`, webpack-bundled `dist/extension.js`, VS Code extension host loads via `require`). Using current `p-limit` in CJS code requires either:

1. Pin to **`p-limit@3.1.0`** (last CJS release, Oct 2020). Still works but stale, and we would still need to wrap it to add the inter-task delay used by low-priority background work.
2. Use **dynamic `import('p-limit')`** at every call site. Awkward in synchronous code paths and adds an async boundary at module load.
3. **Migrate the whole codebase to ESM.** Touches webpack output format, `tsconfig`, jest/ts-jest, every relative import (ESM requires `.js` extensions), eslint config. Not worth it for one dependency.

The in-house implementation is ~80 lines including JSDoc, has no runtime dependency, fits the CJS bundle, and gives us a clean place to add the `interTaskDelayMs` knob (which `p-limit` does not provide). If the extension ever migrates to ESM we can drop this and swap to `p-limit` mechanically.

## Test plan

- `npm run prettier-fix`, `npm run lint`, `npm run build` all clean.
- `npx jest --no-coverage`: 1900/1900 tests pass. (Three test suites were SIGKILL'd by the OS in CI-like conditions; unrelated to this change.)
- No user-facing strings changed, so no `npm run l10n` needed.

## Follow-ups (out of scope)

- Apply the same limiter to other tree-driven background loads (e.g. lazy index counts) once they exist.
- Add cancellation on tree collapse via the limiter's queue (would need a `clearQueue()` method similar to `p-limit`'s).
