### PR TITLE
ci: unify concurrency group to avoid double CI runs on release branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,11 @@ on:
             - feature/**
 
 concurrency:
-    group: ${{ github.head_ref || github.run_id }}
+    # Use head_ref for PRs, ref_name for pushes. When a forward-merge PR
+    # (release/X.Y → main) is open, both the push to release/X.Y and the
+    # PR trigger resolve to the same group (release/X.Y) so they cancel
+    # each other instead of running CI twice.
+    group: ${{ github.head_ref || github.ref_name }}
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
When a forward-merge PR (`release/X.Y -> main`) is open, each push to the release branch triggered CI **twice** -- once via `push` and once via `pull_request`. The two runs had different concurrency groups and never cancelled each other, doubling Actions minutes.

**Fix**: Change the concurrency group from `github.head_ref || github.run_id` to `github.head_ref || github.ref_name`.

Both the push to `release/X.Y` and the PR from `release/X.Y -> main` now resolve to the same group (`release/X.Y`) and cancel each other. `release/**` stays in the push trigger, preserving CI coverage for direct release-branch pushes.

### Before
```yaml
concurrency:
    group: ${{ github.head_ref || github.run_id }}
```

### After
```yaml
concurrency:
    group: ${{ github.head_ref || github.ref_name }}
```

## Issue
Fixes #666