### PR TITLE
fix: close micro race window between connect() resolve and abort listener removal

### DIFF
--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -297,7 +297,11 @@ export class ClustersClient {
 
         // Track whether connect() has resolved so the abort handler can avoid
         // closing an already-connected client during the micro window between
-        // connect() resolving and removeEventListener firing.
+        // connect() resolving and removeEventListener firing. This window exists
+        // because abort events are dispatched synchronously when abort() is
+        // called: if abort() fires during the synchronous continuation after
+        // connect() resolves but before the listener is removed, the handler
+        // would close the now-connected client without this guard.
         let connected = false;
 
         // Wire up abort: closing the client causes the pending connect() to reject
@@ -317,9 +321,11 @@ export class ClustersClient {
             await this._mongoClient.connect();
             connected = true;
 
-            // Remove the abort listener immediately after connect() resolves so that
-            // a late cancellation during synchronous API init below cannot close an
-            // already-connected client while the method continues as "successful".
+            // Remove the abort listener immediately after connect() resolves so
+            // that a late cancellation during synchronous API init below cannot
+            // close an already-connected client while the method continues as
+            // "successful". The connected flag above serves as a belt-and-suspenders
+            // guard in case abort fires between the assignment and this removal.
             abortSignal?.removeEventListener('abort', onAbort);
 
             this._llmEnhancedFeatureApis = new llmEnhancedFeatureApis(this._mongoClient);
@@ -346,7 +352,12 @@ export class ClustersClient {
             }
             throw error;
         } finally {
-            abortSignal?.removeEventListener('abort', onAbort);
+            // Clean up the abort listener if we didn't already remove it in the
+            // success path (i.e., connect() failed). In the success path the
+            // listener was already removed above.
+            if (abortSignal && !connected) {
+                abortSignal.removeEventListener('abort', onAbort);
+            }
         }
     }
 

--- a/src/documentdb/ClustersClient.ts
+++ b/src/documentdb/ClustersClient.ts
@@ -295,8 +295,17 @@ export class ClustersClient {
             throw new UserCancelledError('abortConnection');
         }
 
+        // Track whether connect() has resolved so the abort handler can avoid
+        // closing an already-connected client during the micro window between
+        // connect() resolving and removeEventListener firing.
+        let connected = false;
+
         // Wire up abort: closing the client causes the pending connect() to reject
         const onAbort = (): void => {
+            if (connected) {
+                // connect() already resolved — do not close the connected client.
+                return;
+            }
             ext.outputChannel.debug('AbortSignal fired — closing MongoClient to interrupt connection handshake.');
             void this._mongoClient.close().catch(() => {
                 // Ignore close errors during abort cleanup
@@ -306,6 +315,7 @@ export class ClustersClient {
 
         try {
             await this._mongoClient.connect();
+            connected = true;
 
             // Remove the abort listener immediately after connect() resolves so that
             // a late cancellation during synchronous API init below cannot close an


### PR DESCRIPTION
## Summary
- Added a `connected` flag that is set immediately after `mongoClient.connect()` resolves
- The `onAbort` handler now checks this flag before calling `close()`, preventing a late abort from closing an already-connected client
- Eliminates the micro race window between `connect()` resolving and `removeEventListener` firing

## Issue
Fixes #644

## Changes
| File | Change |
|------|--------|
| `src/documentdb/ClustersClient.ts` | Add `connected` flag; guard `onAbort` close with `!connected` check |

## Verification
- The `connected` flag transitions from `false` to `true` atomically in the same synchronous tick as `connect()` resolves
- If abort fires during connection: `connected === false` -> close the client (existing behavior preserved)
- If abort fires after connect but before removeEventListener: `connected === true` -> skip close (race window closed)
- The existing `finally` block still removes the listener for cleanup
- No behavior change in normal (non-race) paths