### PR TITLE
docs: clarify PlaygroundEvaluator lifecycle after killWorker

### DIFF
--- a/src/documentdb/playground/PlaygroundEvaluator.ts
+++ b/src/documentdb/playground/PlaygroundEvaluator.ts
@@ -195,6 +195,11 @@ export class PlaygroundEvaluator implements vscode.Disposable {
     /**
      * Force-terminate the worker thread immediately.
      * Used for infinite loop recovery (timeout) and cancellation.
+     *
+     * The PlaygroundEvaluator instance itself is kept by the caller and reused
+     * on the next run. Only the worker thread is discarded here; the next
+     * `evaluate()` call will lazily spawn a fresh worker and reset session
+     * telemetry for that new worker lifecycle.
      */
     killWorker(): void {
         this._workerManager.killWorker();

--- a/src/documentdb/playground/PlaygroundEvaluator.ts
+++ b/src/documentdb/playground/PlaygroundEvaluator.ts
@@ -197,9 +197,9 @@ export class PlaygroundEvaluator implements vscode.Disposable {
      * Used for infinite loop recovery (timeout) and cancellation.
      *
      * The PlaygroundEvaluator instance itself is kept by the caller and reused
-     * on the next run. Only the worker thread is discarded here; the next
-     * `evaluate()` call will lazily spawn a fresh worker and reset session
-     * telemetry for that new worker lifecycle.
+     * on the next run. Only the worker thread is discarded here; `resetSession()`
+     * clears the telemetry fields, and `evaluate()` will spawn a new worker via
+     * `WorkerSessionManager.ensureWorker()` when `isConnectedTo()` returns false.
      */
     killWorker(): void {
         this._workerManager.killWorker();


### PR DESCRIPTION
## Summary
- Clarify that killWorker() only terminates the worker thread and keeps the evaluator instance cached for reuse
- Explain that the next evaluate() call lazily spawns a fresh worker and resets session telemetry

## Issue
Fixes #645

## Verification
- 
pm run build failed because 	sc is not available in this checkout
- git diff --check passed with LF/CRLF warnings only