### PR TITLE
docs: document PlaygroundEvaluator lifecycle after killWorker (#645)

### DIFF
--- a/src/commands/playground/executePlaygroundCode.ts
+++ b/src/commands/playground/executePlaygroundCode.ts
@@ -169,6 +169,9 @@ export async function executePlaygroundCode(
 
                 token.onCancellationRequested(() => {
                     cancelled = true;
+                    // killWorker() terminates the worker thread but the evaluator
+                    // instance stays in the pool. The next evaluate() call will
+                    // detect the dead worker and transparently spawn a new one.
                     evaluator?.killWorker();
                 });
 

--- a/src/documentdb/playground/PlaygroundEvaluator.ts
+++ b/src/documentdb/playground/PlaygroundEvaluator.ts
@@ -53,8 +53,9 @@ import { type MainToWorkerMessage, type SerializableMongoClientOptions, type Wor
  *
  * The evaluator is only removed from the pool by `shutdownEvaluator()` (when
  * all playground documents for the cluster close) or by `disposeEvaluators()`
- * (on extension deactivation). Both paths call `shutdown()` which gracefully
- * closes the worker before removing the evaluator.
+ * (on extension deactivation). `shutdownEvaluator()` calls `shutdown()`, while
+ * `disposeEvaluators()` calls `dispose()`. Both paths gracefully close the
+ * worker before removing the evaluator.
  */
 export class PlaygroundEvaluator implements vscode.Disposable {
     private readonly _workerManager: WorkerSessionManager;

--- a/src/documentdb/playground/PlaygroundEvaluator.ts
+++ b/src/documentdb/playground/PlaygroundEvaluator.ts
@@ -28,6 +28,33 @@ import { type MainToWorkerMessage, type SerializableMongoClientOptions, type Wor
  *
  * The public API is unchanged from the in-process evaluator:
  * `evaluate(connection, code) → Promise<ExecutionResult>`
+ *
+ * ## Lifecycle
+ *
+ * The evaluator instance and the worker thread have **independent lifecycles**:
+ *
+ * ```
+ * Evaluator instance        Worker thread
+ * ─────────────────         ─────────────
+ * new PlaygroundEvaluator()
+ *   └─ evaluate() ────────► spawn + connect
+ *   └─ evaluate() ────────► reuse (no re-auth)
+ *   └─ killWorker() ──────► terminate
+ *   └─ evaluate() ────────► re-spawn + re-connect
+ *   └─ shutdown() ────────► graceful close
+ * ```
+ *
+ * After `killWorker()` (called on user cancellation), the evaluator instance
+ * stays registered in the per-cluster evaluator pool (`evaluators` Map in
+ * `executePlaygroundCode.ts`). The next `evaluate()` call detects that the
+ * worker is dead and transparently spawns a new one. Session telemetry
+ * (`_sessionId`, `_sessionEvalCount`) resets on each worker spawn, so a
+ * killed-and-respawned worker behaves like a fresh evaluator session.
+ *
+ * The evaluator is only removed from the pool by `shutdownEvaluator()` (when
+ * all playground documents for the cluster close) or by `disposeEvaluators()`
+ * (on extension deactivation). Both paths call `shutdown()` which gracefully
+ * closes the worker before removing the evaluator.
  */
 export class PlaygroundEvaluator implements vscode.Disposable {
     private readonly _workerManager: WorkerSessionManager;


### PR DESCRIPTION
## Summary

Clarifies the lifecycle split between evaluator instances and worker threads. After `killWorker()`, the evaluator instance stays in the per-cluster map — the next Run respawns a fresh worker transparently. This design is intentional but wasn't documented, making it easy to misread.

## Changes

| File | Change |
|------|--------|
| `src/documentdb/playground/PlaygroundEvaluator.ts` | Add lifecycle diagram to class JSDoc; explain `killWorker()` vs `shutdown()` vs `dispose()` semantics |
| `src/commands/playground/executePlaygroundCode.ts` | Document the `evaluators` Map lifecycle |

## Verification

- [x] `npm run build` — TypeScript compilation passes
- [x] JSDoc-only change, no behavioral impact

## Issue

Fixes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)