### PR TITLE
fix(autocomplete): referenceText must not emit invalid MQL for unsafe field names

### DIFF
--- a/src/utils/json/data-api/autocomplete/future-work.md
+++ b/src/utils/json/data-api/autocomplete/future-work.md
@@ -15,41 +15,16 @@ Tests cover dashes, brackets, digits, embedded quotes, and backslashes.
 
 ---
 
-## 2. `referenceText` is invalid MQL for special field names
+## ~~2. `referenceText` is invalid MQL for special field names~~ ✅ RESOLVED
 
-**Severity:** Medium — will generate broken aggregation expressions
-**File:** `toFieldCompletionItems.ts` — `referenceText` construction
-**When to fix:** Before the aggregation completion provider is wired up
+**Resolved in:** PR #709 fix
 
-### Problem
+Per-segment check (`JS_IDENTIFIER_PATTERN` applied to each dot-separated segment):
+- All segments valid → `$field.path` (e.g., `$address.city`)
+- Flat field with unsafe name → `{ $getField: "name" }` (e.g., `{ $getField: "order-items" }`)
+- Nested path with unsafe segment → `undefined` (chained `$getField` deferred; see item 3)
 
-`referenceText` is always `$${entry.path}` (e.g., `$address.city`). In MQL, the `$field.path` syntax only works when every segment is a valid identifier without dots, spaces, or `$`. For field names like `order-items`, `a.b`, or `my field`, the `$` prefix syntax produces invalid references.
-
-### Examples
-
-| Field name          | Current `referenceText` | Valid?         | Correct MQL                          |
-| ------------------- | ----------------------- | -------------- | ------------------------------------ |
-| `age`               | `$age`                  | ✅             | `$age`                               |
-| `address.city`      | `$address.city`         | ✅ (nested)    | `$address.city`                      |
-| `order-items`       | `$order-items`          | ❌             | `{ $getField: "order-items" }`       |
-| `a.b` (literal dot) | `$a.b`                  | ❌ (ambiguous) | `{ $getField: { $literal: "a.b" } }` |
-| `my field`          | `$my field`             | ❌             | `{ $getField: "my field" }`          |
-
-### Proposed approaches
-
-**Option A — Make `referenceText` optional:** Return `undefined` for fields that can't use `$`-prefix syntax. The completion provider would omit the reference suggestion for those fields.
-
-**Option B — Use `$getField` for special names:**
-
-```typescript
-referenceText: needsQuoting
-    ? `{ $getField: "${escaped}" }`
-    : `$${entry.path}`,
-```
-
-**Option C — Provide both forms:** Add a `referenceTextRaw` (always `$path`) and `referenceTextSafe` (uses `$getField` when needed). Let the completion provider choose based on context.
-
-**Recommendation:** Option B is pragmatic. Option C is more flexible if we later need to support both forms in different contexts (e.g., `$match` vs `$project`).
+`referenceText` type widened to `string | undefined` in `FieldCompletionData`.
 
 ---
 

--- a/src/utils/json/data-api/autocomplete/toFieldCompletionItems.test.ts
+++ b/src/utils/json/data-api/autocomplete/toFieldCompletionItems.test.ts
@@ -83,16 +83,44 @@ describe('toFieldCompletionItems', () => {
         expect(result[2].insertText).toBe('$type');
     });
 
-    it('adds $ prefix to referenceText', () => {
+    it('emits $field.path for safe identifiers and nested paths with safe segments', () => {
         const fields: FieldEntry[] = [
             { path: 'age', type: 'number', bsonType: 'int32' },
             { path: 'address.city', type: 'string', bsonType: 'string' },
+            { path: '_id', type: 'string', bsonType: 'objectid' },
         ];
 
         const result = toFieldCompletionItems(fields);
 
         expect(result[0].referenceText).toBe('$age');
         expect(result[1].referenceText).toBe('$address.city');
+        expect(result[2].referenceText).toBe('$_id');
+    });
+
+    it('emits $getField for flat fields with special-character names', () => {
+        const fields: FieldEntry[] = [
+            { path: 'order-items', type: 'string', bsonType: 'string' },
+            { path: 'my field', type: 'string', bsonType: 'string' },
+            { path: 'say"hi"', type: 'string', bsonType: 'string' },
+        ];
+
+        const result = toFieldCompletionItems(fields);
+
+        expect(result[0].referenceText).toBe('{ $getField: "order-items" }');
+        expect(result[1].referenceText).toBe('{ $getField: "my field" }');
+        expect(result[2].referenceText).toBe('{ $getField: "say\\"hi\\"" }');
+    });
+
+    it('returns undefined referenceText for nested paths with an unsafe segment', () => {
+        const fields: FieldEntry[] = [
+            { path: 'order.item-count', type: 'number', bsonType: 'int32' },
+            { path: 'user.full name', type: 'string', bsonType: 'string' },
+        ];
+
+        const result = toFieldCompletionItems(fields);
+
+        expect(result[0].referenceText).toBeUndefined();
+        expect(result[1].referenceText).toBeUndefined();
     });
 
     it('preserves isSparse', () => {

--- a/src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts
+++ b/src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts
@@ -14,7 +14,9 @@ import { BSONTypes, type FieldEntry } from '@documentdb-js/schema-analyzer';
  * - `insertText` is the escaped/quoted form that gets inserted when the user selects a
  *   completion item. For simple identifiers it matches `fieldName`; for names containing
  *   special characters (dots, spaces, `$`, etc.) it is wrapped in double quotes.
- * - `referenceText` is the `$`-prefixed aggregation field reference (e.g., "$age").
+ * - `referenceText` is the aggregation field reference (e.g., `"$age"`), or `undefined`
+ *   when no safe single-expression form exists (e.g., a nested path with a special-character
+ *   segment whose `$getField` form would require chaining).
  */
 export interface FieldCompletionData {
     /** The full dot-notated field name, e.g., "address.city" — kept unescaped for display */
@@ -32,15 +34,14 @@ export interface FieldCompletionData {
     /** Text to insert when the user selects this completion — quoted/escaped if the field name contains special chars */
     insertText: string;
     /**
-     * Field reference for aggregation expressions, e.g., "$age", "$address.city".
+     * Field reference for aggregation expressions.
      *
-     * TODO: The simple `$field.path` syntax is invalid MQL for field names containing dots,
-     * spaces, or `$` characters. For such fields, the correct MQL syntax is
-     * `{ $getField: "fieldName" }`. This should be addressed when the aggregation
-     * completion provider is wired up — either by using `$getField` for special names
-     * or by making `referenceText` optional for fields that cannot use the `$` prefix syntax.
+     * - Safe paths (every dot-separated segment is a plain identifier): `"$age"`, `"$address.city"`.
+     * - Flat fields with special characters: `'{ $getField: "order-items" }'`.
+     * - Nested paths with a special-character segment: absent — the correct
+     *   `$getField` form requires chaining and is deferred to a follow-up.
      */
-    referenceText: string;
+    referenceText?: string;
 }
 
 /**
@@ -72,6 +73,23 @@ export function toFieldCompletionItems(fields: FieldEntry[]): FieldCompletionDat
             insertText = entry.path;
         }
 
+        // Build referenceText: check each dot-separated segment individually because
+        // $field.path is valid MQL even when the full path contains dots (nested traversal),
+        // but breaks when any segment contains characters outside plain identifiers.
+        const segments = entry.path.split('.');
+        const hasUnsafeSegment = segments.some((seg) => !JS_IDENTIFIER_PATTERN.test(seg));
+        let referenceText: string | undefined;
+        if (!hasUnsafeSegment) {
+            referenceText = `$${entry.path}`;
+        } else if (segments.length === 1) {
+            // Flat field with special characters — $getField is the correct single-expression form.
+            const escapedForGetField = entry.path.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+            referenceText = `{ $getField: "${escapedForGetField}" }`;
+        } else {
+            // Nested path with an unsafe segment — $getField chaining is complex; omit for now.
+            referenceText = undefined;
+        }
+
         return {
             fieldName: entry.path,
             displayType,
@@ -80,7 +98,7 @@ export function toFieldCompletionItems(fields: FieldEntry[]): FieldCompletionDat
             displayTypes: entry.bsonTypes?.map((t) => BSONTypes.toDisplayString(t as BSONTypes)),
             isSparse: entry.isSparse ?? false,
             insertText,
-            referenceText: `$${entry.path}`,
+            referenceText,
         };
     });
 }


### PR DESCRIPTION
## Summary

Closes #709

`toFieldCompletionItems()` previously emitted `referenceText` as `` `$${entry.path}` `` for every field, which produces invalid MQL for field names containing special characters (e.g., `$order-items`, `$my field`).

**Changes:**
- Check each dot-separated path segment against `JS_IDENTIFIER_PATTERN` individually (not the full path, so nested paths like `address.city` keep their valid `$address.city` form)
- Flat field with an unsafe segment (e.g., `order-items`) → `{ $getField: "order-items" }`
- Nested path with an unsafe segment (e.g., `order.item-count`) → `referenceText` omitted; chained `$getField` form is complex and tracked as a follow-up in `future-work.md`
- `FieldCompletionData.referenceText` widened from `string` to `string?` so the tRPC client-side inferred type stays consistent
- `future-work.md` item 2 marked as resolved

## Behaviour table

| Field path | Before | After |
|---|---|---|
| `age` | `$age` ✅ | `$age` ✅ |
| `address.city` | `$address.city` ✅ | `$address.city` ✅ |
| `order-items` | `$order-items` ❌ | `{ $getField: "order-items" }` ✅ |
| `my field` | `$my field` ❌ | `{ $getField: "my field" }` ✅ |
| `say"hi"` | `$say"hi"` ❌ | `{ $getField: "say\"hi\"" }` ✅ |
| `order.item-count` | `$order.item-count` ❌ | `undefined` ✅ (no invalid MQL emitted) |

## Test plan

- [x] `toFieldCompletionItems.test.ts` — 13 tests pass (3 new tests added for unsafe flat fields, unsafe nested paths, and safe nested paths)
- [x] `tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)