### PR TITLE
Show index count on the Indexes folder node (fixes #659)

### DIFF
--- a/src/tree/documentdb/IndexesItem.ts
+++ b/src/tree/documentdb/IndexesItem.ts
@@ -34,7 +34,7 @@ export class IndexesItem implements TreeElement, TreeElementWithExperience, Tree
      * Cached index count for the collection.
      * undefined means not yet loaded (node not expanded).
      */
-    private indexCount: number | undefined = undefined;
+    private indexCount: number | undefined;
 
     constructor(
         readonly cluster: TreeCluster<BaseClusterModel>,
@@ -62,9 +62,13 @@ export class IndexesItem implements TreeElement, TreeElementWithExperience, Tree
             // Search indexes not supported on this platform, continue without them
         }
 
-        // Cache the count and refresh the tree item to show it
+        // Cache the count. Schedule a tree item refresh on the next tick
+        // to avoid re-entrant getChildren calls from notifyChildrenChanged.
+        const previousCount = this.indexCount;
         this.indexCount = indexes.length;
-        ext.state.notifyChildrenChanged(this.id);
+        if (this.indexCount !== previousCount) {
+            setTimeout(() => ext.state.notifyChildrenChanged(this.id), 0);
+        }
 
         // Sort indexes by name, with _id_ always first
         indexes.sort((a, b) => compareIndexNames(a.name, b.name));

--- a/src/tree/documentdb/IndexesItem.ts
+++ b/src/tree/documentdb/IndexesItem.ts
@@ -8,6 +8,7 @@ import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
 import { ClustersClient, type CollectionItemModel, type DatabaseItemModel } from '../../documentdb/ClustersClient';
 import { type Experience } from '../../DocumentDBExperiences';
+import { ext } from '../../extensionVariables';
 import { type BaseClusterModel, type TreeCluster } from '../models/BaseClusterModel';
 import { type TreeElement } from '../TreeElement';
 import { type TreeElementWithContextValue } from '../TreeElementWithContextValue';
@@ -28,6 +29,12 @@ export class IndexesItem implements TreeElement, TreeElementWithExperience, Tree
     public contextValue: string = 'treeItem_indexes';
 
     private readonly experienceContextValue: string = '';
+
+    /**
+     * Cached index count for the collection.
+     * undefined means not yet loaded (node not expanded).
+     */
+    private indexCount: number | undefined = undefined;
 
     constructor(
         readonly cluster: TreeCluster<BaseClusterModel>,
@@ -55,6 +62,10 @@ export class IndexesItem implements TreeElement, TreeElementWithExperience, Tree
             // Search indexes not supported on this platform, continue without them
         }
 
+        // Cache the count and refresh the tree item to show it
+        this.indexCount = indexes.length;
+        ext.state.notifyChildrenChanged(this.id);
+
         // Sort indexes by name, with _id_ always first
         indexes.sort((a, b) => compareIndexNames(a.name, b.name));
 
@@ -64,10 +75,18 @@ export class IndexesItem implements TreeElement, TreeElementWithExperience, Tree
     }
 
     getTreeItem(): vscode.TreeItem {
+        let description: string | undefined;
+        if (typeof this.indexCount === 'number') {
+            description = this.indexCount === 1
+                ? l10n.t('1 index')
+                : l10n.t('{0} indexes', this.indexCount);
+        }
+
         return {
             id: this.id,
             contextValue: this.contextValue,
             label: l10n.t('Indexes'),
+            description,
             iconPath: new vscode.ThemeIcon('combine'), // TODO: create our onw icon here, this one's shape can change
             collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
         };


### PR DESCRIPTION
Fixes #659

## Summary
Adds index count display to the `Indexes` folder node in the tree view, matching the pattern used by `CollectionItem` for document counts.

### Changes in `src/tree/documentdb/IndexesItem.ts`:
- Added `indexCount` field to cache the count (starts as `undefined`)
- After `getChildren()` fetches the index list, caches the count and triggers a tree item refresh via `ext.state.notifyChildrenChanged()`
- `getTreeItem()` now shows the count as description (e.g., "5 indexes" or "1 index")
- If the node hasn't been expanded yet, no description is shown

### Testing
- All 9 existing `IndexesItem` unit tests pass
- TypeScript compilation passes with no errors
