### PR TITLE
Fix referenceText to not emit invalid MQL for unsafe field names (fixes #709)

### DIFF
--- a/docs/ai-and-plans/PRs/717-referenceText-unsafe-field-names.md
+++ b/docs/ai-and-plans/PRs/717-referenceText-unsafe-field-names.md
@@ -1,0 +1,215 @@
+# PR #717: Correct MQL aggregation references for unsafe field names
+
+**Branch:** `fix/709-referenceText-unsafe-field-names`
+**Base:** `main`
+**Date:** 2026-06-23
+**PR URL:** https://github.com/microsoft/vscode-documentdb/pull/717
+**Fixes:** #709
+
+---
+
+## Why
+
+`toFieldCompletionItems()` produces a `referenceText` for each schema field — the
+aggregation field reference (e.g. `$age`) that a future aggregation completion
+provider will offer. The original implementation always emitted `"$" + path`,
+which is **invalid MQL** for field names that are not valid `$`-prefix references:
+
+| Field name      | Old `referenceText` | Valid? |
+| --------------- | ------------------- | ------ |
+| `order-items`   | `$order-items`      | ❌     |
+| `my field`      | `$my field`         | ❌     |
+| `say"hi"`       | `$say"hi"`          | ❌     |
+
+This was documented as future work in
+[`future-work.md`](../../../src/utils/json/data-api/autocomplete/future-work.md)
+(item 2), with `$getField` (Option B) recommended as the fix.
+
+An initial pass added a single-segment `$getField` fallback, but it had three
+correctness gaps that this PR closes:
+
+1. **Nested paths were broken.** `a.order-items` produced
+   `{ $getField: "a.order-items" }`, which references a *top-level* field
+   literally named `a.order-items` — the wrong document — instead of the nested
+   `order-items` field inside `a`.
+2. **`$`-containing names were misclassified as safe.** The identifier check
+   allowed `$`, so a field named `$price` emitted `$$price`, which MQL reads as
+   the **variable** `$$price`, not the field.
+3. The interface doc claimed nested paths were handled when they were not.
+
+### Scope cleanup (rebase)
+
+The branch was originally stacked on the contributor's `#659` (index-count)
+branch, so the PR carried unrelated `IndexesItem.ts` changes that duplicated a
+feature **already merged to `main`** — the source of the merge conflict. The
+branch was rebased onto `main`, dropping the stale `#659` commits and keeping
+only the `#709` work. The PR now changes four files: the two autocomplete
+sources ([`toFieldCompletionItems.ts`](../../../src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts)
+and its test), the [`future-work.md`](../../../src/utils/json/data-api/autocomplete/future-work.md)
+status update, and this note.
+
+---
+
+## What was done
+
+### 1. Stricter aggregation-safe segment check
+
+A new `AGGREGATION_SAFE_SEGMENT_PATTERN` (`/^[a-zA-Z_][a-zA-Z0-9_]*$/`) replaces
+the previous reuse of `JS_IDENTIFIER_PATTERN` for reference safety. It is
+intentionally stricter: it rejects `$` because `$`/`$$` are reserved in
+aggregation expressions. `JS_IDENTIFIER_PATTERN` is still used unchanged for
+`insertText` quoting (a separate concern).
+
+### 2. `buildAggregationReference(path)` — correct nested references
+
+```
+$a.b.c                                   ← every segment safe (compact form)
+{ $getField: "order-items" }             ← unsafe top-level field
+{ $getField: { field: "order-items",     ← unsafe leaf in a nested path
+               input: "$a" } }
+```
+
+- A fully safe path keeps the compact `$a.b.c` form (unchanged behavior).
+- Otherwise the reference is built with `$getField`. The leading run of safe
+  segments is collapsed into a single quoted `"$a.b"` field-path used as the
+  innermost `input`, and each subsequent (unsafe or trailing) segment is wrapped
+  in `{ $getField: { field, input } }`. This is what makes nested references
+  semantically correct.
+- All literal segment names are escaped via the existing `escapeFieldName`
+  (`\` → `\\`, `"` → `\"`).
+
+### 3. Documentation
+
+- The `referenceText` JSDoc now describes the `$getField` forms and the
+  literal-dot limitation.
+- `future-work.md` item 2 is marked ✅ RESOLVED (mirroring item 1), with the
+  original description preserved in a `<details>` block.
+
+---
+
+## Where this applies (scope)
+
+`referenceText` is the **aggregation field-path expression** (`$field`) form. It
+is used wherever a field appears as an _expression value_, not as a _key_:
+
+```
+✔ affected (uses referenceText / "$field" form)
+  • db.coll.aggregate([ { $project / $group / $addFields / $match: { $expr } ... } ])
+  • find / update with $expr:   find({ $expr: { $gt: ["$order-items", 5] } })
+  • pipeline-form updates:       updateOne(filter, [ { $set: { x: "$a.order-items" } } ])
+
+✘ NOT affected (uses insertText — the quoted key, a different field)
+  • plain find filters:          { "order-items": 5 }
+  • projection include/exclude:  { "order-items": 1 }
+  • index keys, sort keys, etc.  { "order-items": -1 }
+```
+
+In a query a field is either a **key** (left of `:`) → `insertText`, unchanged by
+this PR — or an **expression value** (a `$`-reference) → `referenceText`, fixed
+here. So this is effectively "aggregation-expression contexts" (pipelines plus
+`$expr` and pipeline-style updates), not plain field-name positions.
+
+---
+
+## How it surfaces (examples)
+
+### Sample collection
+
+```
+db.orders  —  a document looks like:
+┌─────────────────────────────────────────────┐
+│ {                                            │
+│   "age":         30,                          │
+│   "address":   { "city": "Berlin" },          │
+│   "order-items": [ ... ],     ← dash (unsafe) │
+│   "a":         { "order-items": 5 },  ← nested│
+│   "$price":      9.99         ← leading $      │
+│ }                                             │
+└─────────────────────────────────────────────┘
+```
+
+### Where the completion kicks in
+
+The cursor sits where an **expression** is expected, and the provider lists fields:
+
+```
+db.orders.aggregate([
+  { $project: { total: ▮ } } ◄── cursor here, provider lists fields
+])
+                  │
+                  ▼
+        ┌──────────────────────────┐
+        │ ▸ age            number   │
+        │ ▸ address.city   string   │
+        │ ▸ order-items    array    │  ◄ pick one →
+        │ ▸ a.order-items  number   │     inserts its
+        │ ▸ $price         number   │     referenceText
+        └──────────────────────────┘
+```
+
+### Before vs. after (what gets inserted)
+
+```
+field picked        BEFORE (always "$"+path)        AFTER (this PR)
+──────────────────  ──────────────────────────────  ─────────────────────────────────────────────────
+age                 $age                      ✅     $age                                          ✅ (unchanged)
+address.city        $address.city             ✅     $address.city                                 ✅ (unchanged)
+
+order-items         $order-items              ❌     { $getField: "order-items" }                  ✅
+                    └ parsed as  $order MINUS items
+
+a.order-items       $a.order-items            ❌     { $getField: { field: "order-items",          ✅
+                    └ "$" form breaks on dash                      input: "$a" } }
+                                                     └ walks INTO "a", then reads the leaf
+
+$price              $$price                   ❌     { $getField: "$price" }                       ✅
+                    └ "$$" = a VARIABLE, not a field └ name treated as a literal
+```
+
+### The subtle one — nested vs. top-level (the core fix)
+
+The earlier single-segment patch would have emitted `{ $getField: "a.order-items" }`,
+which is still wrong: `$getField` with a plain string reads a _top-level_ field
+literally named `a.order-items`.
+
+```
+{ $getField: "a.order-items" }                         { $getField: { field: "order-items", input: "$a" } }
+┌───────────── ROOT ──────────────┐                    ┌───────────── ROOT ──────────────┐
+│ looks for a key literally named  │                    │ input: $a  ──►  { order-items: 5}│
+│ "a.order-items"  →  not found    │  ✗                 │ field: "order-items" ──► 5       │  ✓
+└──────────────────────────────────┘                    └──────────────────────────────────┘
+```
+
+---
+
+## Edge cases covered (tests)
+
+All in
+[`toFieldCompletionItems.test.ts`](../../../src/utils/json/data-api/autocomplete/toFieldCompletionItems.test.ts):
+
+| Case                                  | Input            | `referenceText`                                                                  |
+| ------------------------------------- | ---------------- | -------------------------------------------------------------------------------- |
+| Safe scalar / nested (regression)     | `age`, `address.city` | `$age`, `$address.city`                                                     |
+| Unsafe top-level                      | `order-items`    | `{ $getField: "order-items" }`                                                    |
+| Embedded quotes (top-level)           | `say"hi"`        | `{ $getField: "say\"hi\"" }`                                                      |
+| **Unsafe leaf in nested path**        | `a.order-items`  | `{ $getField: { field: "order-items", input: "$a" } }`                           |
+| **Safe multi-segment prefix collapse**| `a.b.c-d`        | `{ $getField: { field: "c-d", input: "$a.b" } }`                                  |
+| **Unsafe segment then safe segment**  | `order-items.city` | `{ $getField: { field: "city", input: { $getField: "order-items" } } }`        |
+| **Embedded quotes (nested)**          | `a.say"hi"`      | `{ $getField: { field: "say\"hi\"", input: "$a" } }`                             |
+| **Case 3 — `$` in name**              | `$price`, `a$b`, `a.$inner` | `{ $getField: "$price" }`, `{ $getField: "a$b" }`, `{ $getField: { field: "$inner", input: "$a" } }` |
+| **Case 4 — literal-dot ambiguity**    | `a.b`            | `$a.b` (treated as nested — documented limitation)                               |
+| **Case 5 — empty / degenerate**       | `""`, `a..b`     | `{ $getField: "" }`, nested `$getField` chain (defensive; never emitted by `getKnownFields`) |
+
+### Known limitation (out of scope)
+
+A field literally named `"a.b"` is indistinguishable from a nested `{ a: { b } }`
+because `FieldEntry.path` is a flattened, dot-joined string. Dots are always
+interpreted as nesting. Resolving this requires changing `path` to a segment
+array — tracked as item 3 in `future-work.md`.
+
+### Why no production-behavior risk
+
+`referenceText` is currently consumed only by tests; no production code path
+reads it yet (the aggregation completion provider is not wired up). This change
+prepares correct data for that future provider with no user-facing behavior
+change today.

--- a/src/utils/json/data-api/autocomplete/future-work.md
+++ b/src/utils/json/data-api/autocomplete/future-work.md
@@ -15,7 +15,23 @@ Tests cover dashes, brackets, digits, embedded quotes, and backslashes.
 
 ---
 
-## 2. `referenceText` is invalid MQL for special field names
+## 2. ~~`referenceText` is invalid MQL for special field names~~ ✅ RESOLVED
+
+**Resolved in:** PR #717 (fixes #709)
+
+Implemented Option B (`$getField`) with full support for nested paths via the
+`{ $getField: { field, input } }` form, plus a stricter aggregation-safe segment
+check that also routes `$`-containing names through `$getField`:
+
+- top-level unsafe field → `{ $getField: "order-items" }`
+- nested unsafe segment → `{ $getField: { field: "order-items", input: "$a" } }`
+- `$`-prefixed name (e.g. `$price`) → `{ $getField: "$price" }` (would otherwise be misread as the variable `$$price`)
+
+Literal-dot field names remain a known limitation (see item 3) because `path` is
+a flattened string; dots are always interpreted as nesting.
+
+<details>
+<summary>Original description</summary>
 
 **Severity:** Medium — will generate broken aggregation expressions
 **File:** `toFieldCompletionItems.ts` — `referenceText` construction
@@ -50,6 +66,8 @@ referenceText: needsQuoting
 **Option C — Provide both forms:** Add a `referenceTextRaw` (always `$path`) and `referenceTextSafe` (uses `$getField` when needed). Let the completion provider choose based on context.
 
 **Recommendation:** Option B is pragmatic. Option C is more flexible if we later need to support both forms in different contexts (e.g., `$match` vs `$project`).
+
+</details>
 
 ---
 

--- a/src/utils/json/data-api/autocomplete/toFieldCompletionItems.test.ts
+++ b/src/utils/json/data-api/autocomplete/toFieldCompletionItems.test.ts
@@ -113,6 +113,86 @@ describe('toFieldCompletionItems', () => {
         expect(result[0].referenceText).toBe('{ $getField: "say\\"hi\\"" }');
     });
 
+    // Multi-segment paths with an unsafe segment: a flat
+    // `{ $getField: "a.order-items" }` would look up a *top-level* field
+    // literally named "a.order-items", which is the wrong document. The
+    // correct reference walks into the parent via `{ field, input }`.
+    it('uses { field, input } for an unsafe leaf in a nested path', () => {
+        const fields: FieldEntry[] = [{ path: 'a.order-items', type: 'string', bsonType: 'string' }];
+
+        const result = toFieldCompletionItems(fields);
+
+        expect(result[0].referenceText).toBe('{ $getField: { field: "order-items", input: "$a" } }');
+    });
+
+    it('collapses a multi-segment safe prefix into a single $a.b input', () => {
+        const fields: FieldEntry[] = [{ path: 'a.b.c-d', type: 'string', bsonType: 'string' }];
+
+        const result = toFieldCompletionItems(fields);
+
+        expect(result[0].referenceText).toBe('{ $getField: { field: "c-d", input: "$a.b" } }');
+    });
+
+    it('nests $getField when an unsafe segment is followed by safe segments', () => {
+        const fields: FieldEntry[] = [{ path: 'order-items.city', type: 'string', bsonType: 'string' }];
+
+        const result = toFieldCompletionItems(fields);
+
+        expect(result[0].referenceText).toBe('{ $getField: { field: "city", input: { $getField: "order-items" } } }');
+    });
+
+    it('escapes embedded quotes in nested $getField segments', () => {
+        const fields: FieldEntry[] = [{ path: 'a.say"hi"', type: 'string', bsonType: 'string' }];
+
+        const result = toFieldCompletionItems(fields);
+
+        expect(result[0].referenceText).toBe('{ $getField: { field: "say\\"hi\\"", input: "$a" } }');
+    });
+
+    // Case 3: a field name beginning with `$` is NOT a valid `$`-prefix
+    // reference (it would be read as a variable, e.g. `$$price`). It must
+    // fall back to `$getField`, where the name is an opaque literal.
+    it('uses $getField for field names containing a $ (would be misread as a variable)', () => {
+        const fields: FieldEntry[] = [
+            { path: '$price', type: 'number', bsonType: 'int32' },
+            { path: 'a$b', type: 'string', bsonType: 'string' },
+            { path: 'a.$inner', type: 'string', bsonType: 'string' },
+        ];
+
+        const result = toFieldCompletionItems(fields);
+
+        expect(result[0].referenceText).toBe('{ $getField: "$price" }');
+        expect(result[1].referenceText).toBe('{ $getField: "a$b" }');
+        expect(result[2].referenceText).toBe('{ $getField: { field: "$inner", input: "$a" } }');
+    });
+
+    // Case 4: with a flattened `path` string there is no way to tell a field
+    // literally named "a.b" from a nested `{ a: { b } }`. Dots are always
+    // treated as nesting, so a safe dotted path keeps the compact form.
+    it('treats a dotted path with safe segments as nested (literal-dot ambiguity)', () => {
+        const fields: FieldEntry[] = [{ path: 'a.b', type: 'string', bsonType: 'string' }];
+
+        const result = toFieldCompletionItems(fields);
+
+        expect(result[0].referenceText).toBe('$a.b');
+    });
+
+    // Case 5 (defensive): getKnownFields never emits empty segments, but the
+    // builder must not produce a broken bare `$` reference if it ever does.
+    it('does not emit a bare $ reference for empty or degenerate segments', () => {
+        const fields: FieldEntry[] = [
+            { path: '', type: 'string', bsonType: 'string' },
+            { path: 'a..b', type: 'string', bsonType: 'string' },
+        ];
+
+        const result = toFieldCompletionItems(fields);
+
+        expect(result[0].referenceText).toBe('{ $getField: "" }');
+        expect(result[1].referenceText).toBe(
+            '{ $getField: { field: "b", input: { $getField: { field: "", input: "$a" } } } }',
+        );
+    });
+
     it('preserves isSparse', () => {
         const fields: FieldEntry[] = [
             { path: 'name', type: 'string', bsonType: 'string', isSparse: false },

--- a/src/utils/json/data-api/autocomplete/toFieldCompletionItems.test.ts
+++ b/src/utils/json/data-api/autocomplete/toFieldCompletionItems.test.ts
@@ -83,7 +83,7 @@ describe('toFieldCompletionItems', () => {
         expect(result[2].insertText).toBe('$type');
     });
 
-    it('adds $ prefix to referenceText', () => {
+    it('adds $ prefix to referenceText for safe field names', () => {
         const fields: FieldEntry[] = [
             { path: 'age', type: 'number', bsonType: 'int32' },
             { path: 'address.city', type: 'string', bsonType: 'string' },
@@ -93,6 +93,24 @@ describe('toFieldCompletionItems', () => {
 
         expect(result[0].referenceText).toBe('$age');
         expect(result[1].referenceText).toBe('$address.city');
+    });
+
+    it('uses $getField for unsafe field names in referenceText', () => {
+        const fields: FieldEntry[] = [
+            { path: 'order-items', type: 'string', bsonType: 'string' },
+            { path: 'my field', type: 'string', bsonType: 'string' },
+        ];
+
+        const result = toFieldCompletionItems(fields);
+
+        expect(result[0].referenceText).toBe('{ $getField: "order-items" }');
+        expect(result[1].referenceText).toBe('{ $getField: "my field" }');
+    });
+
+    it('escapes embedded double quotes in $getField referenceText', () => {
+        const fields: FieldEntry[] = [{ path: 'say"hi"', type: 'string', bsonType: 'string' }];
+        const result = toFieldCompletionItems(fields);
+        expect(result[0].referenceText).toBe('{ $getField: "say\\"hi\\"" }');
     });
 
     it('preserves isSparse', () => {

--- a/src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts
+++ b/src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts
@@ -34,11 +34,9 @@ export interface FieldCompletionData {
     /**
      * Field reference for aggregation expressions, e.g., "$age", "$address.city".
      *
-     * TODO: The simple `$field.path` syntax is invalid MQL for field names containing dots,
-     * spaces, or `$` characters. For such fields, the correct MQL syntax is
-     * `{ $getField: "fieldName" }`. This should be addressed when the aggregation
-     * completion provider is wired up — either by using `$getField` for special names
-     * or by making `referenceText` optional for fields that cannot use the `$` prefix syntax.
+     * For field names containing special characters (dashes, spaces, quotes, etc.)
+     * that cannot use the `$field` prefix syntax, this emits the `$getField` form
+     * instead, e.g., `{ $getField: "order-items" }`.
      */
     referenceText: string;
 }
@@ -52,6 +50,19 @@ export interface FieldCompletionData {
  * in `insertText` to produce valid query expressions.
  */
 const JS_IDENTIFIER_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+
+/**
+ * Returns true when every dot-separated segment of `path` is a valid
+ * identifier, meaning the `$field`-prefix aggregation syntax is safe.
+ *
+ * The `$` prefix syntax (e.g. `$address.city`) is valid MQL only when
+ * each segment between dots is a valid identifier.  Single-segment
+ * fields containing dashes, spaces, or quotes (e.g. `order-items`,
+ * `my field`, `say"hi"`) cannot use the `$` prefix.
+ */
+function isSafeAggregationReference(path: string): boolean {
+    return path.split('.').every((segment) => JS_IDENTIFIER_PATTERN.test(segment));
+}
 
 /**
  * Converts an array of FieldEntry objects into completion-ready FieldCompletionData items.
@@ -72,6 +83,16 @@ export function toFieldCompletionItems(fields: FieldEntry[]): FieldCompletionDat
             insertText = entry.path;
         }
 
+        let referenceText: string;
+        if (isSafeAggregationReference(entry.path)) {
+            referenceText = `$${entry.path}`;
+        } else {
+            const escaped = entry.path.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+            referenceText = needsQuoting
+                ? `{ $getField: "${escaped}" }`
+                : `{ $getField: "${entry.path}" }`;
+        }
+
         return {
             fieldName: entry.path,
             displayType,
@@ -80,7 +101,7 @@ export function toFieldCompletionItems(fields: FieldEntry[]): FieldCompletionDat
             displayTypes: entry.bsonTypes?.map((t) => BSONTypes.toDisplayString(t as BSONTypes)),
             isSparse: entry.isSparse ?? false,
             insertText,
-            referenceText: `$${entry.path}`,
+            referenceText,
         };
     });
 }

--- a/src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts
+++ b/src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts
@@ -34,9 +34,10 @@ export interface FieldCompletionData {
     /**
      * Field reference for aggregation expressions, e.g., "$age", "$address.city".
      *
-     * For field names containing special characters (dashes, spaces, quotes, etc.)
-     * that cannot use the `$field` prefix syntax, this emits the `$getField` form
-     * instead, e.g., `{ $getField: "order-items" }`.
+     * When every dot-separated segment is a valid identifier the `$field` prefix
+     * syntax is used.  If any segment contains special characters (dashes, spaces,
+     * quotes, etc.) — including in nested paths like `a.order-items` — the
+     * `$getField` form is emitted instead, e.g., `{ $getField: "order-items" }`.
      */
     referenceText: string;
 }
@@ -52,13 +53,23 @@ export interface FieldCompletionData {
 const JS_IDENTIFIER_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
 
 /**
+ * Escapes backslashes and double-quotes in a field path so it can be
+ * safely wrapped in a double-quoted string (for `insertText` quoting
+ * and `$getField` expressions).
+ */
+function escapeFieldName(path: string): string {
+    return path.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
  * Returns true when every dot-separated segment of `path` is a valid
  * identifier, meaning the `$field`-prefix aggregation syntax is safe.
  *
  * The `$` prefix syntax (e.g. `$address.city`) is valid MQL only when
- * each segment between dots is a valid identifier.  Single-segment
- * fields containing dashes, spaces, or quotes (e.g. `order-items`,
- * `my field`, `say"hi"`) cannot use the `$` prefix.
+ * each segment between dots is a valid identifier.  Paths where any
+ * segment contains dashes, spaces, or quotes (e.g. `order-items`,
+ * `a.order-items`, `my field`, `say"hi"`) cannot use the `$` prefix
+ * and must fall back to `$getField`.
  */
 function isSafeAggregationReference(path: string): boolean {
     return path.split('.').every((segment) => JS_IDENTIFIER_PATTERN.test(segment));
@@ -77,8 +88,7 @@ export function toFieldCompletionItems(fields: FieldEntry[]): FieldCompletionDat
 
         let insertText: string;
         if (needsQuoting) {
-            const escaped = entry.path.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-            insertText = `"${escaped}"`;
+            insertText = `"${escapeFieldName(entry.path)}"`;
         } else {
             insertText = entry.path;
         }
@@ -87,10 +97,7 @@ export function toFieldCompletionItems(fields: FieldEntry[]): FieldCompletionDat
         if (isSafeAggregationReference(entry.path)) {
             referenceText = `$${entry.path}`;
         } else {
-            const escaped = entry.path.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-            referenceText = needsQuoting
-                ? `{ $getField: "${escaped}" }`
-                : `{ $getField: "${entry.path}" }`;
+            referenceText = `{ $getField: "${escapeFieldName(entry.path)}" }`;
         }
 
         return {

--- a/src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts
+++ b/src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts
@@ -34,10 +34,15 @@ export interface FieldCompletionData {
     /**
      * Field reference for aggregation expressions, e.g., "$age", "$address.city".
      *
-     * When every dot-separated segment is a valid identifier the `$field` prefix
-     * syntax is used.  If any segment contains special characters (dashes, spaces,
-     * quotes, etc.) — including in nested paths like `a.order-items` — the
-     * `$getField` form is emitted instead, e.g., `{ $getField: "order-items" }`.
+     * When every dot-separated segment is aggregation-safe the compact `$field`
+     * prefix syntax is used. If any segment contains special characters (dashes,
+     * spaces, quotes) or a `$`, the `$getField` form is emitted instead:
+     * - top-level unsafe field → `{ $getField: "order-items" }`
+     * - nested unsafe segment  → `{ $getField: { field: "order-items", input: "$a" } }`
+     *
+     * Literal-dot field names (e.g. a field actually named `"a.b"`) cannot be
+     * distinguished from nested paths here and are treated as nested. See
+     * future-work.md item 3.
      */
     referenceText: string;
 }
@@ -53,6 +58,19 @@ export interface FieldCompletionData {
 const JS_IDENTIFIER_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
 
 /**
+ * Matches a single path segment that is safe to embed directly in the
+ * `$field` aggregation-reference syntax.
+ *
+ * This is intentionally STRICTER than {@link JS_IDENTIFIER_PATTERN}: a
+ * leading or embedded `$` is disallowed. In aggregation expressions the
+ * `$` prefix introduces a field path and `$$` introduces a variable, so a
+ * field literally named `$price` would be misread as the variable
+ * `$$price`, and `a$b` references are ambiguous. Such segments are routed
+ * through `$getField`, where the name is treated as an opaque literal.
+ */
+const AGGREGATION_SAFE_SEGMENT_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/**
  * Escapes backslashes and double-quotes in a field path so it can be
  * safely wrapped in a double-quoted string (for `insertText` quoting
  * and `$getField` expressions).
@@ -62,17 +80,60 @@ function escapeFieldName(path: string): string {
 }
 
 /**
- * Returns true when every dot-separated segment of `path` is a valid
- * identifier, meaning the `$field`-prefix aggregation syntax is safe.
+ * Builds a valid MQL aggregation field reference for a (possibly nested)
+ * field path.
  *
- * The `$` prefix syntax (e.g. `$address.city`) is valid MQL only when
- * each segment between dots is a valid identifier.  Paths where any
- * segment contains dashes, spaces, or quotes (e.g. `order-items`,
- * `a.order-items`, `my field`, `say"hi"`) cannot use the `$` prefix
- * and must fall back to `$getField`.
+ * - When every dot-separated segment is aggregation-safe, the compact
+ *   `$a.b.c` prefix form is used (e.g. `$address.city`).
+ * - Otherwise the reference is constructed with `$getField`:
+ *   - a top-level unsafe field → `{ $getField: "order-items" }`
+ *   - a nested unsafe segment  →
+ *     `{ $getField: { field: "<leaf>", input: <reference-to-parent> } }`
+ *
+ *   The leading run of safe segments is collapsed into a single quoted
+ *   `"$a.b"` field-path used as the innermost `input`, so only the unsafe
+ *   (and any trailing) segments need individual wrapping. Using the
+ *   `{ field, input }` form is what keeps nested references correct:
+ *   `{ $getField: "a.order-items" }` would instead look up a *top-level*
+ *   field literally named `a.order-items`, which is the wrong document.
+ *
+ * NOTE (known limitation): `FieldEntry.path` is a flattened, dot-joined
+ * string, so a field literally named `"a.b"` is indistinguishable from a
+ * nested `{ a: { b } }`. Dots are always interpreted as nesting. See
+ * future-work.md item 3 for the planned segment-array fix.
  */
-function isSafeAggregationReference(path: string): boolean {
-    return path.split('.').every((segment) => JS_IDENTIFIER_PATTERN.test(segment));
+function buildAggregationReference(path: string): string {
+    const segments = path.split('.');
+
+    // Fast path: a fully safe path keeps the compact `$a.b.c` form.
+    if (segments.every((segment) => AGGREGATION_SAFE_SEGMENT_PATTERN.test(segment))) {
+        return `$${path}`;
+    }
+
+    // Collapse the leading run of safe segments into a single `$a.b` input.
+    let prefixLength = 0;
+    while (prefixLength < segments.length && AGGREGATION_SAFE_SEGMENT_PATTERN.test(segments[prefixLength])) {
+        prefixLength++;
+    }
+
+    let reference: string;
+    let startIndex: number;
+    if (prefixLength > 0) {
+        // The safe leading run becomes a quoted `"$a.b"` field-path string,
+        // used as the `input` document for the first unsafe segment.
+        reference = `"$${segments.slice(0, prefixLength).join('.')}"`;
+        startIndex = prefixLength;
+    } else {
+        // No safe prefix: the first segment is an unsafe top-level field.
+        reference = `{ $getField: "${escapeFieldName(segments[0])}" }`;
+        startIndex = 1;
+    }
+
+    for (let i = startIndex; i < segments.length; i++) {
+        reference = `{ $getField: { field: "${escapeFieldName(segments[i])}", input: ${reference} } }`;
+    }
+
+    return reference;
 }
 
 /**
@@ -93,12 +154,7 @@ export function toFieldCompletionItems(fields: FieldEntry[]): FieldCompletionDat
             insertText = entry.path;
         }
 
-        let referenceText: string;
-        if (isSafeAggregationReference(entry.path)) {
-            referenceText = `$${entry.path}`;
-        } else {
-            referenceText = `{ $getField: "${escapeFieldName(entry.path)}" }`;
-        }
+        const referenceText = buildAggregationReference(entry.path);
 
         return {
             fieldName: entry.path,


### PR DESCRIPTION
## Summary
Stops `toFieldCompletionItems()` from emitting invalid MQL aggregation references for unsafe field names (containing dashes, spaces, quotes, `$`-prefixed names, etc.).

Previously, `referenceText` was always `$` + field path, which produces broken MQL for fields like `order-items`, `my field`, or `say"hi"`.

### Changes in `src/utils/json/data-api/autocomplete/toFieldCompletionItems.ts`
- Added `AGGREGATION_SAFE_SEGMENT_PATTERN` regex -- stricter than the JS identifier pattern, disallows leading/embedded `$` which would create ambiguous variable references
- Added `escapeFieldName()` helper -- escapes backslashes and double-quotes for use in `$getField` expressions
- Added `buildAggregationReference()` helper -- emits `$field` for fully safe paths, `{ $getField: "name" }` for unsafe top-level fields, and `{ $getField: { field: "<leaf>", input: <parent-ref> } }` for nested paths with unsafe segments
- Removed the TODO comment from the `referenceText` field doc and replaced it with accurate documentation

### Examples
| Field name | Before | After |
|---|---|---|
| `age` | `$age` | `$age` (unchanged) |
| `address.city` | `$address.city` | `$address.city` (unchanged) |
| `order-items` | `$order-items` (invalid) | `{ $getField: "order-items" }` |
| `a.order-items` | `$a.order-items` (invalid) | `{ $getField: { field: "order-items", input: "$a" } }` |
| `my field` | `$my field` (invalid) | `{ $getField: "my field" }` |
| `$price` | `$$price` (misread as variable) | `{ $getField: "$price" }` |
| `say"hi"` | `$say"hi"` (invalid) | `{ $getField: "say\"hi\"" }` |

### Documentation files updated
- `src/utils/json/data-api/autocomplete/future-work.md` -- item 2 marked as resolved, Option B (`$getField`) documented
- `docs/ai-and-plans/PRs/717-referenceText-unsafe-field-names.md` -- new PR tracking doc added

### Testing
- All 47 autocomplete tests pass (4 test suites)
- New tests for unsafe field name `referenceText` generation including nested paths and `$`-prefixed names
- TypeScript compilation passes with no errors

## Issue
Fixes #709