### PR TITLE
Perf: Convert keyword/operator arrays to Sets in Monarch tokenizer (fixes #582)

### DIFF
--- a/src/documentdb/shell/highlighting/monarchRunner.ts
+++ b/src/documentdb/shell/highlighting/monarchRunner.ts
@@ -192,19 +192,18 @@ const rulesSetCache = new WeakMap<MonarchLanguageRules, Map<string, Set<string>>
  * lazily converted to Sets on first lookup so subsequent `.has()` calls are O(1).
  */
 function resolveCases(matchedText: string, cases: Record<string, string>, rules: MonarchLanguageRules): string {
+    let arrayMap = rulesSetCache.get(rules);
+    if (!arrayMap) {
+        arrayMap = new Map();
+        rulesSetCache.set(rules, arrayMap);
+    }
+
     for (const [key, tokenType] of Object.entries(cases)) {
         if (key === '@default') {
             continue;
         }
 
         const arrayName = key.startsWith('@') ? key.slice(1) : key;
-
-        // Lazily convert the named array to a Set on first access
-        let arrayMap = rulesSetCache.get(rules);
-        if (!arrayMap) {
-            arrayMap = new Map();
-            rulesSetCache.set(rules, arrayMap);
-        }
 
         let set = arrayMap.get(arrayName);
         if (!set) {

--- a/src/documentdb/shell/highlighting/monarchRunner.ts
+++ b/src/documentdb/shell/highlighting/monarchRunner.ts
@@ -181,8 +181,15 @@ function resolveAction(action: string): string {
     return action;
 }
 
+// ─── Lazy Set cache for O(1) keyword/operator lookups ────────────────────────
+
+const rulesSetCache = new WeakMap<MonarchLanguageRules, Map<string, Set<string>>>();
+
 /**
  * Resolve a `cases` lookup: check if the matched text is in a named array.
+ *
+ * Named arrays (keywords, bsonConstructors, shellCommands, operators) are
+ * lazily converted to Sets on first lookup so subsequent `.has()` calls are O(1).
  */
 function resolveCases(matchedText: string, cases: Record<string, string>, rules: MonarchLanguageRules): string {
     for (const [key, tokenType] of Object.entries(cases)) {
@@ -190,11 +197,25 @@ function resolveCases(matchedText: string, cases: Record<string, string>, rules:
             continue;
         }
 
-        // Look up the named array in the rules object
         const arrayName = key.startsWith('@') ? key.slice(1) : key;
-        const array = rules[arrayName as keyof MonarchLanguageRules];
 
-        if (Array.isArray(array) && (array as string[]).includes(matchedText)) {
+        // Lazily convert the named array to a Set on first access
+        let arrayMap = rulesSetCache.get(rules);
+        if (!arrayMap) {
+            arrayMap = new Map();
+            rulesSetCache.set(rules, arrayMap);
+        }
+
+        let set = arrayMap.get(arrayName);
+        if (!set) {
+            const array = rules[arrayName as keyof MonarchLanguageRules];
+            if (Array.isArray(array)) {
+                set = new Set(array as readonly string[]);
+                arrayMap.set(arrayName, set);
+            }
+        }
+
+        if (set?.has(matchedText)) {
             return resolveAction(tokenType);
         }
     }


### PR DESCRIPTION
Fixes #582

## Summary
Converts keyword/operator array lookups in the Monarch tokenizer from O(n) `Array.includes()` to O(1) `Set.has()` using a lazy `WeakMap`-based cache.

### Changes in `src/documentdb/shell/highlighting/monarchRunner.ts`:
- Added `rulesSetCache` — a `WeakMap<MonarchLanguageRules, Map<string, Set<string>>>` that lazily converts named arrays (`keywords`, `bsonConstructors`, `shellCommands`, `operators`) to Sets on first access
- `resolveCases()` now uses `set?.has(matchedText)` instead of `(array as string[]).includes(matchedText)`
- `WeakMap` keyed by the rules object ensures cached Sets are garbage-collected when the rules reference is released

### Testing
- All 45 monarchRunner tests pass
- TypeScript compilation passes with no errors
