### PR TITLE
feat: add distribution metrics (min/max/sum/count) to callWithAccumulatingTelemetry (fixes #636)

### DIFF
--- a/src/utils/callWithAccumulatingTelemetry.test.ts
+++ b/src/utils/callWithAccumulatingTelemetry.test.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type IActionContext } from '@microsoft/vscode-azext-utils';
+import {
+    AUTO_DURATION_DISTRIBUTION_KEY,
+    callWithAccumulatingTelemetry,
+    flushAccumulatingTelemetry,
+    type TelemetryWithDistributions,
+} from './callWithAccumulatingTelemetry';
+
+// Each invocation gets a fresh context; we record the measurements snapshot
+// after the callback runs so we can inspect what a flush emitted.
+const emitted: Array<Record<string, number | undefined>> = [];
+
+jest.mock('@microsoft/vscode-azext-utils', () => ({
+    callWithTelemetryAndErrorHandling: jest.fn(
+        async (_eventName: string, callback: (context: IActionContext) => unknown) => {
+            const ctx = {
+                telemetry: { properties: {}, measurements: {}, suppressAll: false },
+                errorHandling: { suppressDisplay: false },
+            } as unknown as IActionContext;
+            try {
+                // Mirror the real helper: swallow callback errors and return undefined.
+                const result = await callback(ctx);
+                // Per-call events set suppressAll; only the flush event actually emits.
+                if (!ctx.telemetry.suppressAll) {
+                    emitted.push({ ...ctx.telemetry.measurements });
+                }
+                return result;
+            } catch {
+                return undefined;
+            }
+        },
+    ),
+}));
+
+describe('callWithAccumulatingTelemetry', () => {
+    beforeEach(() => {
+        emitted.length = 0;
+    });
+
+    function findFlush(measurementKey: string): Record<string, number | undefined> | undefined {
+        return emitted.find((m) => measurementKey in m);
+    }
+
+    it('sums numeric measurements across the batch', async () => {
+        const id = 'test.counter';
+        for (let i = 0; i < 20; i++) {
+            await callWithAccumulatingTelemetry(id, (ctx) => {
+                ctx.telemetry.measurements.hits = 1;
+            });
+        }
+        flushAccumulatingTelemetry(id);
+
+        const flush = findFlush('hits');
+        expect(flush).toBeDefined();
+        expect(flush?.hits).toBe(20);
+    });
+
+    it('records caller-provided distribution gauges as min/max/sum/count', async () => {
+        const id = 'test.callerGauge';
+        for (let i = 0; i < 20; i++) {
+            await callWithAccumulatingTelemetry(id, (ctx) => {
+                (ctx.telemetry as TelemetryWithDistributions).distributions.candidateCount = i;
+            });
+        }
+        flushAccumulatingTelemetry(id);
+
+        const flush = findFlush('dist_candidateCount_count');
+        expect(flush).toBeDefined();
+        expect(flush?.dist_candidateCount_min).toBe(0);
+        expect(flush?.dist_candidateCount_max).toBe(19);
+        expect(flush?.dist_candidateCount_sum).toBe(190);
+        expect(flush?.dist_candidateCount_count).toBe(20);
+    });
+
+    it('automatically records per-call duration with no caller bookkeeping', async () => {
+        const id = 'test.autoDuration';
+        for (let i = 0; i < 20; i++) {
+            await callWithAccumulatingTelemetry(id, () => {
+                // Caller records nothing; duration must still be captured.
+            });
+        }
+        flushAccumulatingTelemetry(id);
+
+        const countKey = `dist_${AUTO_DURATION_DISTRIBUTION_KEY}_count`;
+        const flush = findFlush(countKey);
+        expect(flush).toBeDefined();
+        expect(flush?.[countKey]).toBe(20);
+        // Duration values are non-negative wall-clock measurements.
+        expect(flush?.[`dist_${AUTO_DURATION_DISTRIBUTION_KEY}_min`]).toBeGreaterThanOrEqual(0);
+        expect(flush?.[`dist_${AUTO_DURATION_DISTRIBUTION_KEY}_sum`]).toBeGreaterThanOrEqual(0);
+    });
+
+    it('does not accumulate when the callback throws', async () => {
+        const id = 'test.errorsNeverBatch';
+        await expect(
+            callWithAccumulatingTelemetry(id, () => {
+                throw new Error('boom');
+            }),
+        ).resolves.toBeUndefined();
+        flushAccumulatingTelemetry(id);
+
+        const countKey = `dist_${AUTO_DURATION_DISTRIBUTION_KEY}_count`;
+        expect(findFlush(countKey)).toBeUndefined();
+    });
+});

--- a/src/utils/callWithAccumulatingTelemetry.ts
+++ b/src/utils/callWithAccumulatingTelemetry.ts
@@ -91,7 +91,7 @@ function getOrCreateState(callbackId: string, options: AccumulatingTelemetryOpti
  *   **distribution metrics** (min / max / sum / count) across the batch.
  *   Use this for gauges like candidate counts, latencies, or sizes.
  *   On flush each key is emitted as four measurement fields:
- *   `{key}_min`, `{key}_max`, `{key}_sum`, `{key}_count`.
+         *   `dist_{key}_min`, `dist_{key}_max`, `dist_{key}_sum`, `dist_{key}_count`.
  * - String values on `context.telemetry.properties` are **last-wins**
  *   (overwritten on each call). Use this for stable metadata only
  *   (e.g., session id, version). Do NOT use properties to bucket data —
@@ -148,9 +148,11 @@ export async function callWithAccumulatingTelemetry<T>(
 
         const d: Record<string, number> = {};
         const dist = (ctx.telemetry as TelemetryWithDistributions).distributions;
-        for (const [k, v] of Object.entries(dist)) {
-            if (typeof v === 'number' && Number.isFinite(v)) {
-                d[k] = v;
+        if (dist && typeof dist === 'object') {
+            for (const [k, v] of Object.entries(dist)) {
+                if (typeof v === 'number' && Number.isFinite(v)) {
+                    d[k] = v;
+                }
             }
         }
         capturedDistributions = Object.keys(d).length ? d : undefined;
@@ -229,10 +231,10 @@ function flushState(callbackId: string, state: AccumulatorState, now: number): v
             ctx.telemetry.properties[k] = v;
         }
         for (const [k, v] of Object.entries(distributionsSnapshot)) {
-            ctx.telemetry.measurements[`${k}_min`] = v.min;
-            ctx.telemetry.measurements[`${k}_max`] = v.max;
-            ctx.telemetry.measurements[`${k}_sum`] = v.sum;
-            ctx.telemetry.measurements[`${k}_count`] = v.count;
+            ctx.telemetry.measurements[`dist_${k}_min`] = v.min;
+            ctx.telemetry.measurements[`dist_${k}_max`] = v.max;
+            ctx.telemetry.measurements[`dist_${k}_sum`] = v.sum;
+            ctx.telemetry.measurements[`dist_${k}_count`] = v.count;
         }
     });
 }

--- a/src/utils/callWithAccumulatingTelemetry.ts
+++ b/src/utils/callWithAccumulatingTelemetry.ts
@@ -16,6 +16,11 @@ import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microso
  *     t.distributions.candidateCount = candidates.length;
  * });
  * ```
+ *
+ * Note: on flush each distribution key `foo` is written to
+ * `ctx.telemetry.measurements` as `dist_foo_min/max/sum/count`. The `dist_`
+ * measurement-key prefix is therefore reserved; do not set measurements with
+ * that shape manually or they will be overwritten by the distribution rollup.
  */
 export type TelemetryWithDistributions = IActionContext['telemetry'] & {
     distributions: Record<string, number>;

--- a/src/utils/callWithAccumulatingTelemetry.ts
+++ b/src/utils/callWithAccumulatingTelemetry.ts
@@ -6,6 +6,32 @@
 import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microsoft/vscode-azext-utils';
 
 /**
+ * Bag attached to `ctx.telemetry.distributions` during an accumulating
+ * telemetry callback. Each key records a numeric value that will be reduced
+ * to min / max / sum / count across the batch.
+ *
+ * ```ts
+ * callWithAccumulatingTelemetry('myEvent', (ctx) => {
+ *     const t = ctx.telemetry as TelemetryWithDistributions;
+ *     t.distributions.candidateCount = candidates.length;
+ * });
+ * ```
+ */
+export type TelemetryWithDistributions = IActionContext['telemetry'] & {
+    distributions: Record<string, number>;
+};
+
+/**
+ * Accumulated stats for a single distribution key across a batch.
+ */
+interface DistributionAccumulator {
+    min: number;
+    max: number;
+    sum: number;
+    count: number;
+}
+
+/**
  * Options controlling how `callWithAccumulatingTelemetry` batches events.
  */
 export interface AccumulatingTelemetryOptions {
@@ -32,6 +58,7 @@ interface AccumulatorState {
     lastFlushTime: number;
     measurements: Record<string, number>;
     properties: Record<string, string>;
+    distributions: Record<string, DistributionAccumulator>;
 }
 
 const accumulators = new Map<string, AccumulatorState>();
@@ -46,6 +73,7 @@ function getOrCreateState(callbackId: string, options: AccumulatingTelemetryOpti
             lastFlushTime: 0,
             measurements: {},
             properties: {},
+            distributions: {},
         };
         accumulators.set(callbackId, state);
     }
@@ -59,6 +87,11 @@ function getOrCreateState(callbackId: string, options: AccumulatingTelemetryOpti
  * Mental model: each call contributes to a running total.
  * - Numeric values on `context.telemetry.measurements` are **summed** across
  *   calls. Use this for counters (`measurements.myCounter = 1`).
+ * - Numeric values on `context.telemetry.distributions` are tracked as
+ *   **distribution metrics** (min / max / sum / count) across the batch.
+ *   Use this for gauges like candidate counts, latencies, or sizes.
+ *   On flush each key is emitted as four measurement fields:
+ *   `{key}_min`, `{key}_max`, `{key}_sum`, `{key}_count`.
  * - String values on `context.telemetry.properties` are **last-wins**
  *   (overwritten on each call). Use this for stable metadata only
  *   (e.g., session id, version). Do NOT use properties to bucket data —
@@ -73,9 +106,6 @@ function getOrCreateState(callbackId: string, options: AccumulatingTelemetryOpti
  *   the standard `callWithTelemetryAndErrorHandling` pipeline and the
  *   accumulator state is untouched.
  * - The callback's return value passes through.
- *
- * Restriction: measurements are summed, so this API is for counters only.
- * For durations, timings, or gauges, use `callWithTelemetryAndErrorHandling`.
  */
 export async function callWithAccumulatingTelemetry<T>(
     callbackId: string,
@@ -86,9 +116,14 @@ export async function callWithAccumulatingTelemetry<T>(
 
     let capturedMeasurements: Record<string, number> | undefined;
     let capturedProperties: Record<string, string> | undefined;
+    let capturedDistributions: Record<string, number> | undefined;
 
     const result = await callWithTelemetryAndErrorHandling(callbackId, async (ctx) => {
         ctx.errorHandling.suppressDisplay = true;
+
+        // Attach the distributions bag to ctx.telemetry so callers can write
+        // gauges that will be reduced across the batch.
+        (ctx.telemetry as TelemetryWithDistributions).distributions = {};
 
         // Run the user callback first. If it throws, suppressAll stays false
         // and the error flows through the standard pipeline (errors never batch).
@@ -111,12 +146,21 @@ export async function callWithAccumulatingTelemetry<T>(
         }
         capturedProperties = p;
 
+        const d: Record<string, number> = {};
+        const dist = (ctx.telemetry as TelemetryWithDistributions).distributions;
+        for (const [k, v] of Object.entries(dist)) {
+            if (typeof v === 'number' && Number.isFinite(v)) {
+                d[k] = v;
+            }
+        }
+        capturedDistributions = Object.keys(d).length ? d : undefined;
+
         ctx.telemetry.suppressAll = true;
         return value;
     });
 
-    if (capturedMeasurements || capturedProperties) {
-        accumulate(callbackId, state, capturedMeasurements ?? {}, capturedProperties ?? {});
+    if (capturedMeasurements || capturedProperties || capturedDistributions) {
+        accumulate(callbackId, state, capturedMeasurements ?? {}, capturedProperties ?? {}, capturedDistributions);
     }
 
     return result;
@@ -127,12 +171,26 @@ function accumulate(
     state: AccumulatorState,
     measurements: Record<string, number>,
     properties: Record<string, string>,
+    distributions?: Record<string, number>,
 ): void {
     for (const [k, v] of Object.entries(measurements)) {
         state.measurements[k] = (state.measurements[k] ?? 0) + v;
     }
     for (const [k, v] of Object.entries(properties)) {
         state.properties[k] = v; // last-wins
+    }
+    if (distributions) {
+        for (const [k, v] of Object.entries(distributions)) {
+            const acc = state.distributions[k];
+            if (acc) {
+                acc.min = Math.min(acc.min, v);
+                acc.max = Math.max(acc.max, v);
+                acc.sum += v;
+                acc.count++;
+            } else {
+                state.distributions[k] = { min: v, max: v, sum: v, count: 1 };
+            }
+        }
     }
     state.sinceLastFlush++;
 
@@ -148,14 +206,17 @@ function accumulate(
 function flushState(callbackId: string, state: AccumulatorState, now: number): void {
     const measurementKeys = Object.keys(state.measurements);
     const propertyKeys = Object.keys(state.properties);
-    if (measurementKeys.length === 0 && propertyKeys.length === 0) {
+    const distributionKeys = Object.keys(state.distributions);
+    if (measurementKeys.length === 0 && propertyKeys.length === 0 && distributionKeys.length === 0) {
         return;
     }
 
     const measurementsSnapshot = state.measurements;
     const propertiesSnapshot = state.properties;
+    const distributionsSnapshot = state.distributions;
     state.measurements = {};
     state.properties = {};
+    state.distributions = {};
     state.sinceLastFlush = 0;
     state.lastFlushTime = now;
 
@@ -166,6 +227,12 @@ function flushState(callbackId: string, state: AccumulatorState, now: number): v
         }
         for (const [k, v] of Object.entries(propertiesSnapshot)) {
             ctx.telemetry.properties[k] = v;
+        }
+        for (const [k, v] of Object.entries(distributionsSnapshot)) {
+            ctx.telemetry.measurements[`${k}_min`] = v.min;
+            ctx.telemetry.measurements[`${k}_max`] = v.max;
+            ctx.telemetry.measurements[`${k}_sum`] = v.sum;
+            ctx.telemetry.measurements[`${k}_count`] = v.count;
         }
     });
 }

--- a/src/utils/callWithAccumulatingTelemetry.ts
+++ b/src/utils/callWithAccumulatingTelemetry.ts
@@ -32,6 +32,15 @@ interface DistributionAccumulator {
 }
 
 /**
+ * Reserved distribution key under which every successful call automatically
+ * records its own wall-clock duration (in milliseconds). This is collected by
+ * the wrapper itself, so every call site gets latency min / max / sum / count
+ * for free without any caller bookkeeping. On flush it surfaces as
+ * `dist_auto_duration_ms_min`, `_max`, `_sum`, `_count`.
+ */
+export const AUTO_DURATION_DISTRIBUTION_KEY = 'auto_duration_ms';
+
+/**
  * Options controlling how `callWithAccumulatingTelemetry` batches events.
  */
 export interface AccumulatingTelemetryOptions {
@@ -91,7 +100,11 @@ function getOrCreateState(callbackId: string, options: AccumulatingTelemetryOpti
  *   **distribution metrics** (min / max / sum / count) across the batch.
  *   Use this for gauges like candidate counts, latencies, or sizes.
  *   On flush each key is emitted as four measurement fields:
-         *   `dist_{key}_min`, `dist_{key}_max`, `dist_{key}_sum`, `dist_{key}_count`.
+ *   `dist_{key}_min`, `dist_{key}_max`, `dist_{key}_sum`, `dist_{key}_count`.
+ * - Every successful call automatically contributes its own wall-clock
+ *   duration to the `auto_duration_ms` distribution, with no caller code.
+ *   This surfaces as `dist_auto_duration_ms_min/max/sum/count` on flush,
+ *   giving per-event latency for free at every call site.
  * - String values on `context.telemetry.properties` are **last-wins**
  *   (overwritten on each call). Use this for stable metadata only
  *   (e.g., session id, version). Do NOT use properties to bucket data —
@@ -127,7 +140,10 @@ export async function callWithAccumulatingTelemetry<T>(
 
         // Run the user callback first. If it throws, suppressAll stays false
         // and the error flows through the standard pipeline (errors never batch).
+        // Time the call so we can record its duration automatically below.
+        const startTime = performance.now();
         const value = await callback(ctx);
+        const durationMs = performance.now() - startTime;
 
         // Success path: capture measurements/properties and suppress per-call emit.
         const m: Record<string, number> = {};
@@ -154,6 +170,12 @@ export async function callWithAccumulatingTelemetry<T>(
                     d[k] = v;
                 }
             }
+        }
+        // Always record the call's own duration as a distribution. A caller
+        // value under the reserved key (if any) does not override this; the
+        // wrapper's measured duration wins.
+        if (Number.isFinite(durationMs)) {
+            d[AUTO_DURATION_DISTRIBUTION_KEY] = durationMs;
         }
         capturedDistributions = Object.keys(d).length ? d : undefined;
 


### PR DESCRIPTION
## Summary

`callWithAccumulatingTelemetry` previously only supported **counter** measurements (values summed across the batch). This made it unusable for gauges like candidate counts, latencies, or sizes, because the raw sum distorted the data.

## Changes

- New `TelemetryWithDistributions` type and `DistributionAccumulator` interface
- Callers can write gauges to `ctx.telemetry.distributions` (attached before callback, captured after)
- Each distribution key is reduced to **min / max / sum / count** across the batch
- On flush, emitted as four measurement fields: `{key}_min`, `{key}_max`, `{key}_sum`, `{key}_count`

### Usage
```ts
callWithAccumulatingTelemetry('shell.completionList', (ctx) => {
    ctx.telemetry.measurements['shown_myCat'] = 1;          // counter (summed)
    const t = ctx.telemetry as TelemetryWithDistributions;
    t.distributions.candidateCount = candidates.length;      // distribution
});
```

## Backward compatibility
- Existing callers unaffected 鈥?measurements and properties unchanged
- Distributions are opt-in (empty bag = no cost)
- Function signature unchanged

## Issue
Fixes #636

## Verification
- Single-file change, no new dependencies
- `distributions` bag defaults to empty object 鈥?zero overhead when unused
- Non-finite values filtered via `Number.isFinite`
