### PR TITLE
feat: flatten and simplify hello metadata telemetry in cluster metadata collector

### DIFF
--- a/src/documentdb/utils/getClusterMetadata.test.ts
+++ b/src/documentdb/utils/getClusterMetadata.test.ts
@@ -36,11 +36,10 @@ describe('getTelemetryShape', () => {
             ok: 1,
         };
 
-        const result = getTelemetryShape(helloInfo, ['$', 'connectionId', 'localTime']);
+        const result = getTelemetryShape(helloInfo, ['$', 'connectionId', 'localTime', 'hosts', 'me', 'primary']);
 
         expect(result).toBe(
             [
-                'hosts:array:string',
                 'internal.documentdb_versions:array:string',
                 'internal.kind:string',
                 'isWritablePrimary:boolean',
@@ -115,7 +114,7 @@ describe('getClusterMetadata', () => {
         expect(result['topology_hello_saslSupportedMechs']).toBe('SCRAM-SHA-256;MONGODB-OIDC');
         expect(result['topology_hello_internal_documentdb_versions']).toBe('1.112-0;1.113.0;12.1-1');
         expect(result['topology_hello_internal_kind']).toBe('azuredocumentdb');
-        expect(result['topology_helloShape']).toContain('hosts:array:string');
+        expect(result['topology_helloShape']).not.toContain('hosts:array:string');
         expect(result['topology_helloShape']).not.toContain('host-a');
         expect(result['topology_hello_hosts_0']).toBeUndefined();
         expect(result['topology_hello_connectionId']).toBeUndefined();

--- a/src/documentdb/utils/getClusterMetadata.test.ts
+++ b/src/documentdb/utils/getClusterMetadata.test.ts
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type MongoClient } from 'mongodb';
+
+import { getClusterMetadata, getTelemetryShape } from './getClusterMetadata';
+
+describe('getTelemetryShape', () => {
+    it('collects hello keys and value types without raw values', () => {
+        const helloInfo = {
+            isWritablePrimary: true,
+            msg: 'isdbgrid',
+            hosts: ['host-a', 'host-b'],
+            maxBsonObjectSize: 16777216,
+            maxMessageSizeBytes: 48000000,
+            maxWriteBatchSize: 25000,
+            maxWireVersion: 25,
+            minWireVersion: 0,
+            connectionId: 1339367315,
+            localTime: 1782455165668,
+            logicalSessionTimeoutMinutes: 30,
+            operationTime: {
+                $timestamp: {
+                    t: 1782455165,
+                    i: 668,
+                },
+            },
+            internal: {
+                documentdb_versions: ['1.112-0', '1.113.0'],
+                kind: 'azuredocumentdb',
+            },
+            saslSupportedMechs: ['SCRAM-SHA-256', 'MONGODB-OIDC'],
+            readOnly: false,
+            ok: 1,
+        };
+
+        const result = getTelemetryShape(helloInfo, ['$', 'connectionId', 'localTime']);
+
+        expect(result).toBe(
+            [
+                'hosts:array:string',
+                'internal.documentdb_versions:array:string',
+                'internal.kind:string',
+                'isWritablePrimary:boolean',
+                'logicalSessionTimeoutMinutes:number',
+                'maxBsonObjectSize:number',
+                'maxMessageSizeBytes:number',
+                'maxWireVersion:number',
+                'maxWriteBatchSize:number',
+                'minWireVersion:number',
+                'msg:string',
+                'ok:number',
+                'readOnly:boolean',
+                'saslSupportedMechs:array:string',
+            ].join(';'),
+        );
+
+        expect(result).not.toContain('host-a');
+        expect(result).not.toContain('connectionId');
+        expect(result).not.toContain('localTime');
+        expect(result).not.toContain('$timestamp');
+    });
+});
+
+describe('getClusterMetadata', () => {
+    it('collects only allow-listed hello values plus hello shape', async () => {
+        const helloInfo = {
+            msg: 'isdbgrid',
+            hosts: ['host-a', 'host-b'],
+            maxWireVersion: 25,
+            minWireVersion: 0,
+            connectionId: 1339367315,
+            localTime: 1782455165668,
+            internal: {
+                documentdb_versions: ['1.112-0', '1.113.0', '12.1-1'],
+                kind: 'azuredocumentdb',
+            },
+            saslSupportedMechs: ['SCRAM-SHA-256', 'MONGODB-OIDC'],
+            readOnly: false,
+            ok: 1,
+        };
+
+        const adminDb = {
+            command: jest.fn(async (command: Record<string, number>): Promise<unknown> => {
+                if (command.buildInfo === 1) {
+                    return { version: '1.0.0', platform: 'test', storageEngines: ['wiredTiger'] };
+                }
+
+                if (command.serverStatus === 1) {
+                    return { uptime: 10 };
+                }
+
+                if (command.hello === 1) {
+                    return helloInfo;
+                }
+
+                if (command.hostInfo === 1) {
+                    return { currentTime: 1782455165668 };
+                }
+
+                throw new Error('Unexpected command');
+            }),
+        };
+
+        const client = { db: () => ({ admin: () => adminDb }) } as unknown as MongoClient;
+
+        const result = await getClusterMetadata(client, ['host-a.example.com']);
+
+        expect(result['topology_type']).toBe('isdbgrid');
+        expect(result['topology_numberOfServers']).toBe('2');
+        expect(result['topology_maxWireVersion']).toBe('25');
+        expect(result['topology_minWireVersion']).toBe('0');
+        expect(result['topology_hello_saslSupportedMechs']).toBe('SCRAM-SHA-256;MONGODB-OIDC');
+        expect(result['topology_hello_internal_documentdb_versions']).toBe('1.112-0;1.113.0;12.1-1');
+        expect(result['topology_hello_internal_kind']).toBe('azuredocumentdb');
+        expect(result['topology_helloShape']).toContain('hosts:array:string');
+        expect(result['topology_helloShape']).not.toContain('host-a');
+        expect(result['topology_hello_hosts_0']).toBeUndefined();
+        expect(result['topology_hello_connectionId']).toBeUndefined();
+    });
+});

--- a/src/documentdb/utils/getClusterMetadata.test.ts
+++ b/src/documentdb/utils/getClusterMetadata.test.ts
@@ -36,7 +36,7 @@ describe('getTelemetryShape', () => {
             ok: 1,
         };
 
-        const result = getTelemetryShape(helloInfo, ['$', 'connectionId', 'localTime', 'hosts', 'me', 'primary']);
+        const result = getTelemetryShape(helloInfo);
 
         expect(result).toBe(
             [

--- a/src/documentdb/utils/getClusterMetadata.ts
+++ b/src/documentdb/utils/getClusterMetadata.ts
@@ -42,7 +42,7 @@ export function getDomainMetadata(hosts: string[]): ClusterMetadata {
 export async function getClusterMetadata(
     client: MongoClient,
     hosts: string[],
-    ignoredPrefixes: string[] = ['$', 'connectionId', 'localTime'],
+    ignoredPrefixes: string[] = ['$', 'connectionId', 'localTime', 'hosts', 'me', 'primary'],
 ): Promise<ClusterMetadata> {
     const result: ClusterMetadata = {};
 
@@ -168,7 +168,7 @@ async function fetchServerStatus(adminDb: Admin, result: ClusterMetadata): Promi
 async function fetchTopologyInfo(
     adminDb: Admin,
     result: ClusterMetadata,
-    ignoredPrefixes: string[] = ['$', 'connectionId', 'localTime'],
+    ignoredPrefixes: string[] = ['$', 'connectionId', 'localTime', 'hosts', 'me', 'primary'],
 ): Promise<void> {
     try {
         const helloInfo = await adminDb.command({ hello: 1 });

--- a/src/documentdb/utils/getClusterMetadata.ts
+++ b/src/documentdb/utils/getClusterMetadata.ts
@@ -39,29 +39,41 @@ export function getDomainMetadata(hosts: string[]): ClusterMetadata {
  * @returns A promise that resolves to an object containing various metadata about the MongoDB cluster.
  *
  */
-export async function getClusterMetadata(
-    client: MongoClient,
-    hosts: string[],
-    ignoredPrefixes: string[] = ['$', 'connectionId', 'localTime', 'hosts', 'me', 'primary'],
-): Promise<ClusterMetadata> {
+export async function getClusterMetadata(client: MongoClient, hosts: string[]): Promise<ClusterMetadata> {
     const result: ClusterMetadata = {};
 
     const adminDb = client.db().admin();
 
     await fetchBuildInfo(adminDb, result);
     await fetchServerStatus(adminDb, result);
-    await fetchTopologyInfo(adminDb, result, ignoredPrefixes);
+    await fetchTopologyInfo(adminDb, result);
     await fetchHostInfo(adminDb, result);
     processDomainInfo(hosts, result);
 
     return result;
 }
 
-function isIgnoredKey(key: string, ignoredKeys: string[]): boolean {
-    return ignoredKeys.some((ignored) => (ignored === '$' ? key.startsWith('$') : key === ignored));
+/**
+ * Hello-response keys excluded from the telemetry shape by exact match.
+ * These carry per-connection or per-request values that are not useful as shape signals.
+ */
+const DEFAULT_IGNORED_HELLO_KEYS = ['connectionId', 'localTime', 'hosts', 'me', 'primary'];
+
+/**
+ * Hello-response key prefixes excluded from the telemetry shape.
+ * Keys starting with '$' (e.g. '$clusterTime') are protocol metadata and are pruned along with their subtrees.
+ */
+const DEFAULT_IGNORED_HELLO_KEY_PREFIXES = ['$'];
+
+function isIgnoredKey(key: string, ignoredKeys: string[], ignoredKeyPrefixes: string[]): boolean {
+    return ignoredKeys.includes(key) || ignoredKeyPrefixes.some((prefix) => key.startsWith(prefix));
 }
 
-export function getTelemetryShape(value: unknown, ignoredKeys: string[] = []): string {
+export function getTelemetryShape(
+    value: unknown,
+    ignoredKeys: string[] = DEFAULT_IGNORED_HELLO_KEYS,
+    ignoredKeyPrefixes: string[] = DEFAULT_IGNORED_HELLO_KEY_PREFIXES,
+): string {
     const shapeEntries: string[] = [];
     const stack: Array<{ value: unknown; path: string }> = [{ value, path: '' }];
 
@@ -92,7 +104,7 @@ export function getTelemetryShape(value: unknown, ignoredKeys: string[] = []): s
         }
 
         for (const [key, child] of Object.entries(currentValue)) {
-            if (isIgnoredKey(key, ignoredKeys)) {
+            if (isIgnoredKey(key, ignoredKeys, ignoredKeyPrefixes)) {
                 continue;
             }
 
@@ -165,11 +177,7 @@ async function fetchServerStatus(adminDb: Admin, result: ClusterMetadata): Promi
     }
 }
 
-async function fetchTopologyInfo(
-    adminDb: Admin,
-    result: ClusterMetadata,
-    ignoredPrefixes: string[] = ['$', 'connectionId', 'localTime', 'hosts', 'me', 'primary'],
-): Promise<void> {
+async function fetchTopologyInfo(adminDb: Admin, result: ClusterMetadata): Promise<void> {
     try {
         const helloInfo = await adminDb.command({ hello: 1 });
         result['topology_type'] = helloInfo.msg || 'unknown';
@@ -180,7 +188,7 @@ async function fetchTopologyInfo(
         setIfDefined(result, 'topology_hello_saslSupportedMechs', helloInfo.saslSupportedMechs);
         setIfDefined(result, 'topology_hello_internal_documentdb_versions', helloInfo.internal?.documentdb_versions);
         setIfDefined(result, 'topology_hello_internal_kind', helloInfo.internal?.kind);
-        result['topology_helloShape'] = getTelemetryShape(helloInfo, ignoredPrefixes);
+        result['topology_helloShape'] = getTelemetryShape(helloInfo);
     } catch (error) {
         try {
             result['topology_error'] = error instanceof Error ? error.message : String(error);

--- a/src/documentdb/utils/getClusterMetadata.ts
+++ b/src/documentdb/utils/getClusterMetadata.ts
@@ -39,26 +39,108 @@ export function getDomainMetadata(hosts: string[]): ClusterMetadata {
  * @returns A promise that resolves to an object containing various metadata about the MongoDB cluster.
  *
  */
-export async function getClusterMetadata(client: MongoClient, hosts: string[]): Promise<ClusterMetadata> {
+export async function getClusterMetadata(
+    client: MongoClient,
+    hosts: string[],
+    ignoredPrefixes: string[] = ['$', 'connectionId', 'localTime'],
+): Promise<ClusterMetadata> {
     const result: ClusterMetadata = {};
 
     const adminDb = client.db().admin();
 
     await fetchBuildInfo(adminDb, result);
     await fetchServerStatus(adminDb, result);
-    await fetchTopologyInfo(adminDb, result);
+    await fetchTopologyInfo(adminDb, result, ignoredPrefixes);
     await fetchHostInfo(adminDb, result);
     processDomainInfo(hosts, result);
 
     return result;
 }
 
+function isIgnoredKey(key: string, ignoredKeys: string[]): boolean {
+    return ignoredKeys.some((ignored) => (ignored === '$' ? key.startsWith('$') : key === ignored));
+}
+
+export function getTelemetryShape(value: unknown, ignoredKeys: string[] = []): string {
+    const shapeEntries: string[] = [];
+    const stack: Array<{ value: unknown; path: string }> = [{ value, path: '' }];
+
+    while (stack.length > 0) {
+        const current = stack.pop()!;
+        const currentValue = current.value;
+        const currentPath = current.path;
+
+        if (currentValue === undefined || currentValue === null) {
+            if (currentPath) {
+                shapeEntries.push(`${currentPath}:${currentValue === null ? 'null' : 'undefined'}`);
+            }
+            continue;
+        }
+
+        if (Array.isArray(currentValue)) {
+            if (currentPath) {
+                shapeEntries.push(`${currentPath}:array:${getArrayElementType(currentValue)}`);
+            }
+            continue;
+        }
+
+        if (typeof currentValue !== 'object') {
+            if (currentPath) {
+                shapeEntries.push(`${currentPath}:${typeof currentValue}`);
+            }
+            continue;
+        }
+
+        for (const [key, child] of Object.entries(currentValue)) {
+            if (isIgnoredKey(key, ignoredKeys)) {
+                continue;
+            }
+
+            stack.push({ value: child, path: currentPath ? `${currentPath}.${key}` : key });
+        }
+    }
+
+    return shapeEntries.sort().join(';');
+}
+
+function getArrayElementType(values: readonly unknown[]): string {
+    const elementTypes = new Set(values.map(getTelemetryValueType));
+
+    if (elementTypes.size === 0) {
+        return 'empty';
+    }
+
+    if (elementTypes.size === 1) {
+        return Array.from(elementTypes)[0] ?? 'unknown';
+    }
+
+    return 'mixed';
+}
+
+function getTelemetryValueType(value: unknown): string {
+    if (value === null) {
+        return 'null';
+    }
+
+    if (Array.isArray(value)) {
+        return 'array';
+    }
+
+    return typeof value;
+}
+
+function setIfDefined(result: ClusterMetadata, key: string, value: unknown): void {
+    if (value !== undefined && value !== null) {
+        result[key] = Array.isArray(value) ? value.map(String).join(';') : String(value);
+    }
+}
+
 async function fetchBuildInfo(adminDb: Admin, result: ClusterMetadata): Promise<void> {
     try {
         const buildInfo = await adminDb.command({ buildInfo: 1 });
-        result['serverInfo_version'] = buildInfo.version;
-        result['serverInfo_platform'] = buildInfo.platform;
-        result['serverInfo_storageEngines'] = (buildInfo.storageEngines as string[])?.join(';');
+        setIfDefined(result, 'serverInfo_version', buildInfo.version);
+        setIfDefined(result, 'serverInfo_platform', buildInfo.platform);
+        setIfDefined(result, 'serverInfo_storageEngines', buildInfo.storageEngines);
     } catch (error) {
         try {
             result['serverInfo_error'] = error instanceof Error ? error.message : String(error);
@@ -72,7 +154,7 @@ async function fetchBuildInfo(adminDb: Admin, result: ClusterMetadata): Promise<
 async function fetchServerStatus(adminDb: Admin, result: ClusterMetadata): Promise<void> {
     try {
         const serverStatus = await adminDb.command({ serverStatus: 1 });
-        result['serverStatus_uptime'] = serverStatus.uptime.toString();
+        setIfDefined(result, 'serverStatus_uptime', serverStatus.uptime);
     } catch (error) {
         try {
             result['serverStatus_error'] = error instanceof Error ? error.message : String(error);
@@ -83,13 +165,22 @@ async function fetchServerStatus(adminDb: Admin, result: ClusterMetadata): Promi
     }
 }
 
-async function fetchTopologyInfo(adminDb: Admin, result: ClusterMetadata): Promise<void> {
+async function fetchTopologyInfo(
+    adminDb: Admin,
+    result: ClusterMetadata,
+    ignoredPrefixes: string[] = ['$', 'connectionId', 'localTime'],
+): Promise<void> {
     try {
         const helloInfo = await adminDb.command({ hello: 1 });
         result['topology_type'] = helloInfo.msg || 'unknown';
         result['topology_numberOfServers'] = (helloInfo.hosts?.length || 0).toString();
-        result['topology_minWireVersion'] = helloInfo.minWireVersion.toString();
-        result['topology_maxWireVersion'] = helloInfo.maxWireVersion.toString();
+        result['topology_minWireVersion'] = helloInfo.minWireVersion?.toString() ?? 'unknown';
+        result['topology_maxWireVersion'] = helloInfo.maxWireVersion?.toString() ?? 'unknown';
+
+        setIfDefined(result, 'topology_hello_saslSupportedMechs', helloInfo.saslSupportedMechs);
+        setIfDefined(result, 'topology_hello_internal_documentdb_versions', helloInfo.internal?.documentdb_versions);
+        setIfDefined(result, 'topology_hello_internal_kind', helloInfo.internal?.kind);
+        result['topology_helloShape'] = getTelemetryShape(helloInfo, ignoredPrefixes);
     } catch (error) {
         try {
             result['topology_error'] = error instanceof Error ? error.message : String(error);
@@ -110,7 +201,7 @@ async function fetchHostInfo(adminDb: Admin, result: ClusterMetadata): Promise<v
             hostInfo.system.currentTime = 'redacted'; // Redact system current time
         }
         // TODO: review in April 2024 if we need to redact more of the hostInfo fields.
-        result['hostInfo_json'] = JSON.stringify(hostInfo);
+        setIfDefined(result, 'hostInfo_json', JSON.stringify(hostInfo));
     } catch (error) {
         try {
             result['hostInfo_error'] = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
The topology info collected from the hello command was previously hand-picked field by field. This change replaces that with a generic iterative shape collector (`getTelemetryShape`) that walks the hello response and records a flat, value-free signal for each key.

For scalar values it records the key path and value type (e.g. `maxWireVersion:number`). For arrays it records only presence and element type (e.g. `saslSupportedMechs:array:string`) without descending into elements, so no index-specific paths or raw values are emitted and telemetry cardinality stays bounded. Nested objects are walked recursively.

Excluded keys are pruned (along with their subtrees) via two clearly-named lists: `ignoredKeys` (exact match, e.g. `connectionId`, `localTime`, `hosts`, `me`, `primary`) and `ignoredKeyPrefixes` (prefix match, e.g. any key starting with `$`). These defaults live in a single place and are applied directly by `getTelemetryShape`. A regression test covers the shape collection and exclusion behavior.