### PR TITLE
Add UX PR review helper skill

### DIFF
--- a/.github/skills/ux-pr-review/SKILL.md
+++ b/.github/skills/ux-pr-review/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: ux-pr-review
+description: Prepare and run an agent-assisted UX / workflow review of a pull request. Use when the operator says "I'm about to work on a UX PR review, please prepare", "prepare a UX review for PR #NNN", "review the UX of this branch/feature", or when pairing on a hands-on review where a person exercises the extension and the agent verifies findings against the code. The agent pre-seeds a structured review document (with a user-interaction diagram and a pre-discovered inconsistency list), then drives a live, iterative review loop grouped by severity. Does NOT cover pure code review (see CONTRIBUTING.md §6.1) or release notes (see writing-release-notes).
+---
+
+# UX PR Review (agent-assisted)
+
+A UX review is different from a code review: the value comes from **actually using the
+extension and walking real user journeys**, not from reading a diff. The pattern is a
+**person paired with an agent** — the person drives the UX and reports what they see; the
+agent reads the code, verifies each claim against it, keeps the running log, and maintains
+the todo list.
+
+This skill has **two modes**:
+
+1. **Prepare (pre-assessment)** — triggered up front. The agent inventories the feature's
+   user interactions, draws where each flow **starts and terminates**, pre-discovers
+   **flow inconsistencies** (modal vs. non-modal vs. silent), seeds the review document,
+   and hands off to the operator with an executive summary.
+2. **Live review** — the operator exercises the feature and dictates observations; the
+   agent verifies against code, records each finding, and keeps the priority index + todo
+   list current.
+
+> The full document skeleton lives in [references/review-document-template.md](./references/review-document-template.md).
+> The pre-discovery checklist lives in [references/inconsistency-checklist.md](./references/inconsistency-checklist.md).
+> Worked examples: [`docs/ai-and-plans/PRs/documentdb-quickstart/ux-review.md`](../../../docs/ai-and-plans/PRs/documentdb-quickstart/ux-review.md) and [`docs/ai-and-plans/PRs/621-kubernetes-discovery/bugbash-090-kubernetes-ux-review.md`](../../../docs/ai-and-plans/PRs/621-kubernetes-discovery/bugbash-090-kubernetes-ux-review.md).
+
+## When to Use
+
+- The operator asks to **prepare** a UX review, or says they are about to start one.
+- Reviewing the UX/workflow of a PR, branch, or feature by hand.
+- Pairing live: the operator reports what they saw and asks you to investigate and update
+  the todo list / review doc.
+
+---
+
+## Mode 1 — Prepare (do this when asked to "prepare")
+
+Work through these steps, then stop and hand off. **Do not start critiquing individual
+pixels yet** — the goal is to give the operator a seeded document and a map of the flows.
+
+### Step 1 — Identify the review target
+
+Determine the PR number, branch, and the **feature surface** (the source folders that
+implement it). If not given, ask which PR/branch. Read `package.json` menus/commands, the
+tree items, the webview components, and the command handlers for that surface.
+
+### Step 2 — Inventory the user interactions
+
+List every place the user can **act** on this feature: tree nodes and their context menus,
+empty-state rows, wizard steps / quick picks, webview buttons, commands, drag-and-drop.
+For each, note the **entry point** (how the user gets there) and the **terminal state**
+(success, error, silent no-op, dialog, tree refresh, new panel).
+
+### Step 3 — Draw where flows start and terminate
+
+Produce **both** an ASCII diagram and a Mermaid diagram in the document's "User
+interaction map" section:
+
+- **ASCII flow** — a compact state/branch map (see the `Appendix A` flow in the Local
+  Quick Start example). Good for phase machines and webview panels.
+- **Mermaid `flowchart`** — nodes for each user action/state, edges for transitions, and
+  **explicit terminal nodes** for every outcome (success toast, modal error, silent
+  no-op, tree badge). Mark inconsistent terminations so they stand out.
+
+```mermaid
+flowchart TD
+    A[User clicks 'Start'] --> B{Container ours & alive?}
+    B -- yes --> C[Starting… → Running badge]
+    B -- missing --> D([SILENT no-op ⚠️ only output channel])
+    B -- not ours --> E([Modal warning])
+```
+
+The point of the diagram is to make **asymmetric terminations obvious**: if one branch
+ends in a modal, another in a passive tree row, and a third in nothing at all, the diagram
+should show it at a glance.
+
+### Step 4 — Pre-discover flow inconsistencies
+
+Before the operator touches the feature, sweep the code for the inconsistencies UX reviews
+most often catch (full list in [references/inconsistency-checklist.md](./references/inconsistency-checklist.md)).
+The headline one:
+
+> **Error/feedback surface inconsistency** — the same _class_ of event is surfaced three
+> different ways across the feature: sometimes a **modal** (`showErrorMessage(…, { modal: true })`),
+> sometimes a **non-modal** toast/warning, sometimes a **passive tree row**, and sometimes
+> **nothing at all** (a silent early-return with only output-channel text). List every
+> occurrence with its file reference and flag the divergences. The house style across
+> shipped discovery providers is: **errors → modal + output channel; tree rows → actions
+> only; a single canonical "Click here to retry" node.**
+
+Seed these as **Flag** items in the document so the operator can confirm them live.
+
+### Step 5 — Seed the review document
+
+Create the file at **`docs/ai-and-plans/PRs/{pr-number}-{slug}/ux-review.md`** (or
+`ux-review-iteration-N-{topic}.md` for follow-up iterations). Use the full skeleton in
+[references/review-document-template.md](./references/review-document-template.md):
+header block, "How this review was run", the **Legend** (Priority + Status + Markers), the
+**User interaction map** (the two diagrams from Step 3), "The story in one paragraph", the
+**Priority index** table, the P0→P3 + Implemented section stubs (pre-filled with the Step-4
+Flags as `🟠 Open`), an **Open ideas** section, and an **Appendix** for the flow reference.
+
+> This document is committed. `docs/ai-and-plans/PRs/` is tracked — do **not** place it in
+> `docs/plan/` or `docs/analysis/` (those are git-ignored). Never `git add -f`.
+
+### Step 6 — Executive summary + hand-off
+
+End your turn with a short **executive summary of the pre-assessment**:
+
+- the feature surface and the flows you mapped;
+- how many pre-discovered Flags you seeded, grouped by suspected severity;
+- the top inconsistencies to confirm (especially error-surface asymmetry);
+- **where the seeded file is**, and an explicit invitation: _"The pre-seeded review doc is
+  at `<path>`. Start the hands-on investigation — exercise the feature and tell me what you
+  see; I'll verify each observation against the code and keep the doc and todo list
+  updated."_
+
+Do not proceed to deep per-item analysis until the operator starts driving.
+
+---
+
+## Mode 2 — Live review loop
+
+For each observation the operator reports:
+
+1. **Verify against code.** Trace the exact code path that produces the behavior. Never
+   record a finding you have not confirmed in the source.
+2. **Record the item** in the correct priority section using the four-part shape:
+   - **Observation** — what the reviewer saw (their words).
+   - **Finding** — what the code does and why, with file references and `⚠️`/`🔍` markers.
+   - **Suggestion** (💡) — the recommended direction. If the operator has a lean, capture it
+     as a blockquote _"TN leans towards … because …"_ and keep the status **Open** (it is a
+     suggestion, not a decision).
+   - **Status** — 🟠 Open / 🟡 Open (soft) / ✅ Implemented.
+3. **Update the Priority index** table and the **todo list** (`manage_todo_list`) so the
+   operator always sees remaining items at a glance.
+4. **Heavy trade-offs → Open ideas.** When a finding has real design options, add an
+   `O#` entry with a **pros/cons table** and a suggested option rather than deciding inline.
+5. **Out-of-scope → issues.** If a finding is beyond the PR's scope or would risk delaying
+   the merge, offer to file a repo issue and link it from the log instead of expanding scope.
+6. **Phase the work.** Review one user journey at a time (first-run/empty state → adding →
+   presentation → connectivity → destructive actions), closing each out before the next, so
+   context stays lean.
+
+If the operator asks for tests to lock in an agreed behavior, add them as the finding lands.
+
+---
+
+## Mode 3 — Fixing in iterations
+
+Once the operator starts choosing fixes, the review runs in **iterations**. Each iteration
+is a numbered pass over the open items; anything **not resolved in an iteration is carried
+forward to the next one** so nothing is ever silently dropped. The document is the ledger:
+an item leaves it only by becoming **Implemented**, **Closed** (won't-fix, with a reason),
+or **filed as a repo issue** (with a link).
+
+### The iteration loop
+
+1. **Group the current iteration.** Under an `## Iteration N` heading (or per-item
+   `➡️ Iteration N` sub-entries, as the K8s review does), list the items being worked this
+   pass. Everything still `🟠 Open` after the pass rolls into `## Iteration N+1`.
+2. **Capture the decision — and its _reason_ — before coding.** When the operator picks a
+   fix, **ask them why**. Record their choice _and_ the reasoning inline on the item as a
+   **Decision** block:
+
+   > **Decision (Iteration N):** {{what was chosen}}. **Reason:** {{operator's rationale}}.
+
+   > **Remind the operator:** _"This reasoning is the real value of the review — it's what
+   > lets future maintainers and contributors understand **why** the code looks the way it
+   > does. A one-line 'because …' now saves a re-litigation later."_ Never invent a
+   > rationale; if the operator hasn't given one, ask for it and wait.
+
+3. **Implement one item at a time.** Follow the code-review discipline in
+   [CONTRIBUTING.md](../../../CONTRIBUTING.md) §6.3: report progress inline; if you deviate
+   from the plan, document why; only proceed when confidence is high, otherwise stop and ask.
+   **Commit each item individually — no mass commits.**
+4. **Document the fix with a commit reference.** After the item is committed, flip its status
+   to `✅ Implemented` and append an **Implemented** block that says what changed, the files
+   touched, and a **link to the commit**:
+
+   > ✅ **Implemented (Iteration N):** {{what was done}}. Files: {{links}}.
+   > Commit: [`{{short-sha}}`]({{commit url}}). Verified via {{lint / tests / build}}.
+
+   If the fix answers a Copilot-reviewer comment or a repo issue, post the same summary there
+   and link it back from the item.
+
+5. **Carry forward the remainder.** At the end of the iteration, update the **Priority
+   index** (status column) and the **todo list** so every unresolved item is explicitly
+   parked in the next iteration. An item is never removed from the ledger without a terminal
+   status.
+
+### Terminal states for an item
+
+| Outcome                 | How it's recorded                                                            |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| Fixed on this branch    | `✅ Implemented` + Decision block + Implemented block with commit link       |
+| Won't fix               | `🚫 Closed` + a one-line **reason** (this reason is mandatory)               |
+| Deferred / out-of-scope | Filed as a repo issue, `🔗 Tracked` + issue link; removed from active P-list |
+| Still open              | Stays `🟠 Open` and **moves to the next iteration**                          |
+
+### After merge
+
+Stamp the log with a short reconciliation note pointing to the current source of truth (user
+manual / pre-merge code review), so a stale iteration is never mistaken for current behavior.
+
+---
+
+## Severity & status legend (use exactly these)
+
+**Priority**
+
+| Priority | Meaning                                            |
+| -------- | -------------------------------------------------- |
+| **P0**   | Blocking — the user gets stuck                     |
+| **P1**   | Broken / misleading, or a consistency & safety gap |
+| **P2**   | Polish, expectation, or a smaller feature gap      |
+| **P3**   | Nice-to-have / cosmetic / acknowledged             |
+
+**Status**
+
+| Status             | Meaning                                                                  |
+| ------------------ | ------------------------------------------------------------------------ |
+| 🟠 **Open**        | Recorded + analyzed; carries a recommendation but stays a _suggestion_   |
+| 🟡 **Open (soft)** | Open, but the recommendation depends on an investigation or is "as-is"   |
+| ✅ **Implemented** | A change was made on this branch and verified (Decision + commit link)   |
+| 🚫 **Closed**      | Won't fix — with a mandatory one-line reason                             |
+| 🔗 **Tracked**     | Deferred to a repo issue (linked); dropped from the active priority list |
+
+**Inline markers**
+
+| Marker            | Meaning                                                 |
+| ----------------- | ------------------------------------------------------- |
+| ⚠️ **Flag**       | Confirmed gap or bug                                    |
+| 💡 **Suggestion** | A design/wording recommendation to react to             |
+| 🔍 **Answered**   | A "how does this work?" question answered from the code |
+
+---
+
+## Conventions
+
+- **Terminology:** "DocumentDB" for the service; "MongoDB API" / "DocumentDB API" for the
+  wire protocol. Never "MongoDB" alone.
+- **File references:** link the exact file (and line where useful) that produces each
+  behavior so a later implementation pass does not have to re-derive it.
+- **Recommendations are suggestions, not decisions.** The operator (author) owns the call;
+  record their reasoning inline. This is what lets future maintainers understand _why_.
+- **Reconcile after merge.** A running log goes stale the moment behavior changes. When the
+  work merges, stamp the log with a note pointing to the current source of truth (user
+  manual / pre-merge code review).

--- a/.github/skills/ux-pr-review/references/inconsistency-checklist.md
+++ b/.github/skills/ux-pr-review/references/inconsistency-checklist.md
@@ -1,0 +1,138 @@
+# Pre-discovery inconsistency checklist
+
+Sweep the feature's code for these during **Prepare, Step 4**, before the operator touches
+the UI. These are the gaps UX reviews repeatedly catch that ordinary code review misses —
+they are only visible when you compare _sibling flows against each other_, not when reading
+one diff in isolation. Seed every hit as a `🟠 Open` item with an `⚠️` marker and a file
+reference.
+
+## 1. Error / feedback surface asymmetry (the big one)
+
+The same _class_ of event is surfaced differently across the feature. Grep for each surface
+and list every occurrence side by side:
+
+- **Modal** — `showErrorMessage(…, { modal: true })`, `showWarningMessage(…, { modal: true })`
+- **Non-modal toast** — `showErrorMessage(…)`, `showWarningMessage(…)`, `showInformationMessage(…)`
+- **Passive tree row** — an error/status node with **no command and no context menu** (exists
+  only to display a string; truncates in the tree, can't be copied)
+- **Silent** — a `catch { return undefined }` / early-`return` that produces **no UI**, with
+  detail only in the output channel
+
+**Flag when:** one branch of the _same feature_ ends in a modal, another in a toast, another
+in a passive row, and another in nothing. Decide one rule and apply it feature-wide.
+
+**House style (verified across shipped discovery providers):** errors → **modal + output
+channel**; tree rows are **actions only**; a single canonical **"Click here to retry"**
+node — never a passive in-tree error-summary row.
+
+## 2. Silent no-ops on user actions
+
+Lifecycle actions (start/stop/restart/connect/delete) that can **early-return with no
+feedback** when state drifted (container/resource deleted externally, session expired, item
+not found). The stale row persists; the user clicks and nothing happens. Flag every
+action-handler guard that can short-circuit before showing anything.
+
+## 3. Destructive-action consistency
+
+- Does every destructive command route through the **shared confirmation**
+  (`getConfirmationAsInSettings()`), honoring the user's `confirmationStyle`? Flag any
+  destructive action that calls a bespoke confirm (e.g. `getConfirmationWithClick()`) or
+  none at all.
+- Does a delete leave **orphans** (volume, secret, cached credentials, stored records)?
+- Is there a **hard precondition** that we only delete resources the extension created
+  (label/ownership re-check immediately before removal)?
+
+## 4. Consent before sensitive operations
+
+Reading the clipboard, copying a **password / connection string** to the clipboard, or
+storing secrets should be **consented and/or offer a "without password" choice** — not
+silent. Flag any path that puts a plaintext secret on the clipboard without a prompt when a
+sibling command does prompt.
+
+- **Preview before apply.** Whenever the user accepts **content from an external source** to
+  be applied/stored (clipboard, a dropped/opened file, pasted text — e.g. the K8s
+  "paste kubeconfig from clipboard" flow), they should be able to **review the content
+  before it takes effect**. Generalize: any "apply what I just handed you" action offers a
+  **Preview / Review** affordance (open it in an untitled doc, show a diff, or a confirm
+  dialog that displays what will be applied) and only proceeds on explicit confirmation.
+  Flag any import/apply path that consumes external content **blindly**.
+
+## 5. Empty state & first-run dead ends
+
+- Does the empty state offer an **actionable** row ("Click here to…"), or a passive
+  message? Passive-only states with no action are dead ends.
+- After a failed/leftover state, is there **always a way out** (Delete / Recreate / Retry)?
+  A state that shows a warning but exposes **no command** is stuck.
+- Are prerequisites (e.g. Docker) revealed **before** the user commits to the click, or only
+  after?
+
+## 6. Icon / label stability
+
+- **Stable provider-identity icons** vs. **state-driven icons** that flip on every refresh.
+  The house style is a fixed identity icon; transient state goes in `description` / tooltip.
+  Flag any tree node whose icon changes with lifecycle state.
+- **Wording drift:** the same concept named two ways (e.g. product name in the root vs. the
+  auth prompt); jargon labels ("Add kubeconfig source") vs. field-standard verbs; **em
+  dashes** and other punctuation in user-facing strings that need a sweep.
+
+## 7. Header / hero carrying state it shouldn't
+
+Webview headers that **change with phase** and can get **stuck** (e.g. success/failed reuse
+the "Setting up…" title). Prefer a **static header**; state lives in the body / a
+content-area card. Flag any hero that swaps per phase or doesn't branch on success/failure.
+
+## 8. Progress & long-wait honesty
+
+Long operations (image pull, readiness wait) that show a **static spinner + fixed label**
+for minutes with no live signal. Flag stages that can sit silent past ~10s; note whether a
+real progress signal (bytes, N-of-M) exists to surface.
+
+## 9. Wizard / quick-pick dead ends
+
+A wizard step that **throws and closes** when a precondition isn't met (not signed in, no
+session) instead of keeping the user in flow with an inline "Sign in…/Add…" affordance.
+
+## 10. Command / menu parity
+
+A bespoke node that **fully replaces** its base `contextValue` and thereby loses genuinely
+useful, storage-independent commands (e.g. "Open in Shell", "New Query"). Flag missing
+parity and note which commands are safe to opt back in.
+
+## 11. Accessibility of state changes
+
+Tree rows that change only `description` + icon on state transition with **no live-region
+announcement**, so screen-reader users don't hear the change. (Webviews often use
+`aria-live`; trees usually don't.) Record as a sequenced a11y item.
+
+## 12. Surprising / automatic actions ("no magic")
+
+**General rule: never surprise the user with actions happening "by magic."** When the
+extension does things on the user's behalf, it should be visible and, where consequential,
+reviewable.
+
+- **Automatic multi-step flows.** When several steps run automatically (e.g. the URL
+  handler that opens a connection: parse → add → reveal → connect), ask whether the user
+  is **told what is about to happen** and/or what **was** done. Consider a **confirmation /
+  summary notification** before or after the automatic sequence (the `vscodeUriHandler`
+  flow is the reference example). Flag any chain of side effects that fires with no
+  before/after signal.
+- **Consequential or irreversible auto-actions** (creating/removing resources, writing
+  storage, connecting to a target) warrant an **explicit confirm** or at minimum a clear
+  after-the-fact notice — not a silent side effect.
+- **Actions that complete too fast to notice.** When an automatic action finishes so
+  quickly the user can't tell it happened (or the UI flickers past a state), consider a
+  **short intentional delay** or a **transient progress/toast** so the change is
+  perceivable. A UI that snaps instantly through states reads as "nothing happened." Flag
+  spots where a small delay or a lingering confirmation would make an automatic action
+  legible.
+- **Where the review should decide:** for each automatic behavior, the operator picks one
+  of — (a) silent (only for trivial, reversible, expected actions), (b) after-the-fact
+  toast/summary, or (c) up-front confirmation — and the choice + reason is recorded as a
+  Decision. Consistency across sibling flows matters as much as the individual choice.
+
+---
+
+**Output of the sweep:** a list of concrete, code-referenced Flags grouped by suspected
+priority (P0–P3), ready to drop into the seeded document's priority sections and Priority
+index. The single highest-value output is the **error-surface asymmetry table** (item 1):
+every user-facing failure in the feature, and how it is surfaced today.

--- a/.github/skills/ux-pr-review/references/review-document-template.md
+++ b/.github/skills/ux-pr-review/references/review-document-template.md
@@ -1,0 +1,223 @@
+# Review document template
+
+Copy this skeleton verbatim into `docs/ai-and-plans/PRs/{pr-number}-{slug}/ux-review.md`
+and fill the `{{…}}` placeholders during the pre-assessment. Keep the section order.
+Sections marked _(seed now)_ are produced during **Prepare**; the P0–P3 item bodies are
+filled during the **Live review**.
+
+---
+
+````markdown
+# {{Feature}} — UX Review Pack
+
+> **Who this is for:** anyone about to do a hands-on UX review of the **{{Feature}}**
+> feature, or anyone triaging the findings.
+> **What this is:** a single catch-up document that captures a round of runtime UX
+> feedback, states what the code _actually does today_ (verified against the current
+> branch), and — for each item — offers a **suggestion** and a **status**. Items are
+> **sorted by priority** (P0 → P3).
+
+- **Feature area:** {{source folders that implement the surface}}
+- **PR / branch:** [{{owner/repo#NNN}}]({{pr url}}) · `{{branch}}`
+- **Related design docs:** {{links, if any}}
+- **Scope:** the UX-facing surface (tree structure, wording, icons, webviews, lifecycle
+  actions, error recovery). Backend internals appear only where they explain a
+  user-visible symptom.
+- **Review date:** {{YYYY-MM-DD}}
+
+## How this review was run
+
+A person exercised the real feature and dictated observations; an AI assistant did the
+code-checking, root-cause tracing, and write-up. Each finding is backed by the exact code
+path that produces the behavior, so a later implementation pass doesn't have to re-derive
+it. Items are grouped and ordered **by priority**; each carries an **Observation** (what
+the reviewer saw), a **Finding** (what the code does and why), a **Suggestion**, and a
+**Status**. Heavier design questions with real trade-offs are pulled into
+[Open ideas](#open-ideas--options-pros--cons).
+
+## Legend
+
+### Priority
+
+| Priority | Meaning                                            |
+| -------- | -------------------------------------------------- |
+| **P0**   | Blocking — the user gets stuck                     |
+| **P1**   | Broken / misleading, or a consistency & safety gap |
+| **P2**   | Polish, expectation, or a smaller feature gap      |
+| **P3**   | Nice-to-have / cosmetic / acknowledged             |
+
+### Status
+
+| Status             | Meaning                                                                  |
+| ------------------ | ------------------------------------------------------------------------ |
+| 🟠 **Open**        | Recorded + analyzed; carries a recommendation but stays a _suggestion_   |
+| 🟡 **Open (soft)** | Open, but depends on an investigation or is a soft "leave as-is"         |
+| ✅ **Implemented** | Changed on this branch and verified (Decision + commit link recorded)    |
+| 🚫 **Closed**      | Won't fix — with a mandatory one-line reason                             |
+| 🔗 **Tracked**     | Deferred to a repo issue (linked); dropped from the active priority list |
+
+> **Items are worked in iterations.** Anything still 🟠 Open at the end of an iteration
+> **moves to the next one** — an item leaves this ledger only as ✅ Implemented, 🚫 Closed,
+> or 🔗 Tracked. Each fix records **why it was chosen** (Decision) and **how it was done**
+> (Implemented + commit link).
+
+### Markers (inline)
+
+| Marker            | Meaning                                                 |
+| ----------------- | ------------------------------------------------------- |
+| ⚠️ **Flag**       | Confirmed gap or bug                                    |
+| 💡 **Suggestion** | A design/wording recommendation to react to             |
+| 🔍 **Answered**   | A "how does this work?" question answered from the code |
+
+> **For the operator:** items below are **Open** by default — each records a recommendation
+> ("… leans towards … because …") that is a **suggestion, not a final decision**. Disagree
+> freely; where there are real trade-offs, see [Open ideas](#open-ideas--options-pros--cons).
+
+---
+
+## User interaction map _(seed now)_
+
+Where every user action **starts** and where it **terminates**. Divergent terminations
+(modal vs. non-modal vs. silent) are flagged here and re-checked live.
+
+**ASCII flow**
+
+```text
+{{compact state / branch map — entry points on the left, terminal states on the right}}
+```
+
+**Mermaid**
+
+```mermaid
+flowchart TD
+    {{action}} --> {{decision}}
+    {{decision}} -- {{case}} --> {{terminal state, e.g. success toast}}
+    {{decision}} -- {{case}} --> {{([SILENT no-op ⚠️])}}
+    {{decision}} -- {{case}} --> {{([Modal error])}}
+```
+
+**Interaction inventory**
+
+| #     | User action (entry) | Where it lives | Terminal state(s)                | Surface                         | ⚠️                     |
+| ----- | ------------------- | -------------- | -------------------------------- | ------------------------------- | ---------------------- |
+| {{1}} | {{Click 'Start'}}   | {{file}}       | {{Running badge / silent no-op}} | {{tree / modal / toast / none}} | {{⚠️ if inconsistent}} |
+
+---
+
+## The story in one paragraph
+
+{{2–5 sentences: what the feature does, the journey, and the headline findings by
+priority.}}
+
+---
+
+## Priority index
+
+| #   | Priority | Item     | Status  |
+| --- | -------- | -------- | ------- |
+| 1   | **P0**   | {{item}} | 🟠 Open |
+| 2   | **P1**   | {{item}} | 🟠 Open |
+| …   |          |          |         |
+
+---
+
+## P0 — Blocking (the user gets stuck)
+
+### 1. {{Title}} ⚠️
+
+**Priority:** P0 · **Status:** 🟠 Open
+
+> **{{Reviewer}} leans towards {{direction}}** — {{one-line rationale}}. _Because {{why}}._
+
+**Observation:** {{what the reviewer saw}}
+
+**Finding:**
+
+- ⚠️ {{what the code does, with a file reference}}
+- 🔍 {{answered question, if any}}
+
+💡 **Suggestion:** {{recommended direction; link to an Open idea if there are trade-offs}}
+
+> **Decision (Iteration {{N}}):** {{what the operator chose}}. **Reason:** {{their rationale —
+> ask for it; this is the review's value for future maintainers}}.
+
+> ✅ **Implemented (Iteration {{N}}):** {{what was done}}. Files: {{links}}. Commit:
+> [`{{sha}}`]({{commit url}}). Verified via {{lint / tests / build}}.
+
+---
+
+## P1 — Broken / misleading, or consistency & safety
+
+{{### items …}}
+
+## P2 — Polish, expectation, or feature gap
+
+{{### items …}}
+
+## P3 — Nice-to-have / cosmetic / acknowledged
+
+{{### items …}}
+
+## Implemented
+
+{{### items that already shipped on this branch, with ✅}}
+
+---
+
+## Iteration log
+
+A running record of each fix pass. Items still 🟠 Open at the end of an iteration roll into
+the next one; nothing is dropped without a terminal status.
+
+### Iteration {{N}}
+
+| #     | Item     | Decision (why)      | Outcome                                |
+| ----- | -------- | ------------------- | -------------------------------------- |
+| {{1}} | {{item}} | {{chosen + reason}} | ✅ Implemented — [`{{sha}}`]({{url}})  |
+| {{2}} | {{item}} | —                   | 🟠 Open → carried to Iteration {{N+1}} |
+
+---
+
+## Open ideas — options, pros & cons
+
+Genuinely open design questions with real trade-offs. Recommendations are suggestions to
+react to, not decisions.
+
+### O1. {{Question}} (item {{n}})
+
+| Option       | Pros  | Cons  |
+| ------------ | ----- | ----- |
+| **A. {{…}}** | {{…}} | {{…}} |
+| **B. {{…}}** | {{…}} | {{…}} |
+
+> 💡 **Suggested:** {{option + why}}
+
+---
+
+## Appendix A — current flow (reference)
+
+{{Full ASCII phase/flow diagram of the webview or wizard state machine, plus a
+phase-by-phase description. This is the detailed version of the User interaction map.}}
+````
+
+---
+
+## Notes on filling it in
+
+- **Seed the Flags first.** After Step 4 of Prepare, every pre-discovered inconsistency
+  becomes a stub item in the right priority section with status `🟠 Open` and an `⚠️` marker,
+  and a row in the Priority index. The operator confirms/adjusts them live.
+- **One item = one `###` heading** with the `**Priority:** · **Status:**` line, an optional
+  `>` recommendation blockquote, then **Observation / Finding / Suggestion**.
+- **Keep the Priority index and the todo list in sync** as items are added or resolved.
+- **File references** use workspace-relative links to the exact file (and line where useful).
+- **Fix in iterations.** When the operator starts fixing, add each pass to the **Iteration
+  log**. Every item still `🟠 Open` at the end of an iteration is carried to the next one —
+  an item only leaves the ledger as `✅ Implemented`, `🚫 Closed` (with a reason), or `🔗
+Tracked` (issue link).
+- **Always record the _reason_ for a decision.** Ask the operator why they chose a fix and
+  write it in the item's **Decision** block. This rationale is the primary value of the
+  review for future maintainers and contributors.
+- **Document every fix with a commit link.** On completion, flip the status to `✅
+Implemented` and add the **Implemented** block (what changed, files, commit SHA link,
+  verification).


### PR DESCRIPTION
## Summary

- add the `ux-pr-review` skill for preparing and running agent-assisted UX reviews
- include the inconsistency checklist and review document template references
- cherry-pick the isolated skill commit from `feature/atlas-discovery`

## Validation

- `npx prettier --check '.github/skills/ux-pr-review/**/*.md'`
- `npm run prettier-fix`
- `npm run lint`
- `npx jest --no-coverage --runInBand` (159 suites, 2,674 tests)
- `npm run build`