### PR TITLE
fix(kubernetes): time out API requests

### DIFF
--- a/src/plugins/service-kubernetes/discovery-tree/KubernetesContextItem.test.ts
+++ b/src/plugins/service-kubernetes/discovery-tree/KubernetesContextItem.test.ts
@@ -470,7 +470,7 @@ describe('KubernetesContextItem', () => {
 
         it('should identify a namespace-list timeout and retain the retry action', async () => {
             (vscode.window.showErrorMessage as jest.Mock).mockClear();
-            const timeoutError = new Error('Operation timed out after 30 seconds.');
+            const timeoutError = new Error('localized deadline message');
             timeoutError.name = 'KubernetesApiTimeoutError';
             mockListNamespaces.mockRejectedValue(timeoutError);
 
@@ -487,9 +487,7 @@ describe('KubernetesContextItem', () => {
                     detail: expect.stringContaining('Connection timed out'),
                 }),
             );
-            expect(mockOutputChannelError).toHaveBeenCalledWith(
-                expect.stringContaining('Operation timed out after 30 seconds.'),
-            );
+            expect(mockOutputChannelError).toHaveBeenCalledWith(expect.stringContaining('localized deadline message'));
             expect(telemetryContextMock.telemetry.properties).toHaveProperty(
                 'namespaceFetchErrorType',
                 'KubernetesApiTimeoutError',

--- a/src/plugins/service-kubernetes/discovery-tree/KubernetesContextItem.test.ts
+++ b/src/plugins/service-kubernetes/discovery-tree/KubernetesContextItem.test.ts
@@ -395,6 +395,45 @@ describe('KubernetesContextItem', () => {
             expect(maxActiveScans).toBeLessThanOrEqual(5);
         });
 
+        it('should continue scanning remaining namespaces after one namespace times out', async () => {
+            const namespaces = [
+                'namespace-1',
+                'namespace-2',
+                'namespace-timeout',
+                'namespace-4',
+                'namespace-5',
+                'namespace-6',
+                'namespace-working',
+            ];
+            mockListNamespaces.mockResolvedValue(namespaces);
+            mockListDocumentDBServices.mockImplementation(async (_coreApi: unknown, namespace: string) => {
+                if (namespace === 'namespace-timeout') {
+                    const timeoutError = new Error('Operation timed out after 30 seconds.');
+                    timeoutError.name = 'KubernetesApiTimeoutError';
+                    throw timeoutError;
+                }
+
+                return namespace === 'namespace-working'
+                    ? [{ name: 'svc-a', namespace, type: 'ClusterIP', port: 10260 }]
+                    : [];
+            });
+
+            const item = new KubernetesContextItem('parent', 'default', baseContextInfo, 'corr-1');
+            const children = await item.getChildren();
+
+            expect(mockListDocumentDBServices).toHaveBeenCalledTimes(namespaces.length);
+            const timedOutNamespace = children?.find((child) => getNamespaceName(child) === 'namespace-timeout');
+            expect(timedOutNamespace).toBeDefined();
+            expect(getCollapsibleState(timedOutNamespace)).toBe(1);
+
+            const retryChildren = await timedOutNamespace!.getChildren!();
+            expect(retryChildren).toHaveLength(1);
+            expect((retryChildren![0] as { contextValue?: string }).contextValue).toBe('error');
+
+            const workingNamespace = children?.find((child) => getNamespaceName(child) === 'namespace-working');
+            expect(workingNamespace).toBeDefined();
+        });
+
         it('should show informational child when no namespaces exist', async () => {
             mockListNamespaces.mockResolvedValue([]);
 
@@ -426,6 +465,34 @@ describe('KubernetesContextItem', () => {
             expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
                 expect.stringContaining('Failed to connect'),
                 expect.objectContaining({ modal: true }),
+            );
+        });
+
+        it('should identify a namespace-list timeout and retain the retry action', async () => {
+            (vscode.window.showErrorMessage as jest.Mock).mockClear();
+            const timeoutError = new Error('Operation timed out after 30 seconds.');
+            timeoutError.name = 'KubernetesApiTimeoutError';
+            mockListNamespaces.mockRejectedValue(timeoutError);
+
+            const item = new KubernetesContextItem('parent', 'default', baseContextInfo, 'corr-1');
+            const children = await item.getChildren();
+
+            expect(children).toHaveLength(1);
+            expect((children![0] as { contextValue?: string }).contextValue).toBe('error');
+            expect(item.hasRetryNode(children)).toBe(true);
+            expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+                expect.stringContaining('Failed to connect'),
+                expect.objectContaining({
+                    modal: true,
+                    detail: expect.stringContaining('Connection timed out'),
+                }),
+            );
+            expect(mockOutputChannelError).toHaveBeenCalledWith(
+                expect.stringContaining('Operation timed out after 30 seconds.'),
+            );
+            expect(telemetryContextMock.telemetry.properties).toHaveProperty(
+                'namespaceFetchErrorType',
+                'KubernetesApiTimeoutError',
             );
         });
 

--- a/src/plugins/service-kubernetes/discovery-tree/KubernetesContextItem.ts
+++ b/src/plugins/service-kubernetes/discovery-tree/KubernetesContextItem.ts
@@ -17,6 +17,7 @@ import {
     DISCOVERY_VIEW_MODE_STATE_KEY,
     type KubernetesViewMode,
 } from '../config';
+import { isKubernetesApiTimeoutError } from '../kubernetesApiTimeout';
 import {
     createCoreApi,
     listDocumentDBServices,
@@ -106,12 +107,7 @@ export class KubernetesContextItem implements TreeElement, TreeElementWithContex
                     context.telemetry.properties.namespaceFetchErrorType =
                         error instanceof Error ? error.name : 'UnknownError';
 
-                    return createConnectionErrorChildren(
-                        this.id,
-                        errorMessage,
-                        this,
-                        this.alias ?? this.contextInfo.name,
-                    );
+                    return createConnectionErrorChildren(this.id, error, this, this.alias ?? this.contextInfo.name);
                 }
 
                 context.telemetry.measurements.clusterConnectMs = Date.now() - clusterConnectStart;
@@ -341,9 +337,18 @@ async function mapWithBoundedConcurrency<T>(
  * Classifies a Kubernetes API error message into a user-friendly summary
  * and an actionable hint so tree error nodes are immediately useful.
  */
-function classifyConnectionError(errorMessage: string): { summary: string; hint: string } {
+function classifyConnectionError(error: unknown): { summary: string; hint: string } {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     const lower = errorMessage.toLowerCase();
 
+    if (isKubernetesApiTimeoutError(error)) {
+        return {
+            summary: vscode.l10n.t('Connection timed out'),
+            hint: vscode.l10n.t(
+                'The cluster did not respond in time. Check your network connection and firewall settings.',
+            ),
+        };
+    }
     if (lower.includes('401') || lower.includes('unauthorized')) {
         return {
             summary: vscode.l10n.t('Authentication failed (401 Unauthorized)'),
@@ -427,11 +432,12 @@ function classifyConnectionError(errorMessage: string): { summary: string; hint:
  */
 function createConnectionErrorChildren(
     parentId: string,
-    errorMessage: string,
+    error: unknown,
     retryTarget: TreeElement,
     connectionLabel: string,
 ): TreeElement[] {
-    const { summary, hint } = classifyConnectionError(errorMessage);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const { summary, hint } = classifyConnectionError(error);
 
     void vscode.window.showErrorMessage(vscode.l10n.t('Failed to connect to "{0}"', connectionLabel), {
         modal: true,

--- a/src/plugins/service-kubernetes/discovery-tree/KubernetesNamespaceItem.test.ts
+++ b/src/plugins/service-kubernetes/discovery-tree/KubernetesNamespaceItem.test.ts
@@ -229,7 +229,7 @@ describe('KubernetesNamespaceItem', () => {
 
         it('should identify a timed-out service request and retain the retry action', async () => {
             (vscode.window.showErrorMessage as jest.Mock).mockClear();
-            const timeoutError = new Error('Operation timed out after 30 seconds.');
+            const timeoutError = new Error('localized deadline message');
             timeoutError.name = 'KubernetesApiTimeoutError';
             mockListDocumentDBServices.mockRejectedValue(timeoutError);
 
@@ -246,9 +246,7 @@ describe('KubernetesNamespaceItem', () => {
                     detail: expect.stringContaining('Connection timed out'),
                 }),
             );
-            expect(mockOutputChannelError).toHaveBeenCalledWith(
-                expect.stringContaining('Operation timed out after 30 seconds.'),
-            );
+            expect(mockOutputChannelError).toHaveBeenCalledWith(expect.stringContaining('localized deadline message'));
             expect(telemetryContextMock.telemetry.properties).toHaveProperty(
                 'serviceFetchErrorType',
                 'KubernetesApiTimeoutError',

--- a/src/plugins/service-kubernetes/discovery-tree/KubernetesNamespaceItem.test.ts
+++ b/src/plugins/service-kubernetes/discovery-tree/KubernetesNamespaceItem.test.ts
@@ -227,6 +227,34 @@ describe('KubernetesNamespaceItem', () => {
             expect(telemetryContextMock.telemetry.properties).toHaveProperty('serviceFetchError', 'true');
         });
 
+        it('should identify a timed-out service request and retain the retry action', async () => {
+            (vscode.window.showErrorMessage as jest.Mock).mockClear();
+            const timeoutError = new Error('Operation timed out after 30 seconds.');
+            timeoutError.name = 'KubernetesApiTimeoutError';
+            mockListDocumentDBServices.mockRejectedValue(timeoutError);
+
+            const item = new KubernetesNamespaceItem('parent/ctx', 'default', baseContextInfo, 'my-ns', 'corr-1');
+            const children = await item.getChildren();
+
+            expect(children).toHaveLength(1);
+            expect((children![0] as { contextValue?: string }).contextValue).toBe('error');
+            expect(item.hasRetryNode(children)).toBe(true);
+            expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+                expect.stringContaining('Failed to list services in "my-context/my-ns"'),
+                expect.objectContaining({
+                    modal: true,
+                    detail: expect.stringContaining('Connection timed out'),
+                }),
+            );
+            expect(mockOutputChannelError).toHaveBeenCalledWith(
+                expect.stringContaining('Operation timed out after 30 seconds.'),
+            );
+            expect(telemetryContextMock.telemetry.properties).toHaveProperty(
+                'serviceFetchErrorType',
+                'KubernetesApiTimeoutError',
+            );
+        });
+
         it('should show retry node and modal when kubeconfig fails to load', async () => {
             (vscode.window.showErrorMessage as jest.Mock).mockClear();
             mockLoadConfiguredKubeConfig.mockRejectedValue(new Error('ENOENT: config not found'));

--- a/src/plugins/service-kubernetes/discovery-tree/KubernetesNamespaceItem.ts
+++ b/src/plugins/service-kubernetes/discovery-tree/KubernetesNamespaceItem.ts
@@ -13,6 +13,7 @@ import { createGenericElementWithContext } from '../../../tree/api/createGeneric
 import { containsRetryNode, createRetryNode } from '../../../tree/api/retryNode';
 import { getCountPrefix } from '../../../utils/countPrefix';
 import { DISCOVERY_PROVIDER_ID } from '../config';
+import { isKubernetesApiTimeoutError } from '../kubernetesApiTimeout';
 import {
     createCoreApi,
     listDocumentDBServices,
@@ -69,7 +70,7 @@ export class KubernetesNamespaceItem implements TreeElement, TreeElementWithCont
                         error instanceof Error ? error.name : 'UnknownError';
                     return createServiceErrorChildren(
                         this.id,
-                        errorMessage,
+                        error,
                         this,
                         `${this.contextInfo.name}/${this.namespace}`,
                     );
@@ -156,16 +157,22 @@ export class KubernetesNamespaceItem implements TreeElement, TreeElementWithCont
  */
 function createServiceErrorChildren(
     parentId: string,
-    errorMessage: string,
+    error: unknown,
     retryTarget: TreeElement,
     namespaceLabel: string,
 ): TreeElement[] {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     const lower = errorMessage.toLowerCase();
 
     let summary: string;
     let hint: string;
 
-    if (lower.includes('403') || lower.includes('forbidden')) {
+    if (isKubernetesApiTimeoutError(error)) {
+        summary = vscode.l10n.t('Connection timed out');
+        hint = vscode.l10n.t(
+            'The cluster did not respond in time. Check your network connection and firewall settings.',
+        );
+    } else if (lower.includes('403') || lower.includes('forbidden')) {
         summary = vscode.l10n.t('Access denied listing services (403 Forbidden)');
         hint = vscode.l10n.t('Your account lacks permission to list services in this namespace.');
     } else if (lower.includes('401') || lower.includes('unauthorized')) {

--- a/src/plugins/service-kubernetes/discovery-tree/KubernetesNamespaceItem.ts
+++ b/src/plugins/service-kubernetes/discovery-tree/KubernetesNamespaceItem.ts
@@ -171,6 +171,11 @@ function createServiceErrorChildren(
     } else if (lower.includes('401') || lower.includes('unauthorized')) {
         summary = vscode.l10n.t('Authentication failed listing services (401)');
         hint = vscode.l10n.t('Credentials may have expired. Re-authenticate with your cluster.');
+    } else if (lower.includes('timeout') || lower.includes('timed out')) {
+        summary = vscode.l10n.t('Connection timed out');
+        hint = vscode.l10n.t(
+            'The cluster did not respond in time. Check your network connection and firewall settings.',
+        );
     } else {
         summary = vscode.l10n.t('Failed to list services');
         hint = vscode.l10n.t('Check the output channel for details.');

--- a/src/plugins/service-kubernetes/kubernetesApiTimeout.test.ts
+++ b/src/plugins/service-kubernetes/kubernetesApiTimeout.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+    createKubernetesApiOperationError,
+    getKubernetesApiErrorMessage,
+    isKubernetesApiTimeoutError,
+    normalizeKubernetesApiError,
+} from './kubernetesApiTimeout';
+
+jest.mock('vscode', () => ({
+    l10n: {
+        t: jest.fn((template: string, ...args: unknown[]) =>
+            template.replace(/\{(\d+)\}/g, (_match: string, index: string) => String(args[Number(index)])),
+        ),
+    },
+}));
+
+function createNamedError(name: string, message: string): Error {
+    const error = new Error(message);
+    error.name = name;
+    return error;
+}
+
+describe('kubernetesApiTimeout', () => {
+    it.each(['AbortError', 'TimeoutError'])('normalizes generated-client %s failures as timeouts', (name) => {
+        const rawError = createNamedError(name, 'transport abort');
+
+        expect(isKubernetesApiTimeoutError(rawError)).toBe(false);
+
+        const normalized = normalizeKubernetesApiError(rawError);
+        expect(isKubernetesApiTimeoutError(normalized)).toBe(true);
+        expect(normalized.message).toBe('Operation timed out after 30 seconds.');
+    });
+
+    it('does not classify an arbitrary AbortError until it crosses a known API boundary', () => {
+        const abortError = createNamedError('AbortError', 'request cancelled during teardown');
+
+        expect(isKubernetesApiTimeoutError(abortError)).toBe(false);
+        expect(getKubernetesApiErrorMessage(abortError)).toBe('request cancelled during teardown');
+    });
+
+    it('preserves contextual messages on an already-wrapped timeout error', () => {
+        const contextualError = createNamedError(
+            'KubernetesApiTimeoutError',
+            'Failed to list services in namespace "app": Operation timed out after 30 seconds.',
+        );
+
+        expect(normalizeKubernetesApiError(contextualError)).toBe(contextualError);
+        expect(getKubernetesApiErrorMessage(contextualError)).toBe(contextualError.message);
+    });
+
+    it('brands a contextual operation error when its cause is a generated-client timeout', () => {
+        const normalizedCause = normalizeKubernetesApiError(createNamedError('AbortError', 'transport abort'));
+        const operationError = createKubernetesApiOperationError(
+            'Failed to list namespaces: Operation timed out after 30 seconds.',
+            normalizedCause,
+        );
+
+        expect(isKubernetesApiTimeoutError(operationError)).toBe(true);
+        expect(operationError.message).toBe('Failed to list namespaces: Operation timed out after 30 seconds.');
+    });
+
+    it('does not brand a contextual operation error from an unnormalized AbortError', () => {
+        const operationError = createKubernetesApiOperationError(
+            'Port-forward setup was cancelled.',
+            createNamedError('AbortError', 'request cancelled during teardown'),
+        );
+
+        expect(isKubernetesApiTimeoutError(operationError)).toBe(false);
+    });
+});

--- a/src/plugins/service-kubernetes/kubernetesApiTimeout.ts
+++ b/src/plugins/service-kubernetes/kubernetesApiTimeout.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type Middleware } from '@kubernetes/client-node';
+import * as vscode from 'vscode';
+
+export const KUBERNETES_API_TIMEOUT_MS = 30_000;
+
+const KUBERNETES_API_TIMEOUT_SECONDS = KUBERNETES_API_TIMEOUT_MS / 1000;
+const KUBERNETES_API_TIMEOUT_ERROR_NAME = 'KubernetesApiTimeoutError';
+
+export const kubernetesApiTimeoutMiddleware: Middleware = {
+    async pre(context) {
+        // A signal cannot be reused after it aborts. Create a fresh deadline for
+        // every generated-client request when the middleware runs.
+        context.setSignal(AbortSignal.timeout(KUBERNETES_API_TIMEOUT_MS));
+        return context;
+    },
+    async post(context) {
+        return context;
+    },
+};
+
+export function isKubernetesApiTimeoutError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+
+    // The generated client uses node-fetch v2, which reports an aborted
+    // AbortSignal as AbortError. TimeoutError covers runtimes that preserve
+    // AbortSignal.timeout()'s native reason instead.
+    return (
+        error.name === KUBERNETES_API_TIMEOUT_ERROR_NAME || error.name === 'AbortError' || error.name === 'TimeoutError'
+    );
+}
+
+export function getKubernetesApiErrorMessage(error: unknown): string {
+    if (isKubernetesApiTimeoutError(error)) {
+        return vscode.l10n.t('Operation timed out after {0} seconds.', String(KUBERNETES_API_TIMEOUT_SECONDS));
+    }
+
+    if (error instanceof Error) {
+        return error.message;
+    }
+
+    if (typeof error === 'string') {
+        return error;
+    }
+
+    if (isRecord(error)) {
+        const message = error.message;
+        if (typeof message === 'string') {
+            return message;
+        }
+
+        const body = error.body;
+        if (typeof body === 'string') {
+            return body;
+        }
+        if (isRecord(body) && typeof body.message === 'string') {
+            return body.message;
+        }
+    }
+
+    return String(error);
+}
+
+export function createKubernetesApiOperationError(message: string, cause: unknown): Error {
+    const error = new Error(message);
+    if (isKubernetesApiTimeoutError(cause)) {
+        error.name = KUBERNETES_API_TIMEOUT_ERROR_NAME;
+    }
+    return error;
+}
+
+export function normalizeKubernetesApiError(error: unknown): Error {
+    if (!isKubernetesApiTimeoutError(error)) {
+        return error instanceof Error ? error : new Error(String(error));
+    }
+
+    const timeoutError = new Error(getKubernetesApiErrorMessage(error));
+    timeoutError.name = KUBERNETES_API_TIMEOUT_ERROR_NAME;
+    return timeoutError;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/plugins/service-kubernetes/kubernetesApiTimeout.ts
+++ b/src/plugins/service-kubernetes/kubernetesApiTimeout.ts
@@ -23,24 +23,11 @@ export const kubernetesApiTimeoutMiddleware: Middleware = {
     },
 };
 
-export function isKubernetesApiTimeoutError(error: unknown): boolean {
-    if (!(error instanceof Error)) {
-        return false;
-    }
-
-    // The generated client uses node-fetch v2, which reports an aborted
-    // AbortSignal as AbortError. TimeoutError covers runtimes that preserve
-    // AbortSignal.timeout()'s native reason instead.
-    return (
-        error.name === KUBERNETES_API_TIMEOUT_ERROR_NAME || error.name === 'AbortError' || error.name === 'TimeoutError'
-    );
+export function isKubernetesApiTimeoutError(error: unknown): error is Error {
+    return error instanceof Error && error.name === KUBERNETES_API_TIMEOUT_ERROR_NAME;
 }
 
 export function getKubernetesApiErrorMessage(error: unknown): string {
-    if (isKubernetesApiTimeoutError(error)) {
-        return vscode.l10n.t('Operation timed out after {0} seconds.', String(KUBERNETES_API_TIMEOUT_SECONDS));
-    }
-
     if (error instanceof Error) {
         return error.message;
     }
@@ -76,13 +63,31 @@ export function createKubernetesApiOperationError(message: string, cause: unknow
 }
 
 export function normalizeKubernetesApiError(error: unknown): Error {
-    if (!isKubernetesApiTimeoutError(error)) {
+    if (isKubernetesApiTimeoutError(error)) {
+        return error;
+    }
+
+    if (!isAbortSignalTimeoutError(error)) {
         return error instanceof Error ? error : new Error(String(error));
     }
 
-    const timeoutError = new Error(getKubernetesApiErrorMessage(error));
+    const timeoutError = new Error(
+        vscode.l10n.t('Operation timed out after {0} seconds.', String(KUBERNETES_API_TIMEOUT_SECONDS)),
+    );
     timeoutError.name = KUBERNETES_API_TIMEOUT_ERROR_NAME;
     return timeoutError;
+}
+
+function isAbortSignalTimeoutError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+
+    // The generated client uses node-fetch v2, which reports our timed signal
+    // as AbortError. TimeoutError covers runtimes that preserve
+    // AbortSignal.timeout()'s native reason. Only normalize these names at
+    // known generated-client request boundaries.
+    return error.name === 'AbortError' || error.name === 'TimeoutError';
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/plugins/service-kubernetes/kubernetesClient.test.ts
+++ b/src/plugins/service-kubernetes/kubernetesClient.test.ts
@@ -581,7 +581,9 @@ describe('kubernetesClient', () => {
 
             await expect(listDocumentDBServices(mockCoreApi, 'default', mockKubeConfig)).rejects.toMatchObject({
                 name: 'KubernetesApiTimeoutError',
-                message: expect.stringContaining('Operation timed out after 30 seconds.'),
+                message: expect.stringMatching(
+                    /Failed to list services.*Failed to list DKO resources.*Operation timed out after 30 seconds\./,
+                ),
             });
         });
 
@@ -847,7 +849,7 @@ describe('kubernetesClient', () => {
 
             await expect(listNamespaces(mockCoreApi)).rejects.toMatchObject({
                 name: 'KubernetesApiTimeoutError',
-                message: expect.stringContaining('Operation timed out after 30 seconds.'),
+                message: expect.stringMatching(/Failed to list namespaces: Operation timed out after 30 seconds\./),
             });
         });
     });

--- a/src/plugins/service-kubernetes/kubernetesClient.test.ts
+++ b/src/plugins/service-kubernetes/kubernetesClient.test.ts
@@ -29,7 +29,18 @@ const mockGetClusters = jest.fn();
 const mockGetUsers = jest.fn();
 const mockGetCurrentContext = jest.fn();
 const mockSetCurrentContext = jest.fn();
-const mockMakeApiClient = jest.fn();
+const mockGetCurrentCluster = jest.fn();
+const mockCreateConfiguration = jest.fn((configuration: unknown) => configuration);
+const mockServerConfiguration = jest.fn().mockImplementation((server: string, variables: Record<string, string>) => ({
+    server,
+    variables,
+}));
+const mockCoreV1ApiClient = {};
+const mockCoreV1ApiConstructor = jest.fn().mockImplementation(() => mockCoreV1ApiClient);
+let mockCustomObjectsApiClient: Record<string, jest.Mock> = {
+    listNamespacedCustomObject: jest.fn().mockResolvedValue({ items: [] }),
+};
+const mockCustomObjectsApiConstructor = jest.fn().mockImplementation(() => mockCustomObjectsApiClient);
 
 const mockLoadFromDefault = jest.fn();
 const mockGetSource = jest.fn<KubeconfigSourceRecord | undefined, [string]>();
@@ -51,10 +62,12 @@ jest.mock('@kubernetes/client-node', () => ({
         getUsers: mockGetUsers,
         getCurrentContext: mockGetCurrentContext,
         setCurrentContext: mockSetCurrentContext,
-        makeApiClient: mockMakeApiClient,
+        getCurrentCluster: mockGetCurrentCluster,
     })),
-    CoreV1Api: jest.fn(),
-    CustomObjectsApi: jest.fn(),
+    CoreV1Api: mockCoreV1ApiConstructor,
+    CustomObjectsApi: mockCustomObjectsApiConstructor,
+    createConfiguration: mockCreateConfiguration,
+    ServerConfiguration: mockServerConfiguration,
     ActionOnInvalid: { THROW: 'throw', FILTER: 'filter' },
 }));
 
@@ -78,6 +91,19 @@ function createApiExceptionLike(statusCode: number, message: string): Error & { 
     return error;
 }
 
+function createAbortError(): Error {
+    const error = new Error('The user aborted a request.');
+    error.name = 'AbortError';
+    return error;
+}
+
+function createMockKubeConfig(customApiMock: Record<string, jest.Mock>): { getCurrentCluster: jest.Mock } {
+    mockCustomObjectsApiClient = customApiMock;
+    return {
+        getCurrentCluster: jest.fn().mockReturnValue({ server: 'https://cluster.example.com' }),
+    };
+}
+
 describe('kubernetesClient', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -87,6 +113,10 @@ describe('kubernetesClient', () => {
         mockGetClusters.mockReturnValue([{ name: 'cluster', server: 'https://cluster.example.com' }]);
         mockGetUsers.mockReturnValue([{ name: 'user' }]);
         mockGetCurrentContext.mockReturnValue('ctx');
+        mockGetCurrentCluster.mockReturnValue({ server: 'https://cluster.example.com' });
+        mockCustomObjectsApiClient = {
+            listNamespacedCustomObject: jest.fn().mockResolvedValue({ items: [] }),
+        };
     });
 
     describe('config', () => {
@@ -336,6 +366,59 @@ describe('kubernetesClient', () => {
         });
     });
 
+    describe('createCoreApi', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { createCoreApi } = require('./kubernetesClient');
+
+        it('constructs the generated client with a fresh 30-second timeout signal for every request', async () => {
+            const kubeConfig = {
+                setCurrentContext: jest.fn(),
+                getCurrentCluster: jest.fn().mockReturnValue({ server: 'https://cluster.example.com' }),
+            };
+            const firstSignal = new AbortController().signal;
+            const secondSignal = new AbortController().signal;
+            const timeoutSpy = jest
+                .spyOn(AbortSignal, 'timeout')
+                .mockReturnValueOnce(firstSignal)
+                .mockReturnValueOnce(secondSignal);
+
+            try {
+                const client = await createCoreApi(kubeConfig, 'context-a');
+
+                expect(client).toBe(mockCoreV1ApiClient);
+                expect(kubeConfig.setCurrentContext).toHaveBeenCalledWith('context-a');
+                expect(mockServerConfiguration).toHaveBeenCalledWith('https://cluster.example.com', {});
+
+                const configurationParameters = mockCreateConfiguration.mock.calls[0][0] as {
+                    readonly authMethods?: { readonly default?: unknown };
+                    readonly promiseMiddleware?: Array<{
+                        pre(context: { setSignal(signal: AbortSignal): void }): Promise<unknown>;
+                        post(context: unknown): Promise<unknown>;
+                    }>;
+                };
+                expect(configurationParameters.authMethods?.default).toBe(kubeConfig);
+
+                const middleware = configurationParameters.promiseMiddleware?.[0];
+                expect(middleware).toBeDefined();
+
+                const firstRequest = { setSignal: jest.fn() };
+                const secondRequest = { setSignal: jest.fn() };
+                await middleware!.pre(firstRequest);
+                await middleware!.pre(secondRequest);
+
+                expect(timeoutSpy).toHaveBeenNthCalledWith(1, 30_000);
+                expect(timeoutSpy).toHaveBeenNthCalledWith(2, 30_000);
+                expect(firstRequest.setSignal).toHaveBeenCalledWith(firstSignal);
+                expect(secondRequest.setSignal).toHaveBeenCalledWith(secondSignal);
+
+                const response = {};
+                await expect(middleware!.post(response)).resolves.toBe(response);
+            } finally {
+                timeoutSpy.mockRestore();
+            }
+        });
+    });
+
     describe('listDocumentDBServices', () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { listDocumentDBServices } = require('./kubernetesClient');
@@ -372,22 +455,20 @@ describe('kubernetesClient', () => {
                     ],
                 }),
             };
-            const mockKubeConfig = {
-                makeApiClient: jest.fn().mockReturnValue({
-                    listNamespacedCustomObject: jest.fn().mockResolvedValue({
-                        items: [
-                            {
-                                metadata: { name: 'mydb' },
-                                spec: {},
-                                status: {
-                                    status: 'Cluster in healthy state',
-                                    tls: { ready: true },
-                                },
+            const mockKubeConfig = createMockKubeConfig({
+                listNamespacedCustomObject: jest.fn().mockResolvedValue({
+                    items: [
+                        {
+                            metadata: { name: 'mydb' },
+                            spec: {},
+                            status: {
+                                status: 'Cluster in healthy state',
+                                tls: { ready: true },
                             },
-                        ],
-                    }),
+                        },
+                    ],
                 }),
-            };
+            });
 
             const services: KubeServiceInfo[] = await listDocumentDBServices(mockCoreApi, 'default', mockKubeConfig);
 
@@ -408,6 +489,10 @@ describe('kubernetesClient', () => {
                 serviceName: 'manual-documentdb',
                 clusterIP: '10.0.0.2',
             });
+            expect(mockCustomObjectsApiConstructor).toHaveBeenCalledTimes(1);
+            expect(mockCreateConfiguration).toHaveBeenCalledWith(
+                expect.objectContaining({ promiseMiddleware: expect.any(Array) }),
+            );
         });
 
         it('should fall back to generic DocumentDB discovery when the DKO CRD is unavailable', async () => {
@@ -429,11 +514,9 @@ describe('kubernetesClient', () => {
                     ],
                 }),
             };
-            const mockKubeConfig = {
-                makeApiClient: jest.fn().mockReturnValue({
-                    listNamespacedCustomObject: jest.fn().mockRejectedValue(createApiExceptionLike(404, 'Not Found')),
-                }),
-            };
+            const mockKubeConfig = createMockKubeConfig({
+                listNamespacedCustomObject: jest.fn().mockRejectedValue(createApiExceptionLike(404, 'Not Found')),
+            });
 
             const services: KubeServiceInfo[] = await listDocumentDBServices(mockCoreApi, 'default', mockKubeConfig);
             expect(services).toHaveLength(1);
@@ -456,11 +539,9 @@ describe('kubernetesClient', () => {
                     ],
                 }),
             };
-            const mockKubeConfig = {
-                makeApiClient: jest.fn().mockReturnValue({
-                    listNamespacedCustomObject: jest.fn().mockRejectedValue(createApiExceptionLike(403, 'Forbidden')),
-                }),
-            };
+            const mockKubeConfig = createMockKubeConfig({
+                listNamespacedCustomObject: jest.fn().mockRejectedValue(createApiExceptionLike(403, 'Forbidden')),
+            });
 
             await expect(listDocumentDBServices(mockCoreApi, 'default', mockKubeConfig)).rejects.toThrow(
                 /Failed to list DKO resources.*Forbidden/,
@@ -481,15 +562,27 @@ describe('kubernetesClient', () => {
                     ],
                 }),
             };
-            const mockKubeConfig = {
-                makeApiClient: jest.fn().mockReturnValue({
-                    listNamespacedCustomObject: jest.fn().mockRejectedValue(new Error('ECONNRESET')),
-                }),
-            };
+            const mockKubeConfig = createMockKubeConfig({
+                listNamespacedCustomObject: jest.fn().mockRejectedValue(new Error('ECONNRESET')),
+            });
 
             await expect(listDocumentDBServices(mockCoreApi, 'default', mockKubeConfig)).rejects.toThrow(
                 /Failed to list DKO resources.*ECONNRESET/,
             );
+        });
+
+        it('should surface DKO request timeouts with a distinct timeout error type', async () => {
+            const mockCoreApi = {
+                listNamespacedService: jest.fn().mockResolvedValue({ items: [] }),
+            };
+            const mockKubeConfig = createMockKubeConfig({
+                listNamespacedCustomObject: jest.fn().mockRejectedValue(createAbortError()),
+            });
+
+            await expect(listDocumentDBServices(mockCoreApi, 'default', mockKubeConfig)).rejects.toMatchObject({
+                name: 'KubernetesApiTimeoutError',
+                message: expect.stringContaining('Operation timed out after 30 seconds.'),
+            });
         });
 
         it('should throw on RBAC error', async () => {
@@ -698,6 +791,26 @@ describe('kubernetesClient', () => {
                 expect(endpoint.reason).toContain('node address');
             }
         });
+
+        it('should propagate a NodePort node-list timeout instead of reporting the target as unreachable', async () => {
+            const service = createServiceInfo({
+                name: 'mongo-np-timeout',
+                displayName: 'mongo-np-timeout',
+                serviceName: 'mongo-np-timeout',
+                namespace: 'default',
+                type: 'NodePort',
+                port: 27017,
+                nodePort: 30017,
+            });
+            const mockCoreApi = {
+                listNode: jest.fn().mockRejectedValue(createAbortError()),
+            };
+
+            await expect(resolveServiceEndpoint(service, mockCoreApi)).rejects.toMatchObject({
+                name: 'KubernetesApiTimeoutError',
+                message: 'Operation timed out after 30 seconds.',
+            });
+        });
     });
 
     describe('listNamespaces', () => {
@@ -725,6 +838,17 @@ describe('kubernetesClient', () => {
             };
 
             await expect(listNamespaces(mockCoreApi)).rejects.toThrow(/Failed to list namespaces/);
+        });
+
+        it('should classify an aborted request as a 30-second Kubernetes API timeout', async () => {
+            const mockCoreApi = {
+                listNamespace: jest.fn().mockRejectedValue(createAbortError()),
+            };
+
+            await expect(listNamespaces(mockCoreApi)).rejects.toMatchObject({
+                name: 'KubernetesApiTimeoutError',
+                message: expect.stringContaining('Operation timed out after 30 seconds.'),
+            });
         });
     });
 
@@ -902,10 +1026,6 @@ describe('kubernetesClient', () => {
     describe('resolveDocumentDBCredentials', () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { resolveDocumentDBCredentials } = require('./kubernetesClient');
-
-        const createMockKubeConfig = (customApiMock: Record<string, jest.Mock>) => ({
-            makeApiClient: jest.fn().mockReturnValue(customApiMock),
-        });
 
         it('should return credentials when matching CR and secret are found', async () => {
             const mockCustomApi = {
@@ -1481,13 +1601,11 @@ describe('kubernetesClient', () => {
                     ],
                 }),
             };
-            const mockKubeConfig = {
-                makeApiClient: jest.fn().mockReturnValue({
-                    listNamespacedCustomObject: jest.fn().mockResolvedValue({
-                        items: [{ metadata: { name: 'mydb' }, spec: {}, status: {} }],
-                    }),
+            const mockKubeConfig = createMockKubeConfig({
+                listNamespacedCustomObject: jest.fn().mockResolvedValue({
+                    items: [{ metadata: { name: 'mydb' }, spec: {}, status: {} }],
                 }),
-            };
+            });
             const services: KubeServiceInfo[] = await listDocumentDBServices(mockCoreApi, 'default', mockKubeConfig);
             expect(services).toHaveLength(1);
             expect(services[0].sourceKind).toBe('dko');

--- a/src/plugins/service-kubernetes/kubernetesClient.ts
+++ b/src/plugins/service-kubernetes/kubernetesClient.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 // Lazy-load @kubernetes/client-node to avoid impacting extension startup.
 // Only type imports are used at the top level — they disappear at runtime.
 import {
+    type Configuration,
     type CoreV1Api,
     type KubeConfig,
     type V1Namespace,
@@ -19,6 +20,13 @@ import {
 } from '@kubernetes/client-node';
 import { ext } from '../../extensionVariables';
 import { CREDENTIAL_SECRET_ANNOTATION, DISCOVERY_ANNOTATION, DOCUMENTDB_PORTS } from './config';
+import {
+    createKubernetesApiOperationError,
+    getKubernetesApiErrorMessage,
+    isKubernetesApiTimeoutError,
+    kubernetesApiTimeoutMiddleware,
+    normalizeKubernetesApiError,
+} from './kubernetesApiTimeout';
 import { getSource, readInlineYaml } from './sources/sourceStore';
 
 /**
@@ -30,6 +38,8 @@ import { getSource, readInlineYaml } from './sources/sourceStore';
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 type KubernetesClientModule = typeof import('@kubernetes/client-node');
+
+type KubernetesApiClientConstructor<T> = new (configuration: Configuration) => T;
 
 /**
  * Lazily imports `@kubernetes/client-node` with defensive interop and diagnostics.
@@ -93,6 +103,33 @@ async function importKubernetesClient(): Promise<KubernetesClientModule> {
     }
 
     return resolved as KubernetesClientModule;
+}
+
+/**
+ * Recreates {@link KubeConfig.makeApiClient} with a request timeout middleware.
+ *
+ * `@kubernetes/client-node` 1.4.0 does not expose a way to attach middleware to
+ * the client returned by `makeApiClient`, so this mirrors its implementation
+ * (`baseServer` + kubeconfig authentication) and adds only the 30-second
+ * request deadline agreed in #741.
+ */
+function createKubernetesApiClient<T>(
+    k8s: KubernetesClientModule,
+    kubeConfig: KubeConfig,
+    apiClientType: KubernetesApiClientConstructor<T>,
+): T {
+    const cluster = kubeConfig.getCurrentCluster();
+    if (!cluster) {
+        throw new Error('No active cluster!');
+    }
+
+    const configuration = k8s.createConfiguration({
+        baseServer: new k8s.ServerConfiguration(cluster.server, {}),
+        authMethods: { default: kubeConfig },
+        promiseMiddleware: [kubernetesApiTimeoutMiddleware],
+    });
+
+    return new apiClientType(configuration);
 }
 
 /**
@@ -586,7 +623,7 @@ function getUrlHostname(server: string): string {
 export async function createCoreApi(kubeConfig: KubeConfig, contextName: string): Promise<CoreV1Api> {
     const k8s = await importKubernetesClient();
     kubeConfig.setCurrentContext(contextName);
-    return kubeConfig.makeApiClient(k8s.CoreV1Api);
+    return createKubernetesApiClient(k8s, kubeConfig, k8s.CoreV1Api);
 }
 
 /**
@@ -605,12 +642,13 @@ export async function listNamespaces(coreApi: CoreV1Api): Promise<string[]> {
             .filter((name): name is string => !!name)
             .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
     } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        throw new Error(
+        const errorMessage = getKubernetesApiErrorMessage(error);
+        throw createKubernetesApiOperationError(
             vscode.l10n.t(
                 'Failed to list namespaces: {0}. Check that your credentials are valid and you have the required RBAC permissions.',
                 errorMessage,
             ),
+            error,
         );
     }
 }
@@ -685,7 +723,7 @@ async function listDkoDocumentDbResources(
 ): Promise<DkoDocumentDbResourceInfo[]> {
     try {
         const k8s = await importKubernetesClient();
-        const customApi = kubeConfig.makeApiClient(k8s.CustomObjectsApi);
+        const customApi = createKubernetesApiClient(k8s, kubeConfig, k8s.CustomObjectsApi);
         const response: unknown = await customApi.listNamespacedCustomObject({
             group: 'documentdb.io',
             version: 'preview',
@@ -751,18 +789,30 @@ async function listDkoDocumentDbResources(
 
         return result.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
     } catch (error) {
-        if (isDkoCrdUnavailableError(error) || options.suppressUnexpectedErrors) {
-            // Treat unavailable DKO metadata as no DKO resources when callers explicitly allow fallback.
+        if (isDkoCrdUnavailableError(error)) {
+            return [];
+        }
+
+        if (options.suppressUnexpectedErrors) {
+            // Credential lookup is best-effort, but a timeout should still be
+            // visible in diagnostics rather than looking like a missing Secret.
+            if (isKubernetesApiTimeoutError(error)) {
+                ext.outputChannel.warn(
+                    `[KubernetesDiscovery] ${getKubernetesApiErrorMessage(error)} ` +
+                        `while listing DKO resources in namespace "${namespace}".`,
+                );
+            }
             return [];
         }
 
         const errorMessage = getKubernetesApiErrorMessage(error);
-        throw new Error(
+        throw createKubernetesApiOperationError(
             vscode.l10n.t(
                 'Failed to list DKO resources in namespace "{0}": {1}. Check that the DocumentDB Kubernetes Operator CRD is installed and that your Kubernetes credentials can list documentdb.io dbs resources.',
                 namespace,
                 errorMessage,
             ),
+            error,
         );
     }
 }
@@ -790,33 +840,6 @@ function getKubernetesApiStatusCode(error: unknown): number | undefined {
     }
 
     return undefined;
-}
-
-function getKubernetesApiErrorMessage(error: unknown): string {
-    if (error instanceof Error) {
-        return error.message;
-    }
-
-    if (typeof error === 'string') {
-        return error;
-    }
-
-    if (isRecord(error)) {
-        const message = error.message;
-        if (typeof message === 'string') {
-            return message;
-        }
-
-        const body = error.body;
-        if (typeof body === 'string') {
-            return body;
-        }
-        if (isRecord(body) && typeof body.message === 'string') {
-            return body.message;
-        }
-    }
-
-    return String(error);
 }
 
 function getNumberProperty(record: Record<string, unknown>, propertyName: string): number | undefined {
@@ -949,13 +972,14 @@ export async function listDocumentDBServices(
             return a.displayName.localeCompare(b.displayName, undefined, { numeric: true });
         });
     } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        throw new Error(
+        const errorMessage = getKubernetesApiErrorMessage(error);
+        throw createKubernetesApiOperationError(
             vscode.l10n.t(
                 'Failed to list services in namespace "{0}": {1}. Check your RBAC permissions.',
                 namespace,
                 errorMessage,
             ),
+            error,
         );
     }
 }
@@ -1185,7 +1209,10 @@ async function getFirstNodeAddress(coreApi: CoreV1Api): Promise<{ address: strin
         if (firstInternalAddress) {
             return { address: firstInternalAddress, isExternal: false };
         }
-    } catch {
+    } catch (error) {
+        if (isKubernetesApiTimeoutError(error)) {
+            throw normalizeKubernetesApiError(error);
+        }
         // If we can't list nodes, we can't resolve NodePort addresses.
     }
 
@@ -1228,7 +1255,13 @@ export async function resolveDocumentDBCredentials(
                 connectionParams: buildDocumentDbConnectionParams(),
             };
         }
-    } catch {
+    } catch (error) {
+        if (isKubernetesApiTimeoutError(error)) {
+            ext.outputChannel.warn(
+                `[KubernetesDiscovery] ${getKubernetesApiErrorMessage(error)} ` +
+                    `while reading credential Secret "${matchingResource.secretName}" in namespace "${namespace}".`,
+            );
+        }
         // Secret not found or not readable
     }
 
@@ -1269,7 +1302,13 @@ export async function resolveGenericServiceCredentials(
             const password = Buffer.from(data.password, 'base64').toString('utf-8');
             return { username, password };
         }
-    } catch {
+    } catch (error) {
+        if (isKubernetesApiTimeoutError(error)) {
+            ext.outputChannel.warn(
+                `[KubernetesDiscovery] ${getKubernetesApiErrorMessage(error)} ` +
+                    `while reading credential Secret "${secretName}" in namespace "${namespace}".`,
+            );
+        }
         // Secret not found or not readable — return undefined so UI can prompt later.
     }
 

--- a/src/plugins/service-kubernetes/kubernetesClient.ts
+++ b/src/plugins/service-kubernetes/kubernetesClient.ts
@@ -642,13 +642,14 @@ export async function listNamespaces(coreApi: CoreV1Api): Promise<string[]> {
             .filter((name): name is string => !!name)
             .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
     } catch (error) {
-        const errorMessage = getKubernetesApiErrorMessage(error);
+        const apiError = normalizeKubernetesApiError(error);
+        const errorMessage = getKubernetesApiErrorMessage(apiError);
         throw createKubernetesApiOperationError(
             vscode.l10n.t(
                 'Failed to list namespaces: {0}. Check that your credentials are valid and you have the required RBAC permissions.',
                 errorMessage,
             ),
-            error,
+            apiError,
         );
     }
 }
@@ -793,26 +794,28 @@ async function listDkoDocumentDbResources(
             return [];
         }
 
+        const apiError = normalizeKubernetesApiError(error);
+
         if (options.suppressUnexpectedErrors) {
             // Credential lookup is best-effort, but a timeout should still be
             // visible in diagnostics rather than looking like a missing Secret.
-            if (isKubernetesApiTimeoutError(error)) {
+            if (isKubernetesApiTimeoutError(apiError)) {
                 ext.outputChannel.warn(
-                    `[KubernetesDiscovery] ${getKubernetesApiErrorMessage(error)} ` +
+                    `[KubernetesDiscovery] ${getKubernetesApiErrorMessage(apiError)} ` +
                         `while listing DKO resources in namespace "${namespace}".`,
                 );
             }
             return [];
         }
 
-        const errorMessage = getKubernetesApiErrorMessage(error);
+        const errorMessage = getKubernetesApiErrorMessage(apiError);
         throw createKubernetesApiOperationError(
             vscode.l10n.t(
                 'Failed to list DKO resources in namespace "{0}": {1}. Check that the DocumentDB Kubernetes Operator CRD is installed and that your Kubernetes credentials can list documentdb.io dbs resources.',
                 namespace,
                 errorMessage,
             ),
-            error,
+            apiError,
         );
     }
 }
@@ -972,14 +975,15 @@ export async function listDocumentDBServices(
             return a.displayName.localeCompare(b.displayName, undefined, { numeric: true });
         });
     } catch (error) {
-        const errorMessage = getKubernetesApiErrorMessage(error);
+        const apiError = normalizeKubernetesApiError(error);
+        const errorMessage = getKubernetesApiErrorMessage(apiError);
         throw createKubernetesApiOperationError(
             vscode.l10n.t(
                 'Failed to list services in namespace "{0}": {1}. Check your RBAC permissions.',
                 namespace,
                 errorMessage,
             ),
-            error,
+            apiError,
         );
     }
 }
@@ -1210,8 +1214,9 @@ async function getFirstNodeAddress(coreApi: CoreV1Api): Promise<{ address: strin
             return { address: firstInternalAddress, isExternal: false };
         }
     } catch (error) {
-        if (isKubernetesApiTimeoutError(error)) {
-            throw normalizeKubernetesApiError(error);
+        const apiError = normalizeKubernetesApiError(error);
+        if (isKubernetesApiTimeoutError(apiError)) {
+            throw apiError;
         }
         // If we can't list nodes, we can't resolve NodePort addresses.
     }
@@ -1256,9 +1261,10 @@ export async function resolveDocumentDBCredentials(
             };
         }
     } catch (error) {
-        if (isKubernetesApiTimeoutError(error)) {
+        const apiError = normalizeKubernetesApiError(error);
+        if (isKubernetesApiTimeoutError(apiError)) {
             ext.outputChannel.warn(
-                `[KubernetesDiscovery] ${getKubernetesApiErrorMessage(error)} ` +
+                `[KubernetesDiscovery] ${getKubernetesApiErrorMessage(apiError)} ` +
                     `while reading credential Secret "${matchingResource.secretName}" in namespace "${namespace}".`,
             );
         }
@@ -1303,9 +1309,10 @@ export async function resolveGenericServiceCredentials(
             return { username, password };
         }
     } catch (error) {
-        if (isKubernetesApiTimeoutError(error)) {
+        const apiError = normalizeKubernetesApiError(error);
+        if (isKubernetesApiTimeoutError(apiError)) {
             ext.outputChannel.warn(
-                `[KubernetesDiscovery] ${getKubernetesApiErrorMessage(error)} ` +
+                `[KubernetesDiscovery] ${getKubernetesApiErrorMessage(apiError)} ` +
                     `while reading credential Secret "${secretName}" in namespace "${namespace}".`,
             );
         }

--- a/src/plugins/service-kubernetes/portForwardTunnel.test.ts
+++ b/src/plugins/service-kubernetes/portForwardTunnel.test.ts
@@ -235,6 +235,19 @@ describe('resolveServiceBackend', () => {
         await expect(resolveServiceBackend(coreApi, 'ns', 'svc', 27017)).rejects.toThrow('Forbidden');
     });
 
+    it('should normalize an Endpoints API abort as a Kubernetes timeout', async () => {
+        const abortError = new Error('The user aborted a request.');
+        abortError.name = 'AbortError';
+        const coreApi = {
+            readNamespacedEndpoints: jest.fn().mockRejectedValue(abortError),
+        } as never;
+
+        await expect(resolveServiceBackend(coreApi, 'ns', 'svc', 27017)).rejects.toMatchObject({
+            name: 'KubernetesApiTimeoutError',
+            message: 'Operation timed out after 30 seconds.',
+        });
+    });
+
     it('should pass correct arguments to readNamespacedEndpoints', async () => {
         const mockRead = jest.fn().mockResolvedValue({
             subsets: [
@@ -1037,5 +1050,34 @@ describe('PortForwardTunnelManager', () => {
 
         expect(ext.outputChannel.appendLine).toHaveBeenCalledWith(expect.stringContaining('error-svc'));
         expect(ext.outputChannel.appendLine).toHaveBeenCalledWith(expect.stringContaining('Forbidden'));
+    });
+
+    it('should not relabel a non-API AbortError from port-forward setup as a timeout', async () => {
+        const abortError = new Error('request cancelled during teardown');
+        abortError.name = 'AbortError';
+        mockPortForward.mockRejectedValue(abortError);
+
+        const freePort = await new Promise<number>((resolve) => {
+            const tmp = net.createServer();
+            tmp.listen(0, '127.0.0.1', () => {
+                const port = (tmp.address() as net.AddressInfo).port;
+                tmp.close(() => resolve(port));
+            });
+        });
+
+        await manager.startTunnel(createMockParams({ localPort: freePort }));
+
+        const client = new net.Socket();
+        const closed = new Promise<void>((resolve) => client.on('close', () => resolve()));
+        client.connect(freePort, '127.0.0.1');
+        await closed;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        expect(ext.outputChannel.appendLine).toHaveBeenCalledWith(
+            expect.stringContaining('request cancelled during teardown'),
+        );
+        expect(ext.outputChannel.appendLine).not.toHaveBeenCalledWith(
+            expect.stringContaining('Operation timed out after 30 seconds.'),
+        );
     });
 });

--- a/src/plugins/service-kubernetes/portForwardTunnel.ts
+++ b/src/plugins/service-kubernetes/portForwardTunnel.ts
@@ -8,6 +8,7 @@ import * as net from 'net';
 import { PassThrough } from 'stream';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
+import { getKubernetesApiErrorMessage } from './kubernetesApiTimeout';
 
 interface TunnelParams {
     /**
@@ -621,7 +622,7 @@ export class PortForwardTunnelManager implements vscode.Disposable {
                 });
             }
         } catch (err) {
-            const errMsg = err instanceof Error ? err.message : String(err);
+            const errMsg = getKubernetesApiErrorMessage(err);
             ext.outputChannel.appendLine(
                 vscode.l10n.t(
                     'Port-forward backend resolution failed for {0}/{1}: {2}',

--- a/src/plugins/service-kubernetes/portForwardTunnel.ts
+++ b/src/plugins/service-kubernetes/portForwardTunnel.ts
@@ -8,7 +8,7 @@ import * as net from 'net';
 import { PassThrough } from 'stream';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { getKubernetesApiErrorMessage } from './kubernetesApiTimeout';
+import { getKubernetesApiErrorMessage, normalizeKubernetesApiError } from './kubernetesApiTimeout';
 
 interface TunnelParams {
     /**
@@ -74,7 +74,12 @@ export async function resolveServiceBackend(
     servicePort: number,
     servicePortName?: string,
 ): Promise<{ podName: string; targetPort: number }> {
-    const endpoints = await coreApi.readNamespacedEndpoints({ name: serviceName, namespace });
+    let endpoints: Awaited<ReturnType<CoreV1Api['readNamespacedEndpoints']>>;
+    try {
+        endpoints = await coreApi.readNamespacedEndpoints({ name: serviceName, namespace });
+    } catch (error) {
+        throw normalizeKubernetesApiError(error);
+    }
     const subsets = endpoints.subsets ?? [];
 
     for (const subset of subsets) {


### PR DESCRIPTION
## Summary

- Cap generated Kubernetes API requests at 30 seconds.
- Route timeout failures through the existing retry-node experience instead of leaving the tree spinning.
- Allow namespace pre-scan workers to continue after an individual namespace times out.

## Implementation

- Add a small timeout helper with a fresh `AbortSignal.timeout(30_000)` for every request.
- Construct `CoreV1Api` and `CustomObjectsApi` clients with the same kubeconfig authentication and base server as `KubeConfig.makeApiClient`, plus timeout middleware.
- Normalize aborted requests as `KubernetesApiTimeoutError` for clear logging, telemetry, and user-facing timeout messages.
- Preserve best-effort credential Secret lookup and the existing port-forward lifecycle.

## Review follow-up

- Raw `AbortError` / `TimeoutError` values are converted to the timeout type only at known generated-client API boundaries. Unrelated port-forward aborts retain their original cause.
- Already-wrapped timeout errors preserve their full operation and namespace context.
- Tree timeout UX checks the typed error before message-text fallbacks, so localization cannot change classification.
- Added focused timeout-helper and port-forward regression tests.

## User experience

- Context and namespace timeouts surface the existing **Click here to retry** action.
- A timed-out namespace remains expandable for retry while successfully scanned namespaces continue to render.
- The timeout is fixed at 30 seconds; this does not add cancellation on tree collapse or a new setting.

## Validation

- `npm run l10n`
- `npm run prettier-fix`
- `npm run lint`
- `npx jest --no-coverage`
- `npm run build`

Addresses #741.
