### PR TITLE
[vscode-ext-webview] Release version 0.10.1 and improve documentation clarity

### DIFF
--- a/.azure-pipelines/release-npm-packages.yml
+++ b/.azure-pipelines/release-npm-packages.yml
@@ -67,8 +67,7 @@ parameters:
     #                    contenttype='Maven' instead of 'npm'. ESRP authenticates and accepts
     #                    the request, then fails at the final content-validation step because
     #                    the payload is not a Maven artifact. NOTHING IS PUBLISHED. This trick
-    #                    is documented by the ESRP team:
-    #                      https://eng.ms/docs/.../release-onboarding (Usage FAQ)
+    #                    is an internally validated technique.
     #
     #                    NOTE: A failed run in this mode does NOT, by itself, prove the auth
     #                    path worked - it could also fail on bad SC, KV permissions, cert
@@ -127,9 +126,10 @@ variables:
 
     # ESRP release notification / approval contacts. Comma-separated list of
     # email addresses (the EsrpRelease task splits on ',' - a ';' is treated as
-    # part of a single address and rejected as an invalid email). Prefer a TEAM
-    # security group or distribution list so releases are not tied to a single
-    # person. Override in ADO -> Variables.
+    # part of a single address and rejected as an invalid email). Each address
+    # must be an individual Microsoft alias; distribution lists and security
+    # groups are not supported. List at least two people so releases are not
+    # tied to a single person. Override in ADO -> Variables.
     EsrpReleaseOwners: 'guanzhousong@microsoft.com,tnaumowicz@microsoft.com'
     EsrpReleaseApprovers: 'guanzhousong@microsoft.com,tnaumowicz@microsoft.com'
 
@@ -488,7 +488,6 @@ extends:
                                         Write-Output "[Success] No forbidden files detected ($($entries.Count) entries scanned)"
 
                               # Publish to npmjs.org via ESRP Release
-                              # Docs: https://eng.ms/docs/microsoft-security/identity/trust-and-security-services/tss-release-distribute/tss-release-esrp-parent/release-onboarding
                               #
                               # Authentication: the Azure RM service connection 'DOCDBEXT_ESRP_RELEASE'
                               # uses Workload Identity Federation, which handles auth to Azure / Key

--- a/.azure-pipelines/release-npm-packages.yml
+++ b/.azure-pipelines/release-npm-packages.yml
@@ -130,8 +130,8 @@ variables:
     # part of a single address and rejected as an invalid email). Prefer a TEAM
     # security group or distribution list so releases are not tied to a single
     # person. Override in ADO -> Variables.
-    EsrpReleaseOwners: 'guanzhousong@microsoft.com,tnaumowicz@microsoft.com'
-    EsrpReleaseApprovers: 'guanzhousong@microsoft.com,tnaumowicz@microsoft.com'
+    EsrpReleaseOwners: 'guanzhousong@microsoft.com,CosmosSDKTeam@service.microsoft.com'
+    EsrpReleaseApprovers: 'guanzhousong@microsoft.com,CosmosSDKTeam@service.microsoft.com'
 
 extends:
     template: v2/OneBranch.Official.CrossPlat.yml@templates

--- a/.azure-pipelines/release-npm-packages.yml
+++ b/.azure-pipelines/release-npm-packages.yml
@@ -130,8 +130,8 @@ variables:
     # part of a single address and rejected as an invalid email). Prefer a TEAM
     # security group or distribution list so releases are not tied to a single
     # person. Override in ADO -> Variables.
-    EsrpReleaseOwners: 'guanzhousong@microsoft.com,CosmosSDKTeam@service.microsoft.com'
-    EsrpReleaseApprovers: 'guanzhousong@microsoft.com,CosmosSDKTeam@service.microsoft.com'
+    EsrpReleaseOwners: 'guanzhousong@microsoft.com,tnaumowicz@microsoft.com'
+    EsrpReleaseApprovers: 'guanzhousong@microsoft.com,tnaumowicz@microsoft.com'
 
 extends:
     template: v2/OneBranch.Official.CrossPlat.yml@templates

--- a/package-lock.json
+++ b/package-lock.json
@@ -26798,7 +26798,7 @@
     },
     "packages/vscode-ext-webview": {
       "name": "@microsoft/vscode-ext-webview",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "peerDependencies": {
         "@trpc/client": "^11.0.0",

--- a/packages/vscode-ext-webview/README.md
+++ b/packages/vscode-ext-webview/README.md
@@ -208,8 +208,8 @@ export const MyView = () => {
 That is the complete data path: the React component calls
 `trpcClient.hello.query(...)`, the call travels through `vscodeLink` as a
 `postMessage`, the host dispatches it to `appRouter.hello`, the result is
-`postMessage`d back, and the call promise resolves with full type inference for
-`r.greeting`.
+sent back with `postMessage`, and the call promise resolves with full type
+inference for `r.greeting`.
 
 `useTrpcClient<AppRouter>()` returns the client directly. The client (and the
 event channel from `useRpcEvents()`) is shared per webview: every component that
@@ -470,7 +470,7 @@ extensions are working examples of that layout against this package.
 
 ## Status
 
-`0.10.0`. APIs are subject to change while the package is in preview. See
+`0.10.1`. APIs are subject to change while the package is in preview. See
 [ADVANCED.md](./ADVANCED.md) for the full set of primitives and patterns.
 
 ## Contributors

--- a/packages/vscode-ext-webview/package.json
+++ b/packages/vscode-ext-webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/vscode-ext-webview",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Webview infrastructure for VS Code extensions: type-safe tRPC over postMessage with pluggable telemetry middleware, plus an optional extension-host panel facade, a framework-agnostic webview client, and optional React hooks.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -40,6 +40,7 @@
     "dist",
     "README.md",
     "ADVANCED.md",
+    "MIGRATION.md",
     "LICENSE"
   ],
   "scripts": {


### PR DESCRIPTION
This pull request contains documentation updates and a patch version bump for the `@microsoft/vscode-ext-webview` package, as well as clarifications to the Azure pipeline configuration for npm package releases. The main changes are grouped below:

**Version and Documentation Updates:**

* Bumped the package version in `package.json` from `0.10.0` to `0.10.1` to reflect a new patch release. [[1]](diffhunk://#diff-556d10eab7e816038695145cd3eb9b5c116c7683d9ee53c9baa315bf7dc235e4L3-R3) [[2]](diffhunk://#diff-9aca7480d4958eb8ff695a2d6029200e56276cf215581e81e10c38b206d2dd3dL473-R473)
* Added `MIGRATION.md` to the `files` array in `package.json`, ensuring it is included in published packages.
* Improved wording and clarity in the `README.md` to better explain the data flow and updated the documented version. [[1]](diffhunk://#diff-9aca7480d4958eb8ff695a2d6029200e56276cf215581e81e10c38b206d2dd3dL211-R212) [[2]](diffhunk://#diff-9aca7480d4958eb8ff695a2d6029200e56276cf215581e81e10c38b206d2dd3dL473-R473)

**Azure Pipeline Configuration Clarifications:**

* Updated comments in `.azure-pipelines/release-npm-packages.yml` to clarify that ESRP release notification and approval contacts must be individual Microsoft aliases, not distribution lists or security groups, and at least two people should be listed.
* Clarified documentation regarding the ESRP publishing process and removed outdated or redundant links. [[1]](diffhunk://#diff-b21b988c921be720175b7739bc71c6aa246099474aa7afca0cff307bcd7b417cL70-R70) [[2]](diffhunk://#diff-b21b988c921be720175b7739bc71c6aa246099474aa7afca0cff307bcd7b417cL491)