### PR TITLE
Revert PostCSS dependency update to restore CI builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19716,9 +19716,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -20973,9 +20973,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
-      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -20993,7 +20993,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

- Revert the `postcss` lockfile update from `8.5.10` to `8.5.24`
- Restore the matching `nanoid@3.3.11` lockfile entry

## Rationale

The recent dependency update has internal package-resolution side effects that cause CI dependency restoration to fail before the build can run. Returning to the previously working dependency set restores the build while the newer package path is resolved.

## Validation

- `npm ci`
- `npm run l10n`
- `npm run prettier-fix`
- `npm run lint`
- Jest: 2,674 tests passed
- `npm run build`