### PR TITLE
fix: prevent "isNullOrUndefined is not a function" crash on Service Discovery activation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5156,37 +5156,6 @@
         "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
-    "node_modules/@microsoft/applicationinsights-channel-js": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.2.tgz",
-      "integrity": "sha512-Q7Q9gV45WSgSmOP2abu0y9tdbFh8sPELMgKUCDy62FsNd3xmE8X3zLtkzc7mcXPlpTeoDXwMCYjCRIAYd6d2lQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/applicationinsights-core-js": "3.4.2",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
-        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": ">= 1.0.0"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-channel-js/node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.2.tgz",
-      "integrity": "sha512-Iw3gq1JREKLbXiVpr3F0+Ezuzphe+o25n9me9H5Kkjmck6tIkuGQea01SNfeemE4wf2mop2QQSvTcKxT8tNN1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
-        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": ">= 1.0.0"
-      }
-    },
     "node_modules/@microsoft/applicationinsights-common": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.1.tgz",
@@ -5224,38 +5193,6 @@
       "license": "MIT",
       "dependencies": {
         "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-web-basic": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.4.2.tgz",
-      "integrity": "sha512-ONJbCSdJ/KMOVT7b8oVVPa2Etp99SHhehprpQn51QrHTiJtTehBLOmovBBIKQZuwWm0ZLKOaoUBWHCkRXUqNAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/applicationinsights-channel-js": "3.4.2",
-        "@microsoft/applicationinsights-core-js": "3.4.2",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
-        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": ">= 1.0.0"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-web-basic/node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.2.tgz",
-      "integrity": "sha512-Iw3gq1JREKLbXiVpr3F0+Ezuzphe+o25n9me9H5Kkjmck6tIkuGQea01SNfeemE4wf2mop2QQSvTcKxT8tNN1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
-        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/dynamicproto-js": {
@@ -9894,6 +9831,39 @@
       },
       "engines": {
         "vscode": "^1.75.0"
+      }
+    },
+    "node_modules/@vscode/extension-telemetry/node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.1.tgz",
+      "integrity": "sha512-QS1k6iwVwR1MznGAB1H0F9raqpevbFNbadLS5O1419pz9OEWBfF9wRQLnENCyo8QS9Q0IdiqnGAON/D8IywpWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@vscode/extension-telemetry/node_modules/@microsoft/applicationinsights-web-basic": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.4.1.tgz",
+      "integrity": "sha512-V/hSlauFp1thJa57+TMv5mAYinJAQUi4zOmDmpahnDgs8g1zrQ0D8QYDmu0Zfi+9GhoD80B4yJez2+ydJPJz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-channel-js": "3.4.1",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@vscode/l10n": {

--- a/package.json
+++ b/package.json
@@ -206,10 +206,11 @@
     "vscode-uri": "~3.1.0",
     "zod": "~4.3.6"
   },
-  "//overrides": "Pin transitive dependencies: glob 12.0.x for latest, test-exclude 7 for compatibility.",
+  "//overrides": "Pin transitive dependencies: glob 12.0.x for latest, test-exclude 7 for compatibility. applicationinsights-web-basic pinned to 3.4.1 to DEDUPE the App Insights stack (distinct from the earlier ~3.3.4 pin removed in v0.9.1 via #614, which existed only to restore applicationinsights-common before extension-telemetry@1.5.2 declared it directly). extension-telemetry resolves web-basic@^3.4.1 up to 3.4.2, which exact-pins core-js/channel-js@3.4.2 while common/1ds-* exact-pin core-js@3.4.1 - bundling two core-js copies and risking an unresolved @nevware21/ts-utils named import (isNullOrUndefined) at runtime. 3.4.1 is in-range (not a downgrade) and collapses the stack to one line. Remove once the AI stack resolves to a single core-js without this pin. See #626.",
   "overrides": {
     "glob": "~12.0.0",
-    "test-exclude": "~7.0.1"
+    "test-exclude": "~7.0.1",
+    "@microsoft/applicationinsights-web-basic": "3.4.1"
   },
   "extensionDependencies": [],
   "contributes": {


### PR DESCRIPTION
## Summary

Fixes a runtime crash — `(0 , o.isNullOrUndefined) is not a function` — that could surface as an error notification when activating Service Discovery (and on other actions that emit telemetry). The root cause was **two duplicate copies of `@microsoft/applicationinsights-core-js`** bundled into the extension, which left a `@nevware21/ts-utils` named import (`isNullOrUndefined`) unresolved at runtime.

## Root cause

`@vscode/extension-telemetry@1.5.2` requests `applicationinsights-web-basic@^3.4.1`, which npm resolves *up* to `3.4.2`. `web-basic@3.4.2` exact-pins `core-js`/`channel-js@3.4.2`, while `applicationinsights-common` and `1ds-*` exact-pin `core-js@3.4.1`. Those conflicting exact pins cause **two `core-js` copies** to be bundled (they are not in webpack `externals`), and the mismatched copy can resolve the `isNullOrUndefined` import to `undefined`.

## Fix

Pin `@microsoft/applicationinsights-web-basic` to `3.4.1` via `overrides`. `3.4.1` satisfies the requested `^3.4.1` range (not a downgrade) and pairs with `core-js@3.4.1` / `channel-js@3.4.1`, collapsing the whole App Insights stack onto a single line.

- Single resolved copy of `applicationinsights-core-js`, `-channel-js`, `-web-basic`, and `@nevware21/ts-utils`.
- Lockfile net −30 lines; recovers the duplicate-bundle overhead noted in #614.
- Distinct from the `~3.3.4` override removed in v0.9.1 (#614): that one restored a missing `applicationinsights-common`; this one deduplicates within the 3.4.x line. The `//overrides` comment in `package.json` documents the distinction and the removal criterion.

## Testing

- `npm run build` — passes
- `npx jest --no-coverage` — 2664/2664 tests pass
- `npm run lint` + Prettier — clean
- Verified single copies via `npm ls @microsoft/applicationinsights-core-js`

## Follow-up

This is a temporary safeguard. Removal is tracked with #626 (`@microsoft/vscode-azext-utils` v3 → v4). When that work is picked up, verify by removing the override and running `npm ls @microsoft/applicationinsights-core-js`: if a single copy resolves, drop the override; otherwise keep it.

Related: #614, #626