### PR TITLE
chore(discovery): clean up legacy activeDiscoveryProviderIds key and document upgrade behavior

### DIFF
--- a/src/documentdb/ClustersExtension.ts
+++ b/src/documentdb/ClustersExtension.ts
@@ -84,6 +84,7 @@ import { AzureVMDiscoveryProvider } from '../plugins/service-azure-vm/AzureVMDis
 import { KubernetesDiscoveryProvider } from '../plugins/service-kubernetes/KubernetesDiscoveryProvider';
 import { KubernetesReachabilityProvider } from '../plugins/service-kubernetes/KubernetesReachabilityProvider';
 import { ConnectionReachabilityService } from '../services/connectionReachabilityService';
+import { removeLegacyActiveDiscoveryProviderIds } from '../services/discoveryProviderVisibility';
 import { DiscoveryService } from '../services/discoveryServices';
 import { maybeShowReleaseNotesNotification } from '../services/releaseNotesNotification';
 import { DemoTask } from '../services/taskService/tasks/DemoTask';
@@ -136,6 +137,9 @@ export class ClustersExtension implements vscode.Disposable {
         DiscoveryService.registerProvider(new AzureMongoRUDiscoveryProvider());
         DiscoveryService.registerProvider(new AzureVMDiscoveryProvider());
         DiscoveryService.registerProvider(new KubernetesDiscoveryProvider());
+
+        // One-time cleanup of the pre-0.9.0 opt-in visibility key; see discoveryProviderVisibility.ts (TODO #831).
+        void removeLegacyActiveDiscoveryProviderIds();
 
         // Connection-reachability providers: source-specific steps that make a saved connection
         // reachable before connecting (e.g. re-establishing a Kubernetes port-forward tunnel).

--- a/src/services/discoveryProviderVisibility.ts
+++ b/src/services/discoveryProviderVisibility.ts
@@ -49,8 +49,16 @@ export async function getHiddenDiscoveryProviderIds(): Promise<string[]> {
  * ~6 months after 0.9.2, once users have upgraded past 0.8.x.
  */
 export async function removeLegacyActiveDiscoveryProviderIds(): Promise<void> {
-    if (ext.context.globalState.get(LEGACY_ACTIVE_DISCOVERY_PROVIDER_IDS_KEY) !== undefined) {
-        await ext.context.globalState.update(LEGACY_ACTIVE_DISCOVERY_PROVIDER_IDS_KEY, undefined);
+    // Best-effort: swallow storage errors so this cleanup can never disrupt activation.
+    try {
+        if (ext.context.globalState.get(LEGACY_ACTIVE_DISCOVERY_PROVIDER_IDS_KEY) !== undefined) {
+            await ext.context.globalState.update(LEGACY_ACTIVE_DISCOVERY_PROVIDER_IDS_KEY, undefined);
+        }
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        ext.outputChannel.error(
+            `Failed to remove legacy '${LEGACY_ACTIVE_DISCOVERY_PROVIDER_IDS_KEY}' discovery state: ${message}`,
+        );
     }
 }
 

--- a/src/services/discoveryProviderVisibility.ts
+++ b/src/services/discoveryProviderVisibility.ts
@@ -8,17 +8,50 @@ import { DiscoveryService, type ProviderDescription } from './discoveryServices'
 
 const HIDDEN_DISCOVERY_PROVIDER_IDS_KEY = 'hiddenDiscoveryProviderIds';
 
+/**
+ * Legacy pre-0.9.0 opt-in allow-list key (see the module doc below). No longer read;
+ * removed once by {@link removeLegacyActiveDiscoveryProviderIds}.
+ */
+const LEGACY_ACTIVE_DISCOVERY_PROVIDER_IDS_KEY = 'activeDiscoveryProviderIds';
+
 let hiddenProviderIdsCache: string[] | undefined;
 
 /**
- * Provider visibility uses a single, simple model: every registered discovery
- * provider is visible by default, and the persisted `hiddenDiscoveryProviderIds`
- * list tracks only the providers the user has chosen to hide. There is no
- * migration path — older state keys are simply ignored, so everyone starts with
- * all providers visible and can hide the ones they don't want.
+ * Discovery-provider visibility — storage model and cross-version upgrade behavior.
+ *
+ * Current model (>= 0.9.0): OPT-OUT deny-list. Every registered provider is visible by
+ * default; `hiddenDiscoveryProviderIds` records only the ones the user chose to hide.
+ * Default (empty list) => all providers visible.
+ *
+ * Legacy model (<= 0.8.x): OPT-IN allow-list stored under `activeDiscoveryProviderIds`.
+ * Default (empty list) => nothing visible; users explicitly activated providers.
+ *
+ * The 0.8.x -> 0.9.x upgrade is intentionally NOT migrated. The semantics are inverted
+ * (opt-in allow-list -> opt-out deny-list), so the legacy `activeDiscoveryProviderIds`
+ * value is ignored and left as-is in globalState. Upgraders therefore start with ALL
+ * providers visible. This is by design and upgrade-safe: it only ever reveals more
+ * providers, never hides one that was previously visible, so it is not a downgrade.
+ *
+ * A one-time active->hidden migration existed briefly during 0.9.0 development but was
+ * dropped before release (never shipped), so no half-migrated state exists in the wild.
+ * Do NOT reintroduce a migration without revisiting that product decision.
  */
 export async function getHiddenDiscoveryProviderIds(): Promise<string[]> {
     return readHiddenDiscoveryProviderIds();
+}
+
+/**
+ * One-time, best-effort cleanup of the stale pre-0.9.0 `activeDiscoveryProviderIds`
+ * globalState key. Safe to run on every activation: it writes only when the key is
+ * still present. The value is intentionally not migrated (see the module doc).
+ *
+ * TODO(#831): remove this function and {@link LEGACY_ACTIVE_DISCOVERY_PROVIDER_IDS_KEY}
+ * ~6 months after 0.9.2, once users have upgraded past 0.8.x.
+ */
+export async function removeLegacyActiveDiscoveryProviderIds(): Promise<void> {
+    if (ext.context.globalState.get(LEGACY_ACTIVE_DISCOVERY_PROVIDER_IDS_KEY) !== undefined) {
+        await ext.context.globalState.update(LEGACY_ACTIVE_DISCOVERY_PROVIDER_IDS_KEY, undefined);
+    }
 }
 
 export async function getVisibleDiscoveryProviders(): Promise<ProviderDescription[]> {


### PR DESCRIPTION
## Summary

Housekeeping for the Service Discovery provider-visibility storage. The pre-0.9.0 model was an **opt-in allow-list** (`activeDiscoveryProviderIds`); since 0.9.0 it's an **opt-out deny-list** (`hiddenDiscoveryProviderIds`). The legacy key is no longer read, but it was left behind in `globalState` on upgrade.

## Changes

- **Documents the cross-version upgrade behavior** in `discoveryProviderVisibility.ts`: the opt-in → opt-out flip is intentionally **not migrated** (upgraders start with all providers visible — only ever *revealing more*, never hiding a previously-visible provider, so it is not a downgrade). The brief 0.9.0-dev migration was dropped before release and never shipped.
- **Adds a one-time, best-effort cleanup** (`removeLegacyActiveDiscoveryProviderIds`) that removes the stale `activeDiscoveryProviderIds` key on activation, wired into `ClustersExtension.registerDiscoveryServices()` (guarded — writes only when the key is still present).

## Notes

- No user-facing behavior change; purely removes dead `globalState`.
- Removal of this temporary cleanup is tracked by #831 (~6 months after 0.9.2).

## Testing

- `npm run build` — passes
- Discovery suites (`discovery-view`, `addDiscoveryRegistry`, `removeDiscoveryRegistry`) — 50 tests pass
- ESLint + Prettier — clean