### PR TITLE
Unify Atlas and index option UI

### DIFF
--- a/src/webviews/documentdb/atlasCredentials/AtlasCredentialsView.tsx
+++ b/src/webviews/documentdb/atlasCredentials/AtlasCredentialsView.tsx
@@ -192,6 +192,13 @@ const useStyles = makeStyles({
         borderRadius: tokens.borderRadiusMedium,
     },
     stageRow: { display: 'flex', alignItems: 'center', gap: '10px', minHeight: '20px' },
+    stageIcon: {
+        width: '18px',
+        height: '18px',
+        flexShrink: 0,
+        display: 'grid',
+        placeItems: 'center',
+    },
     stageDone: { color: tokens.colorPaletteGreenForeground1, fontSize: '18px', flexShrink: 0 },
     stageError: { color: tokens.colorPaletteRedForeground1, fontSize: '18px', flexShrink: 0 },
     stageWarning: { color: tokens.colorStatusWarningForeground1, fontSize: '18px', flexShrink: 0 },
@@ -220,7 +227,7 @@ const StageRow = ({ label, status }: StageRowProps): JSX.Element => {
         icon = <CheckmarkCircleFilled aria-hidden className={styles.stageDone} />;
         statusText = l10n.t('done');
     } else if (status === 'active') {
-        icon = <Spinner size="tiny" aria-hidden />;
+        icon = <Spinner size="extra-tiny" aria-hidden />;
         statusText = l10n.t('in progress');
     } else if (status === 'error') {
         icon = <ErrorCircleFilled aria-hidden className={styles.stageError} />;
@@ -235,7 +242,7 @@ const StageRow = ({ label, status }: StageRowProps): JSX.Element => {
 
     return (
         <div className={styles.stageRow} role="listitem" aria-label={`${label}, ${statusText}`}>
-            {icon}
+            <span className={styles.stageIcon}>{icon}</span>
             <Text aria-hidden className={status === 'pending' ? styles.muted : undefined}>
                 {label}
             </Text>

--- a/src/webviews/documentdb/atlasCredentials/AtlasCredentialsView.tsx
+++ b/src/webviews/documentdb/atlasCredentials/AtlasCredentialsView.tsx
@@ -49,7 +49,6 @@ import {
     bundleIcon,
     CheckmarkCircleFilled,
     CircleHintFilled,
-    CircleRegular,
     CloudRegular,
     ErrorCircleFilled,
     EyeOffRegular,
@@ -230,7 +229,7 @@ const StageRow = ({ label, status }: StageRowProps): JSX.Element => {
         icon = <WarningRegular aria-hidden className={styles.stageWarning} />;
         statusText = l10n.t('warning');
     } else {
-        icon = <CircleRegular aria-hidden className={styles.stagePending} />;
+        icon = <CircleHintFilled aria-hidden className={styles.stagePending} />;
         statusText = l10n.t('pending');
     }
 

--- a/src/webviews/documentdb/indexView/components/CreateIndexDrawer.tsx
+++ b/src/webviews/documentdb/indexView/components/CreateIndexDrawer.tsx
@@ -1245,6 +1245,16 @@ export const CreateIndexDrawer = ({
                                             className="vectorAlgorithmCards"
                                             aria-label={l10n.t('Wildcard index scope')}
                                             value={wildcardScope}
+                                            disabled={interactionDisabled}
+                                            onChange={(_event, data) => {
+                                                if (
+                                                    data.value === 'all' ||
+                                                    data.value === 'projection' ||
+                                                    data.value === 'path'
+                                                ) {
+                                                    setForm((prev) => ({ ...prev, wildcardScope: data.value }));
+                                                }
+                                            }}
                                         >
                                             {wildcardScopeOptions.map((option) => {
                                                 const selected = wildcardScope === option.value;
@@ -1501,6 +1511,16 @@ export const CreateIndexDrawer = ({
                                         className="vectorAlgorithmCards"
                                         aria-label={l10n.t('Vector algorithm')}
                                         value={vectorAlgorithm}
+                                        disabled={interactionDisabled}
+                                        onChange={(_event, data) => {
+                                            if (
+                                                data.value === 'vector-diskann' ||
+                                                data.value === 'vector-hnsw' ||
+                                                data.value === 'vector-ivf'
+                                            ) {
+                                                setForm((prev) => ({ ...prev, vectorAlgorithm: data.value }));
+                                            }
+                                        }}
                                     >
                                         {vectorAlgorithmOptions.map((option) => {
                                             const selected = vectorAlgorithm === option.value;

--- a/src/webviews/documentdb/indexView/components/CreateIndexDrawer.tsx
+++ b/src/webviews/documentdb/indexView/components/CreateIndexDrawer.tsx
@@ -4,7 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import {
+    Body1,
     Button,
+    Card,
+    CardHeader,
     Combobox,
     DrawerBody,
     DrawerFooter,
@@ -23,6 +26,7 @@ import {
     Switch,
     Tab,
     TabList,
+    Text,
     Tooltip,
 } from '@fluentui/react-components';
 import {
@@ -382,14 +386,6 @@ export const CreateIndexDrawer = ({
     const vectorAlgorithmOptions = useMemo(() => buildVectorAlgorithmOptions(), []);
     const vectorSimilarityOptions = useMemo(() => buildVectorSimilarityOptions(), []);
 
-    // Roving-focus targets for the algorithm radio-card group, so arrow keys can
-    // move focus to the newly selected card.
-    const algorithmCardRefs = useRef<Record<string, HTMLButtonElement | null>>({});
-    const wildcardScopeCardRefs = useRef<Record<WildcardScope, HTMLButtonElement | null>>({
-        all: null,
-        projection: null,
-        path: null,
-    });
     const advancedEntryRef = useRef<HTMLButtonElement>(null);
     const previewEntryRef = useRef<HTMLButtonElement>(null);
     const pageTitleRef = useRef<HTMLSpanElement>(null);
@@ -619,24 +615,6 @@ export const CreateIndexDrawer = ({
         pqSampleSizeValid;
 
     const vectorAlgorithmLabel = vectorAlgorithmOptions.find((o) => o.value === vectorAlgorithm)?.label ?? '';
-
-    const moveWildcardScopeSelection = (offset: number): void => {
-        const values = wildcardScopeOptions.map((option) => option.value);
-        const currentIndex = values.indexOf(wildcardScope);
-        const next = values[(currentIndex + offset + values.length) % values.length];
-        setForm((prev) => ({ ...prev, wildcardScope: next }));
-        wildcardScopeCardRefs.current[next]?.focus();
-    };
-
-    // Select the algorithm `offset` positions from the current one (wrapping) and
-    // move focus to its card, so the radio-card group is keyboard navigable.
-    const moveAlgorithmSelection = (offset: number): void => {
-        const values = vectorAlgorithmOptions.map((option) => option.value);
-        const currentIndex = values.indexOf(vectorAlgorithm);
-        const next = values[(currentIndex + offset + values.length) % values.length];
-        setForm((prev) => ({ ...prev, vectorAlgorithm: next }));
-        algorithmCardRefs.current[next]?.focus();
-    };
 
     const vectorCompressionLabel =
         effectiveCompression === 'half'
@@ -1263,57 +1241,50 @@ export const CreateIndexDrawer = ({
                                     hint={l10n.t('Choose which fields the wildcard index covers.')}
                                 >
                                     <div className="wildcardSettings">
-                                        <div
+                                        <RadioGroup
                                             className="vectorAlgorithmCards"
-                                            role="radiogroup"
                                             aria-label={l10n.t('Wildcard index scope')}
+                                            value={wildcardScope}
                                         >
                                             {wildcardScopeOptions.map((option) => {
                                                 const selected = wildcardScope === option.value;
                                                 return (
-                                                    <button
+                                                    <Card
                                                         key={option.value}
-                                                        ref={(node) => {
-                                                            wildcardScopeCardRefs.current[option.value] = node;
-                                                        }}
-                                                        type="button"
-                                                        role="radio"
-                                                        aria-checked={selected}
-                                                        tabIndex={selected ? 0 : -1}
-                                                        className={
-                                                            selected
-                                                                ? 'vectorAlgoCard vectorAlgoCardSelected'
-                                                                : 'vectorAlgoCard'
-                                                        }
+                                                        className="vectorAlgoCard"
+                                                        selected={selected}
                                                         disabled={interactionDisabled}
-                                                        onClick={() =>
-                                                            setForm((prev) => ({
-                                                                ...prev,
-                                                                wildcardScope: option.value,
-                                                            }))
-                                                        }
-                                                        onKeyDown={(event) => {
-                                                            if (
-                                                                event.key === 'ArrowRight' ||
-                                                                event.key === 'ArrowDown'
-                                                            ) {
-                                                                event.preventDefault();
-                                                                moveWildcardScopeSelection(1);
-                                                            } else if (
-                                                                event.key === 'ArrowLeft' ||
-                                                                event.key === 'ArrowUp'
-                                                            ) {
-                                                                event.preventDefault();
-                                                                moveWildcardScopeSelection(-1);
+                                                        onSelectionChange={(_event, data) => {
+                                                            if (data.selected) {
+                                                                setForm((prev) => ({
+                                                                    ...prev,
+                                                                    wildcardScope: option.value,
+                                                                }));
                                                             }
                                                         }}
+                                                        floatingAction={
+                                                            <Radio
+                                                                checked={selected}
+                                                                disabled={interactionDisabled}
+                                                                value={option.value}
+                                                                aria-label={option.label}
+                                                                onChange={() =>
+                                                                    setForm((prev) => ({
+                                                                        ...prev,
+                                                                        wildcardScope: option.value,
+                                                                    }))
+                                                                }
+                                                            />
+                                                        }
                                                     >
-                                                        <span className="vectorAlgoCardTitle">{option.label}</span>
-                                                        <span className="vectorAlgoCardHint">{option.hint}</span>
-                                                    </button>
+                                                        <CardHeader
+                                                            header={<Text weight="semibold">{option.label}</Text>}
+                                                        />
+                                                        <Body1 className="vectorAlgoCardHint">{option.hint}</Body1>
+                                                    </Card>
                                                 );
                                             })}
-                                        </div>
+                                        </RadioGroup>
 
                                         <Collapse visible={wildcardScope === 'path'} unmountOnExit>
                                             <Field
@@ -1526,51 +1497,50 @@ export const CreateIndexDrawer = ({
                                     title={l10n.t('Algorithm')}
                                     hint={l10n.t('Approximate nearest-neighbor algorithm used to build the index.')}
                                 >
-                                    <div
+                                    <RadioGroup
                                         className="vectorAlgorithmCards"
-                                        role="radiogroup"
                                         aria-label={l10n.t('Vector algorithm')}
+                                        value={vectorAlgorithm}
                                     >
                                         {vectorAlgorithmOptions.map((option) => {
                                             const selected = vectorAlgorithm === option.value;
                                             return (
-                                                <button
+                                                <Card
                                                     key={option.value}
-                                                    ref={(node) => {
-                                                        algorithmCardRefs.current[option.value] = node;
-                                                    }}
-                                                    type="button"
-                                                    role="radio"
-                                                    aria-checked={selected}
-                                                    tabIndex={selected ? 0 : -1}
-                                                    className={
-                                                        selected
-                                                            ? 'vectorAlgoCard vectorAlgoCardSelected'
-                                                            : 'vectorAlgoCard'
-                                                    }
+                                                    className="vectorAlgoCard"
+                                                    selected={selected}
                                                     disabled={interactionDisabled}
-                                                    onClick={() =>
-                                                        setForm((prev) => ({ ...prev, vectorAlgorithm: option.value }))
-                                                    }
-                                                    onKeyDown={(event) => {
-                                                        if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
-                                                            event.preventDefault();
-                                                            moveAlgorithmSelection(1);
-                                                        } else if (
-                                                            event.key === 'ArrowLeft' ||
-                                                            event.key === 'ArrowUp'
-                                                        ) {
-                                                            event.preventDefault();
-                                                            moveAlgorithmSelection(-1);
+                                                    onSelectionChange={(_event, data) => {
+                                                        if (data.selected) {
+                                                            setForm((prev) => ({
+                                                                ...prev,
+                                                                vectorAlgorithm: option.value,
+                                                            }));
                                                         }
                                                     }}
+                                                    floatingAction={
+                                                        <Radio
+                                                            checked={selected}
+                                                            disabled={interactionDisabled}
+                                                            value={option.value}
+                                                            aria-label={option.label}
+                                                            onChange={() =>
+                                                                setForm((prev) => ({
+                                                                    ...prev,
+                                                                    vectorAlgorithm: option.value,
+                                                                }))
+                                                            }
+                                                        />
+                                                    }
                                                 >
-                                                    <span className="vectorAlgoCardTitle">{option.label}</span>
-                                                    <span className="vectorAlgoCardHint">{option.hint}</span>
-                                                </button>
+                                                    <CardHeader
+                                                        header={<Text weight="semibold">{option.label}</Text>}
+                                                    />
+                                                    <Body1 className="vectorAlgoCardHint">{option.hint}</Body1>
+                                                </Card>
                                             );
                                         })}
-                                    </div>
+                                    </RadioGroup>
                                 </DrawerSection>
 
                                 <DrawerSection

--- a/src/webviews/documentdb/indexView/components/CreateIndexDrawer.tsx
+++ b/src/webviews/documentdb/indexView/components/CreateIndexDrawer.tsx
@@ -1273,18 +1273,7 @@ export const CreateIndexDrawer = ({
                                                             }
                                                         }}
                                                         floatingAction={
-                                                            <Radio
-                                                                checked={selected}
-                                                                disabled={interactionDisabled}
-                                                                value={option.value}
-                                                                aria-label={option.label}
-                                                                onChange={() =>
-                                                                    setForm((prev) => ({
-                                                                        ...prev,
-                                                                        wildcardScope: option.value,
-                                                                    }))
-                                                                }
-                                                            />
+                                                            <Radio value={option.value} aria-label={option.label} />
                                                         }
                                                     >
                                                         <CardHeader
@@ -1539,18 +1528,7 @@ export const CreateIndexDrawer = ({
                                                         }
                                                     }}
                                                     floatingAction={
-                                                        <Radio
-                                                            checked={selected}
-                                                            disabled={interactionDisabled}
-                                                            value={option.value}
-                                                            aria-label={option.label}
-                                                            onChange={() =>
-                                                                setForm((prev) => ({
-                                                                    ...prev,
-                                                                    vectorAlgorithm: option.value,
-                                                                }))
-                                                            }
-                                                        />
+                                                        <Radio value={option.value} aria-label={option.label} />
                                                     }
                                                 >
                                                     <CardHeader

--- a/src/webviews/documentdb/indexView/components/CreateIndexDrawer.tsx
+++ b/src/webviews/documentdb/indexView/components/CreateIndexDrawer.tsx
@@ -1247,12 +1247,9 @@ export const CreateIndexDrawer = ({
                                             value={wildcardScope}
                                             disabled={interactionDisabled}
                                             onChange={(_event, data) => {
-                                                if (
-                                                    data.value === 'all' ||
-                                                    data.value === 'projection' ||
-                                                    data.value === 'path'
-                                                ) {
-                                                    setForm((prev) => ({ ...prev, wildcardScope: data.value }));
+                                                const scope = data.value;
+                                                if (scope === 'all' || scope === 'projection' || scope === 'path') {
+                                                    setForm((prev) => ({ ...prev, wildcardScope: scope }));
                                                 }
                                             }}
                                         >
@@ -1502,12 +1499,13 @@ export const CreateIndexDrawer = ({
                                         value={vectorAlgorithm}
                                         disabled={interactionDisabled}
                                         onChange={(_event, data) => {
+                                            const algorithm = data.value;
                                             if (
-                                                data.value === 'vector-diskann' ||
-                                                data.value === 'vector-hnsw' ||
-                                                data.value === 'vector-ivf'
+                                                algorithm === 'vector-diskann' ||
+                                                algorithm === 'vector-hnsw' ||
+                                                algorithm === 'vector-ivf'
                                             ) {
-                                                setForm((prev) => ({ ...prev, vectorAlgorithm: data.value }));
+                                                setForm((prev) => ({ ...prev, vectorAlgorithm: algorithm }));
                                             }
                                         }}
                                     >

--- a/src/webviews/documentdb/indexView/indexView.scss
+++ b/src/webviews/documentdb/indexView/indexView.scss
@@ -629,61 +629,22 @@
         }
     }
 
-    // Algorithm picker: three parallel selectable cards, each carrying its own
-    // one-line description, that wrap to a column on a narrow drawer. Implemented
-    // as an ARIA radiogroup of buttons so the whole card is the hit target.
+    // Algorithm picker: parallel Fluent selectable cards that wrap to a column
+    // on a narrow drawer.
     .vectorAlgorithmCards {
         display: flex;
         flex-direction: row;
+        align-items: stretch;
         gap: 8px;
         flex-wrap: wrap;
     }
 
     .vectorAlgoCard {
-        display: flex;
-        flex-direction: column;
-        row-gap: 3px;
         flex: 1 1 150px;
+        align-self: stretch;
+        height: auto;
         min-width: 0;
-        padding: 10px 12px;
-        text-align: start;
-        border: 1px solid var(--colorNeutralStroke2);
-        border-radius: var(--borderRadiusMedium);
-        background-color: var(--colorNeutralBackground1);
-        color: inherit;
-        font-family: inherit;
         cursor: pointer;
-
-        &:hover:not(:disabled) {
-            background-color: var(--colorNeutralBackground1Hover);
-        }
-
-        &:disabled {
-            cursor: default;
-            opacity: 0.6;
-        }
-
-        // Match the Fluent focus ring used elsewhere in the drawer.
-        &:focus-visible {
-            outline: 2px solid var(--colorStrokeFocus2);
-            outline-offset: 2px;
-        }
-    }
-
-    // The selected card is tinted and outlined with the brand stroke so the
-    // active algorithm reads at a glance.
-    .vectorAlgoCardSelected {
-        border-color: var(--colorCompoundBrandStroke);
-        background-color: var(--colorNeutralBackground1Selected);
-
-        &:hover:not(:disabled) {
-            background-color: var(--colorNeutralBackground1Selected);
-        }
-    }
-
-    .vectorAlgoCardTitle {
-        font-weight: var(--fontWeightSemibold);
-        font-size: var(--fontSizeBase300);
     }
 
     .vectorAlgoCardHint {


### PR DESCRIPTION
## Summary
- use Fluent UI cards for index options
- align Atlas pending and credential stage status icons
- keep Atlas and index option styling consistent

## Validation
- `npm run l10n`
- `npm run prettier-fix`
- `npm run lint`
- `npx jest --no-coverage`
- `npm run build`