### PR TITLE
Adapt Fluent colors to VS Code themes

### DIFF
--- a/src/webviews/documentdb/indexView/components/indexList/IndexRowDetails.tsx
+++ b/src/webviews/documentdb/indexView/components/indexList/IndexRowDetails.tsx
@@ -127,7 +127,7 @@ export const IndexRowDetails = ({ index }: IndexRowDetailsProps): JSX.Element =>
                                 <Badge
                                     className="keyBadge focusableBadge"
                                     appearance="tint"
-                                    color="informative"
+                                    color="brand"
                                     shape="rounded"
                                     size="medium"
                                     tabIndex={0}

--- a/src/webviews/documentdb/indexView/components/indexList/IndexTable.tsx
+++ b/src/webviews/documentdb/indexView/components/indexList/IndexTable.tsx
@@ -254,22 +254,9 @@ export const IndexTable = ({
                     const isPending = idx.state === 'creating';
                     const isExpanded = expanded.has(idx.name);
                     /*
-                     * Fluent Table does not provide zebra striping by default.
-                     * We implement it with rowEven/rowOdd classes whose colors
-                     * are painted on each <td>, rather than on the <tr>, so an
-                     * expanded detail row can inherit its parent index's shade.
-                     *
-                     * That cell-level background covers Fluent's normal hover
-                     * and pressed backgrounds, which Fluent paints on the <tr>.
-                     * The matching selectors in indexView.scss therefore also
-                     * paint list hover/pressed colors on the cells. If this
-                     * striping pattern is reused for another Fluent table, both
-                     * the parity classes and those cell-level interaction rules
-                     * must be carried over; otherwise hover/pressed feedback will
-                     * be hidden or visible only on alternating rows.
-                     *
-                     * Compute parity from the data index (not the DOM position)
-                     * so an inserted detail row never breaks the pattern.
+                     * Zebra parity comes from the data index, not the DOM position, so an
+                     * inserted detail row never breaks the alternating pattern. The colors
+                     * (and the matching hover/pressed rules) live in indexView.scss.
                      */
                     const rowClass = rowIdx % 2 === 0 ? 'rowEven' : 'rowOdd';
                     // A delete / hide / unhide in flight shows a spinner in the

--- a/src/webviews/documentdb/indexView/components/indexList/IndexTable.tsx
+++ b/src/webviews/documentdb/indexView/components/indexList/IndexTable.tsx
@@ -253,9 +253,24 @@ export const IndexTable = ({
                     // actions that operate on a live index are disabled.
                     const isPending = idx.state === 'creating';
                     const isExpanded = expanded.has(idx.name);
-                    // Compute zebra parity from the data index (not the DOM
-                    // position) so an inserted detail row never breaks the
-                    // alternating pattern.
+                    /*
+                     * Fluent Table does not provide zebra striping by default.
+                     * We implement it with rowEven/rowOdd classes whose colors
+                     * are painted on each <td>, rather than on the <tr>, so an
+                     * expanded detail row can inherit its parent index's shade.
+                     *
+                     * That cell-level background covers Fluent's normal hover
+                     * and pressed backgrounds, which Fluent paints on the <tr>.
+                     * The matching selectors in indexView.scss therefore also
+                     * paint list hover/pressed colors on the cells. If this
+                     * striping pattern is reused for another Fluent table, both
+                     * the parity classes and those cell-level interaction rules
+                     * must be carried over; otherwise hover/pressed feedback will
+                     * be hidden or visible only on alternating rows.
+                     *
+                     * Compute parity from the data index (not the DOM position)
+                     * so an inserted detail row never breaks the pattern.
+                     */
                     const rowClass = rowIdx % 2 === 0 ? 'rowEven' : 'rowOdd';
                     // A delete / hide / unhide in flight shows a spinner in the
                     // status column (in place of the ready check) for this row.

--- a/src/webviews/documentdb/indexView/components/indexList/IndexTypeBadgeView.tsx
+++ b/src/webviews/documentdb/indexView/components/indexList/IndexTypeBadgeView.tsx
@@ -14,10 +14,11 @@ import { type IndexTypeBadge } from '../../types';
  * (inaccessible) way to encode a category, and the previous per-type mapping
  * assigned alarming palette tokens with no real meaning — e.g. Wildcard →
  * `severe` (orange) and Hashed → `danger` (red) — which wrongly implied those
- * indexes were problematic. Every type now uses one neutral, legible tint; the
- * type is communicated by the badge's text label (and the card's icon).
+ * indexes were problematic. Every type now uses one shared tint generated from
+ * VS Code's active brand color; the type is communicated by the badge's text
+ * label (and the card's icon), not by assigning a different color per type.
  */
-const BADGE_COLOR: BadgeProps['color'] = 'informative';
+const BADGE_COLOR: BadgeProps['color'] = 'brand';
 
 export interface IndexTypeBadgeViewProps {
     type: IndexTypeBadge;

--- a/src/webviews/documentdb/indexView/indexView.scss
+++ b/src/webviews/documentdb/indexView/indexView.scss
@@ -207,6 +207,12 @@
          * convention used in the Results tab. Parity is computed in the
          * component (rowEven / rowOdd) from the data index so that the
          * expanded detail row inherits the same shade as its parent.
+         *
+         * Painting on <td> rather than <tr> is what lets the detail row match
+         * its parent, but it also covers the hover and pressed fills Fluent
+         * paints on the <tr>. The two rules below restore them at the same
+         * cell level; reuse of this striping pattern must carry them along or
+         * rows lose their interaction feedback.
          */
         .rowEven > td {
             background-color: var(--colorNeutralBackground1);
@@ -215,19 +221,13 @@
             background-color: var(--colorNeutralBackground2);
         }
 
-        /*
-         * Fluent applies table-row hover to the <tr>, but the zebra colors
-         * above are painted on each <td> and hide it. Paint the adaptive
-         * VS Code list hover color on the cells so every data row responds
-         * evenly without changing the global action-token semantics.
-         */
+        /* Adaptive list hover, on the cells so every data row responds evenly. */
         .rowEven:not(.fieldsDetailRow):hover > td,
         .rowOdd:not(.fieldsDetailRow):hover > td {
             background-color: var(--vscode-list-hoverBackground, var(--colorSubtleBackgroundHover));
         }
 
-        /* The same cell layer hid Fluent's <tr>:active fill; mirror the now
-            * theme-aware list selection color here and place it after hover. */
+        /* Pressed fill; must stay after hover, both selectors have equal specificity. */
         .rowEven:not(.fieldsDetailRow):active > td,
         .rowOdd:not(.fieldsDetailRow):active > td {
             background-color: var(--vscode-list-activeSelectionBackground, var(--colorSubtleBackgroundPressed));

--- a/src/webviews/documentdb/indexView/indexView.scss
+++ b/src/webviews/documentdb/indexView/indexView.scss
@@ -194,6 +194,15 @@
         }
 
         /*
+         * Fluent gives the inner sortable-header button `background: inherit`.
+         * With translucent VS Code hover colors that repaints the same fill over
+         * the hovered <th>, producing a darker text-width band. Keep one layer.
+         */
+        .fui-TableHeaderCell__button {
+            background-color: transparent;
+        }
+
+        /*
          * Alternating row backgrounds — mirrors the VS Code tree-view
          * convention used in the Results tab. Parity is computed in the
          * component (rowEven / rowOdd) from the data index so that the
@@ -204,6 +213,24 @@
         }
         .rowOdd > td {
             background-color: var(--colorNeutralBackground2);
+        }
+
+        /*
+         * Fluent applies table-row hover to the <tr>, but the zebra colors
+         * above are painted on each <td> and hide it. Paint the adaptive
+         * VS Code list hover color on the cells so every data row responds
+         * evenly without changing the global action-token semantics.
+         */
+        .rowEven:not(.fieldsDetailRow):hover > td,
+        .rowOdd:not(.fieldsDetailRow):hover > td {
+            background-color: var(--vscode-list-hoverBackground, var(--colorSubtleBackgroundHover));
+        }
+
+        /* The same cell layer hid Fluent's <tr>:active fill; mirror the now
+            * theme-aware list selection color here and place it after hover. */
+        .rowEven:not(.fieldsDetailRow):active > td,
+        .rowOdd:not(.fieldsDetailRow):active > td {
+            background-color: var(--vscode-list-activeSelectionBackground, var(--colorSubtleBackgroundPressed));
         }
 
         /*

--- a/src/webviews/index.scss
+++ b/src/webviews/index.scss
@@ -20,7 +20,8 @@ $media-breakpoint-query-control-area: 1024px;
  * for consistency across custom components like MonacoAutoHeight.
  *
  * Uses Fluent UI design tokens:
- * - Border: --colorNeutralStroke1, --borderRadiusMedium
+ * - Border: --documentdb-colorInputStroke, --borderRadiusMedium
+ * - Border (hover): --documentdb-colorInputStrokeHover
  * - Background: --colorNeutralBackground1
  * - Spacing: --spacingVerticalS, --spacingHorizontalS
  * - Animation: --durationFast, --curveEasyEase

--- a/src/webviews/index.scss
+++ b/src/webviews/index.scss
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+@use './theme/fluentOverrides';
+
 /* Define standard variables and values for this extension to be shared with all webviews */
 
 .selectionDisabled {
@@ -29,7 +31,7 @@ $media-breakpoint-query-control-area: 1024px;
  * Base border styling for input-like components
  */
 @mixin input-border {
-    border: 1px solid var(--vscode-checkbox-border); // TODO: find the style name of a fluent input field var(--colorNeutralStroke1) doesn't work well, maybe we failed with style adatpation on this one.
+    border: 1px solid var(--documentdb-colorInputStroke);
     border-radius: var(--borderRadiusMedium);
 }
 
@@ -73,7 +75,7 @@ $media-breakpoint-query-control-area: 1024px;
  */
 @mixin input-hover {
     &:hover:not(:focus-within) {
-        border-color: var(--colorNeutralStroke1Hover);
+        border-color: var(--documentdb-colorInputStrokeHover);
     }
 }
 

--- a/src/webviews/index.scss
+++ b/src/webviews/index.scss
@@ -3,9 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-@use './theme/fluentOverrides';
-
 /* Define standard variables and values for this extension to be shared with all webviews */
+
+/*
+ * The --documentdb-* aliases used below live in theme/fluentAliases.scss, pulled in by
+ * theme/fluentOverrides.scss, which DynamicThemeProvider imports for every webview.
+ */
 
 .selectionDisabled {
     user-select: none;

--- a/src/webviews/theme/DynamicThemeProvider.tsx
+++ b/src/webviews/theme/DynamicThemeProvider.tsx
@@ -6,6 +6,9 @@
 import { FluentProvider } from '@fluentui/react-components';
 import { type PropsWithChildren, type ReactNode } from 'react';
 import { useThemeState, WithTheme } from './state/ThemeContext';
+// Side-effect import: every webview renders through this provider, and they all share one
+// bundle, so this is what puts the global Fluent adaptations on the page.
+import './fluentOverrides.scss';
 
 export type DynamicThemeProviderProps = {
     useAdaptive?: boolean;

--- a/src/webviews/theme/fluentAliases.scss
+++ b/src/webviews/theme/fluentAliases.scss
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * DocumentDB semantic aliases for styling custom controls like Fluent UI.
+ *
+ * Use these variables when a custom component needs the same visual role as a
+ * Fluent component but cannot consume a Fluent recipe directly. Global Fluent
+ * token mappings belong in themeGenerator.ts; component recipe exceptions
+ * belong in fluentOverrides.scss.
+ */
+:root {
+    --documentdb-colorInputStroke: var(
+        --vscode-checkbox-border,
+        var(--vscode-input-border, color-mix(in srgb, var(--vscode-foreground) 55%, transparent))
+    );
+    --documentdb-colorInputStrokeHover: color-mix(in srgb, var(--vscode-foreground) 75%, transparent);
+}

--- a/src/webviews/theme/fluentOverrides.scss
+++ b/src/webviews/theme/fluentOverrides.scss
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * VS Code adaptations for Fluent UI components.
+ *
+ * Keep component-scoped overrides here because Fluent reuses neutral aliases
+ * across controls with different semantics. For example, field stroke tokens
+ * also drive Switch indicators and Tab hover bars when changed globally.
+ */
+
+@use './fluentAliases';
+
+:where(.fui-Input, .fui-SearchBox, .fui-Combobox, .fui-Dropdown, .fui-Select, .fui-SpinButton, .fui-Textarea) {
+    --colorNeutralForeground3: var(--vscode-descriptionForeground, var(--vscode-foreground));
+    --colorNeutralForeground4: var(
+        --vscode-input-placeholderForeground,
+        var(--vscode-descriptionForeground, var(--vscode-foreground))
+    );
+    --colorNeutralStroke1: var(--documentdb-colorInputStroke);
+    --colorNeutralStroke1Hover: var(--documentdb-colorInputStrokeHover);
+    --colorNeutralStroke1Pressed: var(--documentdb-colorInputStrokeHover);
+    --colorNeutralStrokeAccessible: var(--documentdb-colorInputStroke);
+    --colorNeutralStrokeAccessibleHover: var(--documentdb-colorInputStrokeHover);
+    --colorNeutralStrokeAccessiblePressed: var(--documentdb-colorInputStrokeHover);
+}

--- a/src/webviews/theme/fluentOverrides.scss
+++ b/src/webviews/theme/fluentOverrides.scss
@@ -26,3 +26,25 @@
     --colorNeutralStrokeAccessibleHover: var(--documentdb-colorInputStrokeHover);
     --colorNeutralStrokeAccessiblePressed: var(--documentdb-colorInputStrokeHover);
 }
+
+.fui-ProgressBar {
+    --colorCompoundBrandBackground: var(--vscode-progressBar-background, var(--colorBrandStroke1));
+}
+
+.fui-ProgressBar:not([aria-valuenow]) {
+    // Fluent's indeterminate recipe overlays fixed-neutral edges on a solid
+    // brand segment. VS Code defines only the active progress color, so replace
+    // those two layers with one progress-colored segment that fades at its
+    // edges. Determinate bars retain Fluent's normal track and fill recipe.
+    --colorNeutralBackground6: transparent;
+    --colorCompoundBrandBackground: transparent;
+
+    .fui-ProgressBar__bar {
+        background-image: linear-gradient(
+            to right,
+            transparent 0%,
+            var(--vscode-progressBar-background, var(--colorBrandStroke1)) 50%,
+            transparent 100%
+        );
+    }
+}

--- a/src/webviews/theme/fluentOverrides.scss
+++ b/src/webviews/theme/fluentOverrides.scss
@@ -33,11 +33,15 @@
     --colorCompoundBrandBackground: var(--vscode-progressBar-background, var(--colorBrandStroke1));
 }
 
+// Fluent's indeterminate bar has no aria-valuenow, so this selector matches only that variant.
 .fui-ProgressBar:not([aria-valuenow]) {
     // Fluent's indeterminate recipe overlays fixed-neutral edges on a solid
     // brand segment. VS Code defines only the active progress color, so replace
     // those two layers with one progress-colored segment that fades at its
     // edges. Determinate bars retain Fluent's normal track and fill recipe.
+    //
+    // colorNeutralBackground6 is also the bar's rail, so clearing it leaves the
+    // indeterminate variant trackless — intentional, and how VS Code draws its own.
     --colorNeutralBackground6: transparent;
     --colorCompoundBrandBackground: transparent;
 

--- a/src/webviews/theme/fluentOverrides.scss
+++ b/src/webviews/theme/fluentOverrides.scss
@@ -9,6 +9,8 @@
  * Keep component-scoped overrides here because Fluent reuses neutral aliases
  * across controls with different semantics. For example, field stroke tokens
  * also drive Switch indicators and Tab hover bars when changed globally.
+ *
+ * Imported by DynamicThemeProvider, which every webview renders through.
  */
 
 @use './fluentAliases';

--- a/src/webviews/theme/fluentOverrides.test.ts
+++ b/src/webviews/theme/fluentOverrides.test.ts
@@ -4,16 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, test } from '@jest/globals';
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 const fluentProgressEntry = require.resolve('@fluentui/react-progress');
 const fluentProgressStylesPath = path.join(
     path.dirname(path.dirname(fluentProgressEntry)),
     'lib/components/ProgressBar/useProgressBarStyles.styles.raw.js',
 );
-const fluentProgressStyles = readFileSync(fluentProgressStylesPath, 'utf8');
-const fluentOverrides = readFileSync(path.join(__dirname, 'fluentOverrides.scss'), 'utf8');
+const fluentProgressStyles = fs.readFileSync(fluentProgressStylesPath, 'utf8');
+const fluentOverrides = fs.readFileSync(path.join(__dirname, 'fluentOverrides.scss'), 'utf8');
 
 function compactWhitespace(value: string): string {
     return value.replace(/\s+/g, ' ').trim();

--- a/src/webviews/theme/fluentOverrides.test.ts
+++ b/src/webviews/theme/fluentOverrides.test.ts
@@ -7,13 +7,21 @@ import { describe, expect, test } from '@jest/globals';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-const fluentProgressEntry = require.resolve('@fluentui/react-progress');
-const fluentProgressStylesPath = path.join(
-    path.dirname(path.dirname(fluentProgressEntry)),
-    'lib/components/ProgressBar/useProgressBarStyles.styles.raw.js',
-);
-const fluentProgressStyles = fs.readFileSync(fluentProgressStylesPath, 'utf8');
-const fluentOverrides = fs.readFileSync(path.join(__dirname, 'fluentOverrides.scss'), 'utf8');
+function readFluentProgressStyles(): string {
+    // require.resolve lands on <package>/lib-commonjs/index.js; the raw (pre-Griffel) styles ship
+    // beside the ESM build.
+    const packageRoot = path.dirname(path.dirname(require.resolve('@fluentui/react-progress')));
+    const stylesPath = path.join(packageRoot, 'lib/components/ProgressBar/useProgressBarStyles.styles.raw.js');
+
+    if (!fs.existsSync(stylesPath)) {
+        throw new Error(
+            `@fluentui/react-progress no longer exposes its raw ProgressBar styles at "${stylesPath}". ` +
+                'Locate the new file and re-verify the indeterminate override in fluentOverrides.scss.',
+        );
+    }
+
+    return fs.readFileSync(stylesPath, 'utf8');
+}
 
 function compactWhitespace(value: string): string {
     return value.replace(/\s+/g, ' ').trim();
@@ -21,7 +29,7 @@ function compactWhitespace(value: string): string {
 
 describe('Fluent ProgressBar override contract', () => {
     test('Fluent indeterminate gradient retains the recipe adapted by our override', () => {
-        expect(compactWhitespace(fluentProgressStyles)).toContain(
+        expect(compactWhitespace(readFluentProgressStyles())).toContain(
             compactWhitespace(`
                 backgroundImage: \`linear-gradient(
                     to right,
@@ -29,19 +37,6 @@ describe('Fluent ProgressBar override contract', () => {
                     \${tokens.colorTransparentBackground} 50%,
                     \${tokens.colorNeutralBackground6} 100%
                 )\`,
-            `),
-        );
-    });
-
-    test('our indeterminate gradient retains Fluent direction and stop positions', () => {
-        expect(compactWhitespace(fluentOverrides)).toContain(
-            compactWhitespace(`
-                background-image: linear-gradient(
-                    to right,
-                    transparent 0%,
-                    var(--vscode-progressBar-background, var(--colorBrandStroke1)) 50%,
-                    transparent 100%
-                );
             `),
         );
     });

--- a/src/webviews/theme/fluentOverrides.test.ts
+++ b/src/webviews/theme/fluentOverrides.test.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const fluentProgressEntry = require.resolve('@fluentui/react-progress');
+const fluentProgressStylesPath = path.join(
+    path.dirname(path.dirname(fluentProgressEntry)),
+    'lib/components/ProgressBar/useProgressBarStyles.styles.raw.js',
+);
+const fluentProgressStyles = readFileSync(fluentProgressStylesPath, 'utf8');
+const fluentOverrides = readFileSync(path.join(__dirname, 'fluentOverrides.scss'), 'utf8');
+
+function compactWhitespace(value: string): string {
+    return value.replace(/\s+/g, ' ').trim();
+}
+
+describe('Fluent ProgressBar override contract', () => {
+    test('Fluent indeterminate gradient retains the recipe adapted by our override', () => {
+        expect(compactWhitespace(fluentProgressStyles)).toContain(
+            compactWhitespace(`
+                backgroundImage: \`linear-gradient(
+                    to right,
+                    \${tokens.colorNeutralBackground6} 0%,
+                    \${tokens.colorTransparentBackground} 50%,
+                    \${tokens.colorNeutralBackground6} 100%
+                )\`,
+            `),
+        );
+    });
+
+    test('our indeterminate gradient retains Fluent direction and stop positions', () => {
+        expect(compactWhitespace(fluentOverrides)).toContain(
+            compactWhitespace(`
+                background-image: linear-gradient(
+                    to right,
+                    transparent 0%,
+                    var(--vscode-progressBar-background, var(--colorBrandStroke1)) 50%,
+                    transparent 100%
+                );
+            `),
+        );
+    });
+});

--- a/src/webviews/theme/themeGenerator.test.ts
+++ b/src/webviews/theme/themeGenerator.test.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+
+import { generateAdaptiveDarkTheme, generateAdaptiveLightTheme } from './themeGenerator';
+
+describe('adaptive neutral surface states', () => {
+    let originalDocument: Document | undefined;
+    let originalGetComputedStyle: typeof getComputedStyle;
+
+    beforeEach(() => {
+        originalDocument = globalThis.document;
+        originalGetComputedStyle = globalThis.getComputedStyle;
+        globalThis.document = { documentElement: {} } as unknown as Document;
+        globalThis.getComputedStyle = (() =>
+            ({
+                getPropertyValue: () => '#0078d4',
+            }) as unknown as CSSStyleDeclaration) as typeof getComputedStyle;
+    });
+
+    afterEach(() => {
+        if (originalDocument) {
+            globalThis.document = originalDocument;
+        } else {
+            delete (globalThis as { document?: Document }).document;
+        }
+        globalThis.getComputedStyle = originalGetComputedStyle;
+    });
+
+    test.each([
+        ['light', generateAdaptiveLightTheme],
+        ['dark', generateAdaptiveDarkTheme],
+    ])('%s theme uses action colors for pressed surfaces and matching selected foregrounds', (_, generateTheme) => {
+        const theme = generateTheme();
+
+        expect(theme.colorNeutralBackground1Pressed).toBe(
+            'var(--vscode-toolbar-activeBackground, var(--vscode-list-hoverBackground, var(--vscode-editorWidget-background)))',
+        );
+        expect(theme.colorNeutralBackground2Pressed).toBe(
+            'var(--vscode-toolbar-activeBackground, var(--vscode-list-hoverBackground, var(--vscode-sideBar-background)))',
+        );
+        expect(theme.colorNeutralForeground1Selected).toBe(
+            'var(--vscode-list-inactiveSelectionForeground, var(--vscode-editor-foreground))',
+        );
+        expect(theme.colorNeutralForeground2Selected).toBe(
+            'var(--vscode-list-inactiveSelectionForeground, var(--vscode-editor-foreground))',
+        );
+    });
+});

--- a/src/webviews/theme/themeGenerator.ts
+++ b/src/webviews/theme/themeGenerator.ts
@@ -71,12 +71,15 @@ export function getBrandTokensFromPalette(keyColor: string, options: Options = {
  * NOTE — neutral tokens still on the fixed Fluent ramp (candidates for a future
  * pass; see the "theme color coverage" tracking issue):
  *   - colorNeutralBackground3           (markdown cards, feedback dialog, query-plan blocks)
- *   - colorNeutralForeground3 / Foreground4
- *   - colorNeutralStroke1 / Stroke3 / StrokeAccessible
+ *   - colorNeutralForeground3 / Foreground4 / colorNeutralStroke1 / StrokeAccessible
+ *     — globally, that is; fluentOverrides.scss remaps them inside field controls only,
+ *     because these aliases also drive Switch indicators and Tab hover bars
+ *   - colorNeutralStroke3
  *   - colorSubtleBackgroundSelected
  *   - High-contrast theme kinds bypass this generator entirely and fall back to
  *     the static Teams themes (see getFluentUiTheme in state/ThemeContext.tsx),
- *     so none of the VS Code mappings apply there yet.
+ *     so none of these token mappings apply there. The CSS in fluentOverrides.scss
+ *     is not theme-kind aware and does apply — pending a visual pass.
  */
 const adaptiveNeutralSurfaces = {
     // Fluent's Card interaction recipe and the Card/Button disabled recipes use

--- a/src/webviews/theme/themeGenerator.ts
+++ b/src/webviews/theme/themeGenerator.ts
@@ -71,8 +71,7 @@ export function getBrandTokensFromPalette(keyColor: string, options: Options = {
  * NOTE — neutral tokens still on the fixed Fluent ramp (candidates for a future
  * pass; see the "theme color coverage" tracking issue):
  *   - colorNeutralBackground3           (markdown cards, feedback dialog, query-plan blocks)
- *   - colorNeutralBackground1Hover/Pressed/Selected
- *   - colorNeutralForeground3 / Foreground4 / ForegroundDisabled
+ *   - colorNeutralForeground3 / Foreground4
  *   - colorNeutralStroke1 / Stroke3 / StrokeAccessible
  *   - colorSubtleBackground* (toolbar/button hover fills)
  *   - High-contrast theme kinds bypass this generator entirely and fall back to
@@ -80,6 +79,23 @@ export function getBrandTokensFromPalette(keyColor: string, options: Options = {
  *     so none of the VS Code mappings apply there yet.
  */
 const adaptiveNeutralSurfaces = {
+    // Fluent's Card interaction recipe and the Card/Button disabled recipes use
+    // these Background1/Disabled aliases. The initial adaptive pass missed them,
+    // so Solarized, Red and other tinted themes fell back to Fluent's fixed gray
+    // ramps. Map them to VS Code interaction colors so those states now follow
+    // the active workbench theme as well.
+    colorNeutralBackground1Hover:
+        'var(--vscode-list-hoverBackground, var(--vscode-editorWidget-background, var(--vscode-editor-background)))',
+    colorNeutralBackground1Pressed:
+        'var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground, var(--vscode-editorWidget-background)))',
+    colorNeutralBackground1Selected:
+        'var(--vscode-list-inactiveSelectionBackground, var(--vscode-list-hoverBackground, var(--vscode-editorWidget-background)))',
+    colorNeutralBackgroundDisabled:
+        'var(--vscode-input-background, var(--vscode-editorWidget-background, var(--vscode-editor-background)))',
+    colorNeutralForegroundDisabled:
+        'var(--vscode-disabledForeground, var(--vscode-descriptionForeground, var(--vscode-foreground)))',
+    colorNeutralStrokeDisabled:
+        'var(--vscode-disabledForeground, var(--vscode-widget-border, var(--vscode-panel-border)))',
     // Secondary neutral surface: tab band + odd alternating rows. Prefer VS
     // Code's own alternating table-row color, then the side bar / editor-widget
     // backgrounds.

--- a/src/webviews/theme/themeGenerator.ts
+++ b/src/webviews/theme/themeGenerator.ts
@@ -90,7 +90,7 @@ const adaptiveNeutralSurfaces = {
     colorNeutralBackground1Hover:
         'var(--vscode-list-hoverBackground, var(--vscode-editorWidget-background, var(--vscode-editor-background)))',
     colorNeutralBackground1Pressed:
-        'var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground, var(--vscode-editorWidget-background)))',
+        'var(--vscode-toolbar-activeBackground, var(--vscode-list-hoverBackground, var(--vscode-editorWidget-background)))',
     colorNeutralBackground1Selected:
         'var(--vscode-list-inactiveSelectionBackground, var(--vscode-list-hoverBackground, var(--vscode-editorWidget-background)))',
     colorNeutralBackgroundDisabled:
@@ -115,7 +115,7 @@ const adaptiveNeutralSurfaces = {
     colorNeutralBackground2Hover:
         'var(--vscode-list-hoverBackground, var(--vscode-sideBar-background, var(--vscode-editorWidget-background)))',
     colorNeutralBackground2Pressed:
-        'var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground, var(--vscode-sideBar-background)))',
+        'var(--vscode-toolbar-activeBackground, var(--vscode-list-hoverBackground, var(--vscode-sideBar-background)))',
     colorNeutralBackground2Selected:
         'var(--vscode-list-inactiveSelectionBackground, var(--vscode-list-hoverBackground, var(--vscode-sideBar-background)))',
     // Subtle separators: tab-band bottom border, section rules.
@@ -161,7 +161,10 @@ export const generateAdaptiveLightTheme = (): Theme => {
             colorNeutralForeground1: 'var(--vscode-editor-foreground)',
             colorNeutralForeground1Hover: 'var(--vscode-editor-foreground)',
             colorNeutralForeground1Pressed: 'var(--vscode-editor-foreground)',
-            colorNeutralForeground1Selected: 'var(--vscode-editor-foreground)',
+            colorNeutralForeground1Selected:
+                'var(--vscode-list-inactiveSelectionForeground, var(--vscode-editor-foreground))',
+            colorNeutralForeground2Selected:
+                'var(--vscode-list-inactiveSelectionForeground, var(--vscode-editor-foreground))',
 
             colorNeutralBackground1: 'var(--vscode-editor-background)',
 
@@ -190,11 +193,13 @@ export const generateAdaptiveDarkTheme = (): Theme => {
             colorNeutralForeground1: 'var(--vscode-editor-foreground)',
             colorNeutralForeground1Hover: 'var(--vscode-editor-foreground)',
             colorNeutralForeground1Pressed: 'var(--vscode-editor-foreground)',
-            colorNeutralForeground1Selected: 'var(--vscode-editor-foreground)',
+            colorNeutralForeground1Selected:
+                'var(--vscode-list-inactiveSelectionForeground, var(--vscode-editor-foreground))',
             colorNeutralForeground2: 'var(--vscode-foreground)',
             colorNeutralForeground2Hover: 'var(--vscode-foreground)',
             colorNeutralForeground2Pressed: 'var(--vscode-foreground)',
-            colorNeutralForeground2Selected: 'var(--vscode-foreground)',
+            colorNeutralForeground2Selected:
+                'var(--vscode-list-inactiveSelectionForeground, var(--vscode-editor-foreground))',
 
             colorNeutralBackground1: 'var(--vscode-editor-background)',
 

--- a/src/webviews/theme/themeGenerator.ts
+++ b/src/webviews/theme/themeGenerator.ts
@@ -73,7 +73,7 @@ export function getBrandTokensFromPalette(keyColor: string, options: Options = {
  *   - colorNeutralBackground3           (markdown cards, feedback dialog, query-plan blocks)
  *   - colorNeutralForeground3 / Foreground4
  *   - colorNeutralStroke1 / Stroke3 / StrokeAccessible
- *   - colorSubtleBackground* (toolbar/button hover fills)
+ *   - colorSubtleBackgroundSelected
  *   - High-contrast theme kinds bypass this generator entirely and fall back to
  *     the static Teams themes (see getFluentUiTheme in state/ThemeContext.tsx),
  *     so none of the VS Code mappings apply there yet.
@@ -96,6 +96,14 @@ const adaptiveNeutralSurfaces = {
         'var(--vscode-disabledForeground, var(--vscode-descriptionForeground, var(--vscode-foreground)))',
     colorNeutralStrokeDisabled:
         'var(--vscode-disabledForeground, var(--vscode-widget-border, var(--vscode-panel-border)))',
+    // Fluent uses these subtle aliases across buttons, cards, tables, tabs,
+    // tags and trees. VS Code's toolbar tokens are the corresponding general
+    // action colors; list-specific surfaces can use list.* tokens locally.
+    // Falling back to list colors also covers themes that omit toolbar colors.
+    colorSubtleBackgroundHover:
+        'var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground, var(--vscode-editorWidget-background)))',
+    colorSubtleBackgroundPressed:
+        'var(--vscode-toolbar-activeBackground, var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground)))',
     // Secondary neutral surface: tab band + odd alternating rows. Prefer VS
     // Code's own alternating table-row color, then the side bar / editor-widget
     // backgrounds.


### PR DESCRIPTION
## Summary

- map shared Fluent surfaces, interactions, disabled states, fields, and progress indicators to semantic VS Code theme colors
- correct index-table zebra, hover, pressed, header, and badge styling across tinted themes
- isolate component-specific Fluent recipe overrides to avoid changing tabs, switches, avatars, and ratings
- add dependency contract coverage for the Fluent indeterminate ProgressBar gradient recipe

## Validation

- `npm run prettier-fix`
- `npm run lint`
- `npx jest --no-coverage` (181 suites, 2,946 tests)
- `npm run build`