### PR TITLE
Webview visual harness + Playwright suite (parked, extracted from #866)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,6 +40,12 @@ Before finishing work on a PR, agents **must** run the following steps in order:
 
 > ⚠️ **An agent must not finish or terminate until all five steps above have been run and pass successfully.** Skipping these steps leads to CI failures.
 
+## Webview visual checks
+
+`npm run webpack-dev-wv && npm run test:visual`. To inspect a state by hand or with browser tools, run
+`node test/webview-harness/serve.js` and open the printed URL with `?scenario=…&theme=…`. See
+`test/webview-harness/README.md`. Host-side behaviour is **not** exercised.
+
 ## Git Safety
 
 - **Never use `git add -f`** to force-add files. If `git add` refuses a file, it is likely in `.gitignore` for a reason (e.g., `docs/plan/`, `docs/analysis/`, build outputs). Do NOT override this with `-f`.

--- a/.gitignore
+++ b/.gitignore
@@ -266,6 +266,9 @@ paket-files/
 test-results.xml
 testWorkspace
 
+# Artifacts from the Playwright webview visual suite (npm run test:visual)
+testOutput/
+
 # Artifacts from ANTLR4 extension
 grammar/.antlr
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
       },
       "devDependencies": {
         "@eslint/js": "~9.39.1",
+        "@playwright/test": "^1.63.0-alpha-2026-07-29",
         "@pmmmwh/react-refresh-webpack-plugin": "~0.6.1",
         "@swc/cli": "~0.8.0",
         "@swc/core": "~1.15.18",
@@ -6689,6 +6690,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0-alpha-2026-07-29",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@playwright/test/-/test-1.63.0-alpha-2026-07-29.tgz",
+      "integrity": "sha1-cQEMBttMS9hs1vK397LqOJGzm6o=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0-alpha-2026-07-29"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -20921,6 +20938,52 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0-alpha-2026-07-29",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/playwright/-/playwright-1.63.0-alpha-2026-07-29.tgz",
+      "integrity": "sha1-5GWWhWTpwqgG1c1R42Vpb4hAmho=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0-alpha-2026-07-29"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0-alpha-2026-07-29",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/playwright-core/-/playwright-core-1.63.0-alpha-2026-07-29.tgz",
+      "integrity": "sha1-KyoFrBBF1nuMzpkQTOBUD89YtRo=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "test": "node -e \"console.log('\\n[vscode-documentdb] Integration tests are deprecated.\\nThe legacy vscode-test based integration test suite is no longer in use and will be replaced with a new framework in the 0.10.0 release.\\nThis command is now a no-op.\\n')\"",
     "prejesttest": "npm run build --workspaces --if-present",
     "jesttest": "jest",
+    "//test:visual": "Webview visual regression suite. Build the bundle first: npm run webpack-dev-wv. See test/webview-harness/README.md.",
+    "test:visual": "playwright test",
+    "test:visual:update": "playwright test --update-snapshots",
     "prewebpack-dev": "npm run build --workspaces --if-present",
     "webpack-dev": "rimraf ./dist && npm run webpack-dev-ext && npm run webpack-dev-wv",
     "prewebpack-prod": "npm run build --workspaces --if-present",
@@ -97,6 +100,7 @@
   },
   "devDependencies": {
     "@eslint/js": "~9.39.1",
+    "@playwright/test": "^1.63.0-alpha-2026-07-29",
     "@pmmmwh/react-refresh-webpack-plugin": "~0.6.1",
     "@swc/cli": "~0.8.0",
     "@swc/core": "~1.15.18",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Playwright config for the webview visual suite (`npm run test:visual`).
+ *
+ * The suite drives the real built webview bundle in a browser against a stubbed extension host —
+ * see `test/webview-harness/README.md`. It is separate from Jest, which owns `src/**\/*.test.ts`
+ * and never sees these specs.
+ *
+ * `webServer` starts the harness server itself, so a run is a single command. It does NOT build the
+ * bundle: run `npm run webpack-dev-wv` first (the server warns when `dist/views.js` is missing).
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 18099;
+
+export default defineConfig({
+    testDir: './test/webview-harness',
+    outputDir: './testOutput/playwright',
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 1 : 0,
+    reporter: process.env.CI
+        ? [['github'], ['list']]
+        : // The html report is where the captured state images are reviewed: `npx playwright
+          // show-report testOutput/playwright-report`.
+          [['list'], ['html', { open: 'never', outputFolder: 'testOutput/playwright-report' }]],
+    use: {
+        baseURL: `http://127.0.0.1:${PORT}`,
+        // The panel is a tall single column; this is roughly an editor group on a laptop.
+        viewport: { width: 1100, height: 900 },
+        trace: 'retain-on-failure',
+        screenshot: 'only-on-failure',
+    },
+    projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+    webServer: {
+        command: `node test/webview-harness/serve.js ${PORT}`,
+        url: `http://127.0.0.1:${PORT}/quickstart-harness.html`,
+        reuseExistingServer: !process.env.CI,
+        stdout: 'pipe',
+        timeout: 30_000,
+    },
+});

--- a/test/webview-harness/README.md
+++ b/test/webview-harness/README.md
@@ -1,0 +1,44 @@
+# Webview visual harness
+
+Renders a webview in a plain browser so its states can be looked at without running the extension,
+starting Docker, or reaching the states by hand.
+
+The harness stands in for the extension host: it stubs `acquireVsCodeApi()` and answers the tRPC
+wire protocol (`{id, op:{type, path, input}}` in, `{id, result}` back over the window message bus)
+with canned data selected by a query parameter. Nothing talks to Docker or to a database.
+
+## Running it
+
+```sh
+npm run webpack-dev-wv            # build dist/views.js
+node test/webview-harness/serve.js
+```
+
+Then open the printed URL. The server serves `dist/` as the site root (the harness imports
+`./views.js` as an ES module, which needs an http origin) and serves its own `*.html` from this
+folder.
+
+## Local Quick Start (`quickstart-harness.html`)
+
+| Parameter  | Values                                                                                                                                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `scenario` | `introduction`, `configure`, `provisioning`, `success`, `success-relocated-port`, `failed-port-in-use`, `failed-timeout`, `docker-missing-windows`, `docker-missing-mac`, `docker-missing-linux` |
+| `theme`    | `dark` (default), `light`                                                                                                                                                                        |
+
+Example: `http://127.0.0.1:18099/quickstart-harness.html?scenario=docker-missing-windows&theme=light`
+
+The harness advances the wizard the way a user would — by clicking the footer's primary action —
+because the phase is component state, not a prop.
+
+Actions that would leave the webview (`openUrl`, `copyConnectionString`, `openConnection`) are
+logged to the console instead of being performed, so the destination can be checked. That is how the
+per-platform Docker install link is verified: open a `docker-missing-*` scenario, click the install
+CTA, and read the logged URL.
+
+## Caveats
+
+- The `--vscode-*` theme variables here are a representative slice of Dark Modern / Light Modern,
+  not the live values from a VS Code window. Colors are close, not pixel-exact.
+- Relative times render oddly because the canned readiness uses `checkedAtMs: 1`.
+- Host-side behavior (the Docker probes, provisioning, storage) is not exercised at all — this shows
+  what the panel renders for a given host response, nothing more.

--- a/test/webview-harness/README.md
+++ b/test/webview-harness/README.md
@@ -1,16 +1,40 @@
 # Webview visual harness
 
-Renders a webview in a plain browser so its states can be looked at without running the extension,
-starting Docker, or reaching the states by hand.
+Renders a webview in a plain browser so its states can be checked — by a human or by Playwright —
+without running the extension, starting Docker, or reaching each state by hand.
 
 The harness stands in for the extension host: it stubs `acquireVsCodeApi()` and answers the tRPC
 wire protocol (`{id, op:{type, path, input}}` in, `{id, result}` back over the window message bus)
 with canned data selected by a query parameter. Nothing talks to Docker or to a database.
 
-## Running it
+## Automated: `npm run test:visual`
 
 ```sh
-npm run webpack-dev-wv            # build dist/views.js
+npm run webpack-dev-wv            # build dist/views.js — the suite does NOT do this for you
+npm run test:visual               # Playwright; starts the harness server itself
+npx playwright show-report testOutput/playwright-report
+```
+
+`localQuickStart.spec.ts` pins the defects found in the `0.10.0-bug-bash-1` bug bash that have a
+webview surface, so a regression fails the build instead of waiting for the next bash to rediscover
+it: the per-platform Docker install link and restart guidance (#855, #856), the reworked success
+screen (#857), a Docker-assigned host port reaching the connection details (#854), and the localized
+port error (#852). The two defects with no webview surface are pinned in Jest instead — #851 in
+`src/commands/localQuickStart/contributions.test.ts`, #858 in
+`src/commands/newLocalConnection/localEndpoint.test.ts`.
+
+Each state is also captured to `testOutput/screenshots/` and attached to the Playwright report.
+
+**These captures are artifacts, not baselines.** Text here is rendered by the OS, so a pixel
+baseline recorded on one contributor's machine fails on another's for reasons that have nothing to
+do with the UI. The behavioral assertions are the gate; the images are for a human to look at. If
+runs are ever standardized on a single container image, they can become `toHaveScreenshot`
+baselines.
+
+## Manual
+
+```sh
+npm run webpack-dev-wv
 node test/webview-harness/serve.js
 ```
 
@@ -28,12 +52,20 @@ folder.
 Example: `http://127.0.0.1:18099/quickstart-harness.html?scenario=docker-missing-windows&theme=light`
 
 The harness advances the wizard the way a user would — by clicking the footer's primary action —
-because the phase is component state, not a prop.
+because the phase is component state, not a prop. It sets `window.__harnessReady` once the requested
+phase is reached, so tests wait on a signal rather than a sleep.
 
 Actions that would leave the webview (`openUrl`, `copyConnectionString`, `openConnection`) are
-logged to the console instead of being performed, so the destination can be checked. That is how the
-per-platform Docker install link is verified: open a `docker-missing-*` scenario, click the install
-CTA, and read the logged URL.
+recorded on `window.__harnessCalls` and logged to the console instead of being performed. That is how
+the per-platform Docker install link is verified: open a `docker-missing-*` scenario, click the
+install CTA, and read back the URL it would have opened.
+
+### Adding a scenario
+
+Add an entry to `READINESS_BY_SCENARIO` (what the Docker check returns) and/or `STAGE_STREAMS` (the
+provisioning events). A stream is closed only when its last event is terminal — a stream that ends
+without one makes the webview fall back to the settings page, which is correct behavior and would
+silently undo a mid-provision scenario.
 
 ## Caveats
 

--- a/test/webview-harness/README.md
+++ b/test/webview-harness/README.md
@@ -68,6 +68,9 @@ silently undo a mid-provision scenario.
 
 ## Caveats
 
+- Both the harness and `npm run watch:views` read `dist/views.js` from disk. `watch:views` is
+  `webpack serve`, which builds in memory by default, so the config sets
+  `devServer.devMiddleware.writeToDisk`. Without it the harness silently renders a stale bundle.
 - The `--vscode-*` theme variables here are a representative slice of Dark Modern / Light Modern,
   not the live values from a VS Code window. Colors are close, not pixel-exact.
 - Relative times render oddly because the canned readiness uses `checkedAtMs: 1`.

--- a/test/webview-harness/README.md
+++ b/test/webview-harness/README.md
@@ -18,9 +18,8 @@ npx playwright show-report testOutput/playwright-report
 `localQuickStart.spec.ts` pins the defects found in the `0.10.0-bug-bash-1` bug bash that have a
 webview surface, so a regression fails the build instead of waiting for the next bash to rediscover
 it: the per-platform Docker install link and restart guidance (#855, #856), the reworked success
-screen (#857), a Docker-assigned host port reaching the connection details (#854), and the localized
-port error (#852). The two defects with no webview surface are pinned in Jest instead — #851 in
-`src/commands/localQuickStart/contributions.test.ts`, #858 in
+screen (#857), and the localized port error (#852). The two defects with no webview surface are
+pinned in Jest instead — #851 in `src/commands/localQuickStart/contributions.test.ts`, #858 in
 `src/commands/newLocalConnection/localEndpoint.test.ts`.
 
 Each state is also captured to `testOutput/screenshots/` and attached to the Playwright report.
@@ -46,7 +45,7 @@ folder.
 
 | Parameter  | Values                                                                                                                                                                                           |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `scenario` | `introduction`, `configure`, `provisioning`, `success`, `success-relocated-port`, `failed-port-in-use`, `failed-timeout`, `docker-missing-windows`, `docker-missing-mac`, `docker-missing-linux` |
+| `scenario` | `introduction`, `configure`, `provisioning`, `success`, `failed-port-in-use`, `failed-timeout`, `docker-missing-windows`, `docker-missing-mac`, `docker-missing-linux` |
 | `theme`    | `dark` (default), `light`                                                                                                                                                                        |
 
 Example: `http://127.0.0.1:18099/quickstart-harness.html?scenario=docker-missing-windows&theme=light`

--- a/test/webview-harness/localQuickStart.spec.ts
+++ b/test/webview-harness/localQuickStart.spec.ts
@@ -12,7 +12,7 @@
  *
  *   npm run webpack-dev-wv && npm run test:visual
  *
- * Issues covered here are the ones with a webview surface — #852, #854, #855, #856, #857. The two
+ * Issues covered here are the ones with a webview surface — #852, #855, #856, #857. The two
  * without one are covered by Jest instead: #851 in `contributions.test.ts` (package.json menu
  * gating) and #858 in `src/commands/newLocalConnection/localEndpoint.test.ts`.
  */
@@ -39,7 +39,6 @@ type Scenario =
     | 'configure'
     | 'provisioning'
     | 'success'
-    | 'success-relocated-port'
     | 'failed-port-in-use'
     | 'failed-timeout'
     | 'docker-missing-windows'
@@ -202,18 +201,6 @@ test.describe('Local Quick Start — success screen', () => {
         await page.getByRole('button', { name: 'Open Connection' }).click();
 
         await expect.poll(() => callsTo(page, 'localQuickStart.openConnection')).toHaveLength(1);
-    });
-
-    /**
-     * #854: when the preferred port is taken, Docker now assigns one at bind time. The port the
-     * user is told to connect on must be the one Docker actually bound, not the canonical default.
-     */
-    test('a Docker-assigned host port reaches the connection details (#854)', async ({ page }) => {
-        await openScenario(page, 'success-relocated-port');
-
-        await expect(page.getByText('DocumentDB Local is running on localhost:61146.')).toBeVisible();
-        await expect(page.getByText('(localhost:61146)')).toBeVisible();
-        await expect(page.getByText('10260')).toHaveCount(0);
     });
 
     test('captures the success screen in both themes', async ({ page }, testInfo) => {

--- a/test/webview-harness/localQuickStart.spec.ts
+++ b/test/webview-harness/localQuickStart.spec.ts
@@ -173,7 +173,7 @@ test.describe('Local Quick Start — success screen', () => {
 
         await expect(page.getByText('This instance is already in the Connections view')).toBeVisible();
         await expect(page.getByText('You do not need to create a connection for it')).toBeVisible();
-        await expect(page.getByText('The instance is already connected in the Connections view')).toBeVisible();
+        await expect(page.getByText('The connection already exists in the Connections view')).toBeVisible();
     });
 
     /**
@@ -188,6 +188,20 @@ test.describe('Local Quick Start — success screen', () => {
         await page.getByRole('button', { name: 'Copy connection string' }).click();
 
         await expect.poll(() => callsTo(page, 'localQuickStart.copyConnectionString')).toHaveLength(1);
+    });
+
+    /**
+     * The primary action has to reach the host. It used to land on a handler that only ran
+     * `connectionsView.focus`, which is invisible when that view is already active — the button
+     * looked dead. What the host does with the call is asserted in
+     * `src/tree/connections-view/LocalQuickStart/revealQuickStartInstance.test.ts`.
+     */
+    test('Open Connection asks the host to open the instance', async ({ page }) => {
+        await openScenario(page, 'success');
+
+        await page.getByRole('button', { name: 'Open Connection' }).click();
+
+        await expect.poll(() => callsTo(page, 'localQuickStart.openConnection')).toHaveLength(1);
     });
 
     /**

--- a/test/webview-harness/localQuickStart.spec.ts
+++ b/test/webview-harness/localQuickStart.spec.ts
@@ -1,0 +1,273 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Visual + behavioral regression suite for the Local Quick Start webview.
+ *
+ * Every test here pins a defect found in the `0.10.0-bug-bash-1` bug bash, so a regression fails
+ * the build instead of waiting for the next bash to rediscover it. The suite drives the REAL built
+ * `dist/views.js` in a browser; only the extension host is stubbed (see README.md).
+ *
+ *   npm run webpack-dev-wv && npm run test:visual
+ *
+ * Issues covered here are the ones with a webview surface — #852, #854, #855, #856, #857. The two
+ * without one are covered by Jest instead: #851 in `contributions.test.ts` (package.json menu
+ * gating) and #858 in `src/commands/newLocalConnection/localEndpoint.test.ts`.
+ */
+
+import { expect, type Page, test, type TestInfo } from '@playwright/test';
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+/** Where the reviewable state images land, in addition to the Playwright report. */
+const SCREENSHOT_DIR = path.join(__dirname, '..', '..', 'testOutput', 'screenshots');
+
+type HarnessCall = { readonly path: string; readonly input: unknown };
+
+declare global {
+    interface Window {
+        __harnessCalls: HarnessCall[];
+        __harnessReady: boolean;
+    }
+}
+
+type Scenario =
+    | 'introduction'
+    | 'configure'
+    | 'provisioning'
+    | 'success'
+    | 'success-relocated-port'
+    | 'failed-port-in-use'
+    | 'failed-timeout'
+    | 'docker-missing-windows'
+    | 'docker-missing-mac'
+    | 'docker-missing-linux';
+
+/**
+ * Open a scenario and wait until the wizard has settled on the phase it asks for. The harness
+ * advances the wizard by clicking, so the ready flag — not a sleep — is the signal.
+ */
+async function openScenario(page: Page, scenario: Scenario, theme: 'dark' | 'light' = 'dark'): Promise<void> {
+    const errors: string[] = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+    await page.goto(`/quickstart-harness.html?scenario=${scenario}&theme=${theme}`);
+    await page.waitForFunction(() => window.__harnessReady === true);
+    // A render that threw would leave assertions passing against a half-mounted tree.
+    expect(errors, `uncaught page errors in scenario "${scenario}"`).toEqual([]);
+}
+
+/** Host calls the webview made, in order. */
+function callsTo(page: Page, path: string): Promise<HarnessCall[]> {
+    return page.evaluate((wanted) => window.__harnessCalls.filter((call) => call.path === wanted), path);
+}
+
+/**
+ * Capture the state as a report artifact rather than diffing it against a committed baseline.
+ *
+ * Pixel baselines are deliberately NOT used here: text in this panel is rendered by the OS, so a
+ * baseline recorded on one contributor's machine fails on another's for reasons that have nothing
+ * to do with the UI. The behavioral assertions above are the gate; these images are for a human to
+ * look at (`npx playwright show-report`, or the files under `testOutput/screenshots/`). If the team
+ * ever standardizes runs on one container image, these can become `toHaveScreenshot` baselines.
+ */
+async function captureState(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+    const screenshot = await page.screenshot({ fullPage: true, animations: 'disabled' });
+    await testInfo.attach(name, { body: screenshot, contentType: 'image/png' });
+    await fs.mkdir(SCREENSHOT_DIR, { recursive: true });
+    await fs.writeFile(path.join(SCREENSHOT_DIR, `${name}.png`), screenshot);
+}
+
+test.describe('Local Quick Start — Docker setup guidance', () => {
+    /**
+     * #856: the install CTA hardcoded the Docker Engine URL — a Linux-only install — and ignored
+     * the per-platform guide the host resolved. Assert the label AND the URL it would open, since
+     * the label alone was never the broken part.
+     */
+    test('Windows sends the user to Docker Desktop, not Docker Engine (#856)', async ({ page }) => {
+        await openScenario(page, 'docker-missing-windows');
+
+        const cta = page.getByRole('button', { name: 'Get Docker Desktop for Windows' });
+        await expect(cta).toBeVisible();
+        await cta.click();
+
+        await expect
+            .poll(() => callsTo(page, 'common.openUrl').then((calls) => calls.at(-1)?.input))
+            .toEqual({ url: 'https://docs.docker.com/desktop/setup/install/windows-install/' });
+    });
+
+    test('macOS sends the user to Docker Desktop for Mac (#856)', async ({ page }) => {
+        await openScenario(page, 'docker-missing-mac');
+
+        await page.getByRole('button', { name: 'Get Docker Desktop for Mac' }).click();
+
+        await expect
+            .poll(() => callsTo(page, 'common.openUrl').then((calls) => calls.at(-1)?.input))
+            .toEqual({ url: 'https://docs.docker.com/desktop/setup/install/mac-install/' });
+    });
+
+    /** Linux must NOT be redirected to Desktop — the Engine guide is correct there. */
+    test('Linux keeps the Docker Engine install guide (#856)', async ({ page }) => {
+        await openScenario(page, 'docker-missing-linux');
+
+        await expect(page.getByRole('button', { name: 'Get Docker Desktop' })).toHaveCount(0);
+        await page.getByRole('button', { name: 'Open Docker install guide' }).click();
+
+        await expect
+            .poll(() => callsTo(page, 'common.openUrl').then((calls) => calls.at(-1)?.input))
+            .toEqual({ url: 'https://docs.docker.com/engine/install/' });
+    });
+
+    /**
+     * #855: after installing Docker Desktop, a VS Code that was already running keeps its old PATH,
+     * so Docker stays undetected and the setup looks broken. The guidance has to say to restart —
+     * and to say that reloading the window is not enough, which is the wrong thing users try first.
+     */
+    test('Windows guidance asks for a VS Code restart and rules out a window reload (#855)', async ({ page }) => {
+        await openScenario(page, 'docker-missing-windows');
+
+        const guidance = page.getByText('Install Docker Desktop, then restart VS Code');
+        await expect(guidance).toBeVisible();
+        await expect(guidance).toContainText('reloading the window is not enough');
+    });
+
+    test('macOS guidance asks for a VS Code restart (#855)', async ({ page }) => {
+        await openScenario(page, 'docker-missing-mac');
+
+        await expect(page.getByText('Install Docker Desktop, then restart VS Code')).toBeVisible();
+    });
+
+    /** Linux guidance is unchanged — no restart claim that does not apply there. */
+    test('Linux guidance makes no VS Code restart claim (#855)', async ({ page }) => {
+        await openScenario(page, 'docker-missing-linux');
+
+        await expect(page.getByText('Install Docker Engine or Docker Desktop')).toBeVisible();
+        await expect(page.getByText('restart VS Code')).toHaveCount(0);
+    });
+
+    test('captures the Windows Docker-missing screen', async ({ page }, testInfo) => {
+        await openScenario(page, 'docker-missing-windows');
+        await captureState(page, testInfo, 'docker-missing-windows-dark');
+    });
+});
+
+test.describe('Local Quick Start — success screen', () => {
+    /**
+     * #857: "Copy Connection String" sat beside "Open Connection" in the footer and read as the
+     * next REQUIRED step. A bug-bash user followed it and created the connection by hand, ending
+     * up with a duplicate. The footer must no longer offer it.
+     */
+    test('the footer no longer offers Copy Connection String (#857)', async ({ page }) => {
+        await openScenario(page, 'success');
+
+        const footer = page.locator('main > div').last();
+        await expect(footer.getByRole('button', { name: 'Open Connection' })).toBeVisible();
+        await expect(footer.getByRole('button', { name: 'Close' })).toBeVisible();
+        await expect(footer.getByRole('button', { name: /copy/i })).toHaveCount(0);
+    });
+
+    test('the success message says the connection already exists (#857)', async ({ page }) => {
+        await openScenario(page, 'success');
+
+        await expect(page.getByText('This instance is already in the Connections view')).toBeVisible();
+        await expect(page.getByText('You do not need to create a connection for it')).toBeVisible();
+        await expect(page.getByText('The instance is already connected in the Connections view')).toBeVisible();
+    });
+
+    /**
+     * The copy action still EXISTS — it is the only way to reach the instance from mongosh or an
+     * app — but as an optional step, described as being for clients outside VS Code.
+     */
+    test('copy survives as an optional inline action, and still works (#857)', async ({ page }) => {
+        await openScenario(page, 'success');
+
+        await expect(page.getByText('Optional — to reach this instance from a tool outside VS Code')).toBeVisible();
+
+        await page.getByRole('button', { name: 'Copy connection string' }).click();
+
+        await expect.poll(() => callsTo(page, 'localQuickStart.copyConnectionString')).toHaveLength(1);
+    });
+
+    /**
+     * #854: when the preferred port is taken, Docker now assigns one at bind time. The port the
+     * user is told to connect on must be the one Docker actually bound, not the canonical default.
+     */
+    test('a Docker-assigned host port reaches the connection details (#854)', async ({ page }) => {
+        await openScenario(page, 'success-relocated-port');
+
+        await expect(page.getByText('DocumentDB Local is running on localhost:61146.')).toBeVisible();
+        await expect(page.getByText('(localhost:61146)')).toBeVisible();
+        await expect(page.getByText('10260')).toHaveCount(0);
+    });
+
+    test('captures the success screen in both themes', async ({ page }, testInfo) => {
+        await openScenario(page, 'success');
+        await captureState(page, testInfo, 'success-dark');
+
+        await openScenario(page, 'success', 'light');
+        await captureState(page, testInfo, 'success-light');
+    });
+});
+
+test.describe('Local Quick Start — failure screens', () => {
+    /**
+     * #852: this message was a raw template literal that never passed through `l10n.t()`. The
+     * extraction check lives in Jest; what matters here is that the string still reaches the user
+     * intact, with the port interpolated, after being rewritten.
+     */
+    test('an explicit port conflict is reported with the port in it (#852)', async ({ page }) => {
+        await openScenario(page, 'failed-port-in-use');
+
+        const message = 'Port 12345 is already in use. Choose a different port or free it, then retry.';
+        await expect(page.locator('.fui-MessageBarBody').getByText(message)).toBeVisible();
+        // The same sentence must also reach screen readers, not just the message bar.
+        await expect(page.locator('[aria-live="assertive"]').filter({ hasText: message })).toHaveCount(1);
+    });
+
+    /** The retry affordance has to survive the rewrite, or the message is a dead end. */
+    test('a failed setup still offers Retry (#852)', async ({ page }) => {
+        await openScenario(page, 'failed-port-in-use');
+
+        await expect(page.getByRole('button', { name: 'Retry setup' })).toBeVisible();
+    });
+
+    test('a readiness timeout keeps the Wait longer / Start over choice', async ({ page }) => {
+        await openScenario(page, 'failed-timeout');
+
+        await expect(page.getByRole('button', { name: 'Wait longer' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Start over' })).toBeVisible();
+    });
+
+    test('captures the port-conflict screen', async ({ page }, testInfo) => {
+        await openScenario(page, 'failed-port-in-use');
+        await captureState(page, testInfo, 'failed-port-in-use-dark');
+    });
+});
+
+test.describe('Local Quick Start — wizard walkthrough', () => {
+    test('renders the introduction step', async ({ page }, testInfo) => {
+        await openScenario(page, 'introduction');
+
+        await expect(page.getByRole('heading', { name: 'Develop and test locally' })).toBeVisible();
+        await captureState(page, testInfo, 'introduction-dark');
+    });
+
+    test('renders the configure step', async ({ page }, testInfo) => {
+        await openScenario(page, 'configure');
+
+        await expect(page.getByRole('heading', { name: 'Configure setup' })).toBeVisible();
+        await captureState(page, testInfo, 'configure-dark');
+    });
+
+    test('renders the provisioning step with a working Cancel', async ({ page }, testInfo) => {
+        await openScenario(page, 'provisioning');
+
+        // Mid-provision the wizard must stay put and stay cancellable; it used to be possible to
+        // fall back to the settings page when a stream ended without a terminal event.
+        await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Setting up…' })).toBeDisabled();
+        await captureState(page, testInfo, 'provisioning-dark');
+    });
+});

--- a/test/webview-harness/quickstart-harness.html
+++ b/test/webview-harness/quickstart-harness.html
@@ -234,19 +234,6 @@
                         boundPort: 10260,
                     },
                 ],
-                'success-relocated-port': [
-                    { stage: 'checking', status: 'done' },
-                    { stage: 'pulling', status: 'done' },
-                    { stage: 'creating', status: 'done' },
-                    { stage: 'starting', status: 'done' },
-                    { stage: 'waiting', status: 'done' },
-                    {
-                        stage: 'done',
-                        status: 'done',
-                        message: 'DocumentDB Local is running on localhost:61146.',
-                        boundPort: 61146,
-                    },
-                ],
                 'failed-port-in-use': [
                     {
                         stage: 'checking',

--- a/test/webview-harness/quickstart-harness.html
+++ b/test/webview-harness/quickstart-harness.html
@@ -1,0 +1,358 @@
+<!doctype html>
+<html lang="en" class="theme-dark">
+    <head>
+        <meta charset="utf-8" />
+        <title>Local Quick Start — visual harness</title>
+        <style>
+            /* A representative slice of VS Code's Dark Modern / Light Modern token set. The webview's
+               adaptive theme reads these `--vscode-*` variables, so without them Fluent renders with
+               empty colors and the screenshots would not reflect the real panel. */
+            :root {
+                --vscode-font-family: -apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI', system-ui, sans-serif;
+                --vscode-font-size: 13px;
+            }
+            html.theme-dark {
+                --vscode-editor-background: #1f1f1f;
+                --vscode-editor-foreground: #cccccc;
+                --vscode-foreground: #cccccc;
+                --vscode-descriptionForeground: #9d9d9d;
+                --vscode-disabledForeground: #6c6c6c;
+                --vscode-editorWidget-background: #202020;
+                --vscode-editorWidget-border: #454545;
+                --vscode-widget-border: #313131;
+                --vscode-panel-border: #2b2b2b;
+                --vscode-sideBar-background: #181818;
+                --vscode-input-background: #313131;
+                --vscode-input-foreground: #cccccc;
+                --vscode-input-border: #3c3c3c;
+                --vscode-button-background: #0078d4;
+                --vscode-button-foreground: #ffffff;
+                --vscode-button-hoverBackground: #026ec1;
+                --vscode-button-secondaryBackground: #313131;
+                --vscode-button-secondaryForeground: #cccccc;
+                --vscode-list-hoverBackground: #2a2d2e;
+                --vscode-list-activeSelectionBackground: #04395e;
+                --vscode-list-inactiveSelectionBackground: #37373d;
+                --vscode-list-inactiveSelectionForeground: #cccccc;
+                --vscode-list-errorForeground: #f88070;
+                --vscode-list-warningForeground: #cca700;
+                --vscode-toolbar-hoverBackground: #383b3d;
+                --vscode-toolbar-activeBackground: #4c4f51;
+                --vscode-tree-tableOddRowsBackground: #1f1f1f;
+                --vscode-textLink-foreground: #4daafc;
+                --vscode-textLink-activeForeground: #4daafc;
+                --vscode-focusBorder: #0078d4;
+                --vscode-errorForeground: #f85149;
+                --vscode-charts-green: #89d185;
+                --vscode-charts-red: #f14c4c;
+                --vscode-charts-yellow: #cca700;
+                --vscode-charts-blue: #3794ff;
+                --vscode-inputValidation-errorBackground: #5a1d1d;
+                --vscode-inputValidation-errorBorder: #be1100;
+                --vscode-textCodeBlock-background: #2b2b2b;
+                color-scheme: dark;
+            }
+            html.theme-light {
+                --vscode-editor-background: #ffffff;
+                --vscode-editor-foreground: #3b3b3b;
+                --vscode-foreground: #3b3b3b;
+                --vscode-descriptionForeground: #5f5f5f;
+                --vscode-disabledForeground: #a0a0a0;
+                --vscode-editorWidget-background: #f8f8f8;
+                --vscode-editorWidget-border: #c8c8c8;
+                --vscode-widget-border: #e5e5e5;
+                --vscode-panel-border: #e5e5e5;
+                --vscode-sideBar-background: #f8f8f8;
+                --vscode-input-background: #ffffff;
+                --vscode-input-foreground: #3b3b3b;
+                --vscode-input-border: #cecece;
+                --vscode-button-background: #005fb8;
+                --vscode-button-foreground: #ffffff;
+                --vscode-button-hoverBackground: #0258a8;
+                --vscode-button-secondaryBackground: #e5e5e5;
+                --vscode-button-secondaryForeground: #3b3b3b;
+                --vscode-list-hoverBackground: #f2f2f2;
+                --vscode-list-activeSelectionBackground: #e4e6f1;
+                --vscode-list-inactiveSelectionBackground: #e4e6f1;
+                --vscode-list-inactiveSelectionForeground: #3b3b3b;
+                --vscode-list-errorForeground: #b01011;
+                --vscode-list-warningForeground: #855f00;
+                --vscode-toolbar-hoverBackground: #dddddd;
+                --vscode-toolbar-activeBackground: #cccccc;
+                --vscode-tree-tableOddRowsBackground: #f8f8f8;
+                --vscode-textLink-foreground: #005fb8;
+                --vscode-textLink-activeForeground: #005fb8;
+                --vscode-focusBorder: #005fb8;
+                --vscode-errorForeground: #f85149;
+                --vscode-charts-green: #388a34;
+                --vscode-charts-red: #a1260d;
+                --vscode-charts-yellow: #855f00;
+                --vscode-charts-blue: #1a85ff;
+                --vscode-inputValidation-errorBackground: #f2dede;
+                --vscode-inputValidation-errorBorder: #be1100;
+                --vscode-textCodeBlock-background: #f2f2f2;
+                color-scheme: light;
+            }
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+                height: 100%;
+                background: var(--vscode-editor-background);
+                color: var(--vscode-editor-foreground);
+                font-family: var(--vscode-font-family);
+                font-size: var(--vscode-font-size);
+            }
+            /* The real panel gives the webview the full viewport; mirror that. */
+            #root {
+                height: 100vh;
+            }
+            #harness-banner {
+                position: fixed;
+                right: 8px;
+                bottom: 8px;
+                z-index: 9999;
+                padding: 2px 8px;
+                border-radius: 4px;
+                font: 11px/1.6 var(--vscode-font-family);
+                background: var(--vscode-editorWidget-background);
+                border: 1px solid var(--vscode-editorWidget-border);
+                color: var(--vscode-descriptionForeground);
+                opacity: 0.85;
+            }
+        </style>
+    </head>
+    <body data-vscode-theme-kind="vscode-dark">
+        <div id="root"></div>
+        <div id="harness-banner"></div>
+        <script type="module">
+            /*
+             * Standalone visual harness for the Local Quick Start webview.
+             *
+             * It stands in for the extension host: `acquireVsCodeApi()` is stubbed, and the tRPC
+             * wire protocol (`{id, op:{type,path,input}}` in, `{id, result}` back over the window
+             * message bus) is answered with canned data chosen by `?scenario=`. Nothing here talks
+             * to Docker — the point is to see what the panel actually renders in each state.
+             */
+            const params = new URLSearchParams(location.search);
+            const scenario = params.get('scenario') ?? 'introduction';
+            const themeKind = params.get('theme') === 'light' ? 'vscode-light' : 'vscode-dark';
+            // `themeGenerator` samples the `--vscode-*` variables off documentElement, while the
+            // theme KIND is read off body — so the palette lives on <html> and the kind on <body>.
+            document.documentElement.className = themeKind === 'vscode-light' ? 'theme-light' : 'theme-dark';
+            document.body.setAttribute('data-vscode-theme-kind', themeKind);
+            document.getElementById('harness-banner').textContent = `harness · ${scenario} · ${themeKind}`;
+
+            const READY_READINESS = {
+                outcome: 'ready',
+                environment: 'windows',
+                endpointKind: 'namedPipe',
+                endpointSource: 'platformDefault',
+                provider: 'dockerDesktop',
+                providerEvidence: 'liveDaemon',
+                executionTarget: 'local',
+                checkedAtMs: 1,
+                cliInstalled: true,
+                cliVersion: '28.1.1',
+                osType: 'linux',
+                daemonArchitecture: 'x86_64',
+                arch: 'x64',
+                platformSupported: true,
+                canContinueAnyway: false,
+                daemonReachable: true,
+            };
+
+            /** Windows with no Docker CLI — the state #855 and #856 are about. */
+            const CLI_MISSING_WINDOWS = {
+                outcome: 'diagnosed',
+                environment: 'windows',
+                endpointKind: 'namedPipe',
+                endpointSource: 'platformDefault',
+                provider: 'unknown',
+                providerEvidence: 'none',
+                executionTarget: 'local',
+                failureKind: 'cliMissing',
+                checkedAtMs: 1,
+                cliInstalled: false,
+                arch: 'x64',
+                platformSupported: true,
+                canContinueAnyway: false,
+                daemonReachable: false,
+            };
+
+            const CLI_MISSING_LINUX = { ...CLI_MISSING_WINDOWS, environment: 'linux', endpointKind: 'unixSocket' };
+            const CLI_MISSING_MAC = { ...CLI_MISSING_WINDOWS, environment: 'macos', endpointKind: 'unixSocket' };
+
+            const READINESS_BY_SCENARIO = {
+                'docker-missing-windows': CLI_MISSING_WINDOWS,
+                'docker-missing-mac': CLI_MISSING_MAC,
+                'docker-missing-linux': CLI_MISSING_LINUX,
+            };
+
+            const readiness = READINESS_BY_SCENARIO[scenario] ?? READY_READINESS;
+
+            const dockerStatus = {
+                readiness,
+                status: { state: 'NotInstalled' },
+                busy: false,
+                willReuse: false,
+            };
+
+            /**
+             * Stage streams per scenario. `startQuickStart` is a tRPC subscription, so each event is
+             * delivered as its own response message with the same operation id, and the stream is
+             * closed with `complete`.
+             */
+            const DOCKER_MISSING_STREAM = [
+                {
+                    stage: 'checking',
+                    status: 'error',
+                    message: 'Docker CLI was not found on your PATH. Install Docker and retry.',
+                    error: 'Docker CLI was not found on your PATH. Install Docker and retry.',
+                    dockerReadiness: readiness,
+                },
+            ];
+
+            const STAGE_STREAMS = {
+                'docker-missing-windows': DOCKER_MISSING_STREAM,
+                'docker-missing-mac': DOCKER_MISSING_STREAM,
+                'docker-missing-linux': DOCKER_MISSING_STREAM,
+                provisioning: [
+                    { stage: 'checking', status: 'done' },
+                    { stage: 'pulling', status: 'active' },
+                ],
+                success: [
+                    { stage: 'checking', status: 'done' },
+                    { stage: 'pulling', status: 'done' },
+                    { stage: 'creating', status: 'done' },
+                    { stage: 'starting', status: 'done' },
+                    { stage: 'waiting', status: 'done' },
+                    {
+                        stage: 'done',
+                        status: 'done',
+                        message: 'DocumentDB Local is running on localhost:10260.',
+                        boundPort: 10260,
+                    },
+                ],
+                'success-relocated-port': [
+                    { stage: 'checking', status: 'done' },
+                    { stage: 'pulling', status: 'done' },
+                    { stage: 'creating', status: 'done' },
+                    { stage: 'starting', status: 'done' },
+                    { stage: 'waiting', status: 'done' },
+                    {
+                        stage: 'done',
+                        status: 'done',
+                        message: 'DocumentDB Local is running on localhost:61146.',
+                        boundPort: 61146,
+                    },
+                ],
+                'failed-port-in-use': [
+                    {
+                        stage: 'checking',
+                        status: 'error',
+                        message: 'Port 12345 is already in use. Choose a different port or free it, then retry.',
+                        error: 'Port 12345 is already in use. Choose a different port or free it, then retry.',
+                    },
+                ],
+                'failed-timeout': [
+                    { stage: 'checking', status: 'done' },
+                    { stage: 'pulling', status: 'done' },
+                    { stage: 'creating', status: 'done' },
+                    { stage: 'starting', status: 'done' },
+                    {
+                        stage: 'waiting',
+                        status: 'error',
+                        message: 'DocumentDB did not accept connections in time. It may still be initializing.',
+                        error: 'DocumentDB did not accept connections in time. It may still be initializing.',
+                        timedOut: true,
+                    },
+                ],
+            };
+
+            const respond = (id, result, complete) => {
+                window.postMessage({ id, result, complete }, '*');
+            };
+
+            const vscodeApi = {
+                postMessage(message) {
+                    const { id, op } = message ?? {};
+                    if (!id || !op) return;
+                    const { type, path } = op;
+                    if (type === 'subscription.stop' || type === 'abort') return;
+
+                    if (path === 'localQuickStart.startQuickStart' || path === 'localQuickStart.waitLonger') {
+                        const events = STAGE_STREAMS[scenario] ?? STAGE_STREAMS.provisioning;
+                        // Spread the events over a few frames so the stage list animates as it does
+                        // in the real panel, then close the stream.
+                        events.forEach((event, index) => setTimeout(() => respond(id, event), 60 * (index + 1)));
+                        setTimeout(() => respond(id, undefined, true), 60 * (events.length + 1));
+                        return;
+                    }
+
+                    switch (path) {
+                        case 'localQuickStart.getDockerStatus':
+                            respond(id, dockerStatus);
+                            return;
+                        case 'localQuickStart.getStatus':
+                            respond(id, dockerStatus.status);
+                            return;
+                        case 'localQuickStart.startDockerProvider':
+                            respond(id, 'notAvailable');
+                            return;
+                        case 'common.openUrl':
+                            // Prove which URL the CTA would open — this is the #856 assertion.
+                            console.log('[harness] openUrl', JSON.stringify(op.input));
+                            respond(id, undefined);
+                            return;
+                        case 'localQuickStart.copyConnectionString':
+                            console.log('[harness] copyConnectionString invoked');
+                            respond(id, undefined);
+                            return;
+                        case 'localQuickStart.openConnection':
+                            console.log('[harness] openConnection invoked');
+                            respond(id, undefined);
+                            return;
+                        default:
+                            console.log('[harness] unhandled', path, JSON.stringify(op.input ?? null));
+                            respond(id, undefined);
+                    }
+                },
+                getState: () => undefined,
+                setState: (state) => state,
+            };
+
+            globalThis.acquireVsCodeApi = () => vscodeApi;
+            globalThis.l10n_bundle = {};
+
+            const { render } = await import('./views.js');
+            render('localQuickStart', vscodeApi);
+
+            /**
+             * Drive the wizard to the requested phase. The component owns its phase state, so the
+             * harness advances it the way a user would — by clicking the footer's primary action.
+             */
+            const clickByText = (text) => {
+                const target = [...document.querySelectorAll('button')].find(
+                    (button) => button.textContent.trim() === text,
+                );
+                target?.click();
+                return Boolean(target);
+            };
+
+            const settle = () => new Promise((resolve) => setTimeout(resolve, 250));
+
+            (async () => {
+                await settle();
+                if (scenario === 'introduction') return;
+                clickByText('Continue'); // introduction → configure
+                await settle();
+                if (scenario === 'configure') return;
+                clickByText('Start DocumentDB Local'); // configure → provisioning → stream
+                await settle();
+                await settle();
+                globalThis.__harnessReady = true;
+            })();
+        </script>
+    </body>
+</html>

--- a/test/webview-harness/quickstart-harness.html
+++ b/test/webview-harness/quickstart-harness.html
@@ -274,19 +274,35 @@
                 window.postMessage({ id, result, complete }, '*');
             };
 
+            /**
+             * Every host call the webview makes, in order, as `{path, input}`. The automated suite
+             * asserts against this — it is how "the install button opens the Docker Desktop page"
+             * is checked without actually leaving the page.
+             */
+            globalThis.__harnessCalls = [];
+
             const vscodeApi = {
                 postMessage(message) {
                     const { id, op } = message ?? {};
                     if (!id || !op) return;
                     const { type, path } = op;
                     if (type === 'subscription.stop' || type === 'abort') return;
+                    globalThis.__harnessCalls.push({ path, input: op.input ?? null });
 
                     if (path === 'localQuickStart.startQuickStart' || path === 'localQuickStart.waitLonger') {
                         const events = STAGE_STREAMS[scenario] ?? STAGE_STREAMS.provisioning;
                         // Spread the events over a few frames so the stage list animates as it does
-                        // in the real panel, then close the stream.
+                        // in the real panel.
                         events.forEach((event, index) => setTimeout(() => respond(id, event), 60 * (index + 1)));
-                        setTimeout(() => respond(id, undefined, true), 60 * (events.length + 1));
+                        // Only close the stream once it has reached a terminal event. A stream that
+                        // ends without one means the service returned early, and the webview
+                        // correctly falls back to the settings page — which would silently undo a
+                        // mid-provision scenario.
+                        const last = events.at(-1);
+                        const terminal = last?.stage === 'done' || last?.status === 'error';
+                        if (terminal) {
+                            setTimeout(() => respond(id, undefined, true), 60 * (events.length + 1));
+                        }
                         return;
                     }
 
@@ -342,15 +358,23 @@
 
             const settle = () => new Promise((resolve) => setTimeout(resolve, 250));
 
+            /**
+             * `__harnessReady` flips once the wizard has reached the phase the scenario asked for,
+             * so the automated suite can wait on a signal instead of a sleep.
+             */
+            globalThis.__harnessReady = false;
+
             (async () => {
                 await settle();
-                if (scenario === 'introduction') return;
-                clickByText('Continue'); // introduction → configure
-                await settle();
-                if (scenario === 'configure') return;
-                clickByText('Start DocumentDB Local'); // configure → provisioning → stream
-                await settle();
-                await settle();
+                if (scenario !== 'introduction') {
+                    clickByText('Continue'); // introduction → configure
+                    await settle();
+                    if (scenario !== 'configure') {
+                        clickByText('Start DocumentDB Local'); // configure → provisioning → stream
+                        await settle();
+                        await settle();
+                    }
+                }
                 globalThis.__harnessReady = true;
             })();
         </script>

--- a/test/webview-harness/serve.js
+++ b/test/webview-harness/serve.js
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Static server for the webview visual harness (see README.md in this folder).
+ *
+ * It serves the built `dist/` as the site root — the harness imports `./views.js` as an ES module,
+ * which needs a real http origin, not `file://` — and maps `*.html` to this folder, so the harness
+ * is versioned here rather than inside the build output (which `rimraf ./dist` wipes and
+ * `vsce package` would otherwise ship).
+ *
+ *   node test/webview-harness/serve.js            # http://127.0.0.1:18099/quickstart-harness.html
+ *   node test/webview-harness/serve.js 18099 ./dist
+ */
+
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+
+const port = Number(process.argv[2] ?? 18099);
+const distRoot = path.resolve(process.argv[3] ?? path.join(__dirname, '..', '..', 'dist'));
+const harnessRoot = __dirname;
+
+const TYPES = {
+    '.css': 'text/css; charset=utf-8',
+    '.html': 'text/html; charset=utf-8',
+    '.js': 'text/javascript; charset=utf-8',
+    '.json': 'application/json; charset=utf-8',
+    '.map': 'application/json; charset=utf-8',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml',
+    '.ttf': 'font/ttf',
+};
+
+/** Harness pages live in this folder; everything else comes from the build output. */
+function resolveRequest(urlPath) {
+    const requested = urlPath === '/' ? '/quickstart-harness.html' : urlPath;
+    const harnessCandidate = path.join(harnessRoot, requested);
+    if (requested.endsWith('.html') && harnessCandidate.startsWith(harnessRoot) && fs.existsSync(harnessCandidate)) {
+        return harnessCandidate;
+    }
+    const distCandidate = path.join(distRoot, requested);
+    return distCandidate.startsWith(distRoot) ? distCandidate : undefined;
+}
+
+http.createServer((req, res) => {
+    const filePath = resolveRequest(decodeURIComponent(req.url.split('?')[0]));
+    if (!filePath) {
+        res.writeHead(403).end('forbidden');
+        return;
+    }
+    fs.readFile(filePath, (error, data) => {
+        if (error) {
+            res.writeHead(404).end('not found');
+            return;
+        }
+        res.writeHead(200, {
+            'Content-Type': TYPES[path.extname(filePath).toLowerCase()] ?? 'application/octet-stream',
+            // The bundle is rebuilt between runs; never let a stale copy be screenshotted.
+            'Cache-Control': 'no-store',
+        });
+        res.end(data);
+    });
+}).listen(port, '127.0.0.1', () => {
+    if (!fs.existsSync(path.join(distRoot, 'views.js'))) {
+        console.warn(`WARNING: ${path.join(distRoot, 'views.js')} not found — run "npm run webpack-dev-wv" first.`);
+    }
+    console.log(`Harness:  http://127.0.0.1:${port}/quickstart-harness.html?scenario=introduction`);
+    console.log(`Serving:  ${distRoot}`);
+});

--- a/webpack.config.views.js
+++ b/webpack.config.views.js
@@ -87,6 +87,10 @@ module.exports = (env, { mode }) => {
                 directory: path.join(__dirname, 'src/webviews/static'),
                 publicPath: '/static',
             },
+            // The webview visual harness serves `dist/` from disk, so the watch build has to land there.
+            devMiddleware: {
+                writeToDisk: true,
+            },
             allowedHosts: 'all',
             headers: {
                 'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
> **Parked draft.** Nothing here is meant to merge yet. It exists so the work is not lost and so the
> decision behind parking it is written down. See **Why parked**.

Extracted from **#866** (_Fix the Local Quick Start bug-bash issues_). **Authorship is preserved**:
the three harness/Playwright commits are @guanzhousongmicrosoft's, cherry-picked unchanged apart
from the split noted in each message.

Based on **`main`**, deliberately. `main` contains **zero** Local Quick Start files, so
**the suite cannot run here** until that feature lands. That is expected and correct for a parked
branch: basing on `main` keeps the diff to the harness itself instead of dragging the whole feature
along with it.

---

## Why parked

Not a quality judgement. Every layer this stands on is being replaced:

- **webpack is going away.** The harness's whole premise is `dist/views.js` produced by
  `webpack-dev-wv`, served as a site root.
- **the test story is being redone.** `npm test` has been a no-op stub since the legacy
  `vscode-test` suite was retired, with a replacement promised for 0.10.0. Adding a second,
  separately invoked runner before that lands fragments it further.
- **the wire protocol it hand-stubs is moving.** The harness reimplements tRPC-over-`postMessage`
  by hand (`{id, op:{type, path, input}}` in, `{id, result}` back). That plumbing is moving into
  `@microsoft/vscode-ext-webview`.

Building the visual suite on the layer we are about to delete is backwards. This is exactly why
Playwright was filed as **future work** in `docs/ai-and-plans/live-preview-playwright-future-work.md`
(on `feature/local-quickstart`, not yet on `main`), not as current work.

## What it is

`test/webview-harness/` renders a **real** production webview bundle in a plain browser:

- stubs exactly **one** global, `acquireVsCodeApi()`
- serves `dist/` as the **site root**, because the harness `import()`s `./views.js` as an ES module
- answers tRPC with canned fixtures selected by `?scenario=...`, themed by `?theme=dark|light`
- records escaping actions (`common.openUrl`, `localQuickStart.copyConnectionString`,
  `localQuickStart.openConnection`) on `window.__harnessCalls` instead of performing them, which is
  how "the Windows install button opens the Docker **Desktop** page" gets asserted without leaving
  the page

Everything below that stub is the actual shipped code: real React tree, real Fluent styling, real
DOM, real localization lookup path.

## How to use it

**Manual**

```sh
npm run webpack-dev-wv
node test/webview-harness/serve.js
# open the printed URL with ?scenario=...&theme=...
```

**Automated**

```sh
npm run webpack-dev-wv     # the suite does NOT build for you
npm run test:visual
npx playwright show-report testOutput/playwright-report
```

**Agent.** Point browser tools at the running harness: `read_page` for the accessibility tree,
`screenshot_page`, `click_element`, and `run_playwright_code` for measurements and for reading
`window.__harnessCalls`. This is most of the value: an agent can reach a state that otherwise needs
a human, Docker, and several minutes.

## Gotchas (all learned the hard way)

| Trap | Symptom | Handling |
| --- | --- | --- |
| **stale `dist/views.js`**, the number one time waster | assertions test a bundle from an hour ago, with no warning | fixed here: `devServer.devMiddleware.writeToDisk` in `webpack.config.views.js`, because `watch:views` is `webpack serve` and builds in memory |
| **two runners, neither sees the other** | "I ran the tests" is ambiguous | Jest's `testMatch` is `<rootDir>/src/**/*.test.ts`, so it never sees `test/**/*.spec.ts`; Playwright's `testDir` never sees `src/`. **Both must be run.** |
| **HMR lies after a hook change** | `Should have a queue. This is likely a bug in React.` | full reload, not hot update |
| **`box-sizing: content-box`** | layout measurements off by the padding | the harness page sets the box model explicitly |
| **`goto(waitUntil:'load')` hangs** | test times out on an unsettled tRPC call | wait on `window.__harnessReady`, which the harness sets once the requested phase is reached |

## Honest scope

- **not** the VS Code webview host: no CSP, no panel chrome, no real message bus
- theme values are a **representative slice** of Dark Modern / Light Modern, not live values
- **zero** host-side behaviour: no Docker probes, no provisioning, no storage
- screenshots are **artifacts, not baselines**, and deliberately so. Text here is rendered by the
  OS, so a pixel baseline recorded on one contributor's machine fails on another's for reasons that
  have nothing to do with the UI. Turning them into real `toHaveScreenshot` baselines would require
  standardising runs on one container image. The README says so.

## Changes made on top of the cherry-picks

1. **`webpack.config.views.js` gets `devServer.devMiddleware.writeToDisk`.** See the gotchas table.
2. **`.github/copilot-instructions.md`** gains a short "Webview visual checks" note, so agents know
   the harness exists.
3. **Removed the `success-relocated-port` scenario and its test.** It fixtured a host port Docker
   picked at bind time. That mechanism (#854 / `ae25ac3b` in #866) was **not taken**: the Configure
   step suggests and validates a free port, so the port is always explicit and a conflict is a hard,
   explained error. The scenario would have described behaviour the product does not have.
4. **Split `fa417a6e`.** Its Jest half (`src/commands/localQuickStart/contributions.test.ts`) is
   release relevant and stays in #866. Only the Playwright half moved here. Same for `246e6703`:
   only its spec hunk moved.

## Fixture drift to fix when we return

The stub was written against the pre code review shape of the router. It has since moved:

| Stub says | Router now says | Current effect |
| --- | --- | --- |
| `willReuse` | `canReuseExistingData` | ignored |
| (missing) | `suggestedPort` | absent, so `advPort` falls back to `"10260"` |
| (missing) | `checkPort` | unknown path, answers `undefined` |
| (missing) | `onInstanceChanged` | unknown path, answers `undefined` |

All of it degrades harmlessly today, which is precisely the risk: it will drift into fiction while
still looking green.

## Open decisions for when we unpark

1. **CI or explicitly manual?** Unwired, a visual suite rots into fake coverage. Wired, it needs a
   browser image in CI. Pick one and write it down.
2. **Is this the "new framework"** that `npm test` has been promising since it became a no-op stub?
3. **Pin `@playwright/test` to latest stable.** It is currently a caret ranged alpha
   (`^1.63.0-alpha-2026-07-29`), and the lockfile resolves it from an ADO mirror with `sha1`
   integrity hashes. Both are reproducibility and supply chain smells.
4. **Typed fixtures.** The scenarios are untyped JS object literals inside the HTML. Nothing ties
   them to the router's actual output types, which is how the drift above happened silently.

## Verification to run when unparked

The mutation test is the only falsifiable claim about this suite, and right now it exists only as a
sentence in a commit message. Re-run it for real:

```sh
git revert --no-commit bc08cfd1        # undo the #855/#856 webview fixes
npm run webpack-dev-wv && npm run test:visual
# expect: exactly the #855/#856 assertions fail, everything else green
```

## Credit

This implements **3 of the 4** actionable items from our own
`live-preview-playwright-future-work.md`: a committed harness instead of a throwaway page, theme
switching, and a fixture set for host responses. It closes the one that doc calls _"the largest
current gap"_ (theme switching), and correctly **declines** the one it warns is premature (committed
pixel baselines). Thank you, @guanzhousongmicrosoft.

---

**Base:** `main` | **No milestone** | Split out of #866.
