### PR TITLE
RFC: Wave 0 evidence for #880 - ESM readiness audit + typed fake transport

### DIFF
--- a/eslint.esm-readiness.config.mjs
+++ b/eslint.esm-readiness.config.mjs
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * ESM-readiness guards. **Not** part of `npm run lint` - `npm run esm:check` runs it.
+ *
+ * These two rules catch the source-level constructs that a bundler-based build
+ * cannot carry over, taken from the bundler-migration post-mortem summarized in
+ * the modernization research (PR #880):
+ *
+ *   1. `const enum`   - a file-at-a-time transpiler cannot inline the values.
+ *   2. `__dirname` / `__filename` - do not exist in ES modules.
+ *
+ * They are kept out of `eslint.config.mjs` on purpose. Turning them on repo-wide
+ * would apply to every contributor and every open PR, and that is a decision for
+ * the modernization review rather than a side effect of this branch. Running them
+ * separately still answers the question the review needs answered - *how much
+ * would it cost?* - without imposing the answer.
+ *
+ * If the review adopts them, merge these blocks into `eslint.config.mjs` and
+ * delete this file.
+ */
+
+import importPlugin from 'eslint-plugin-import';
+import jest from 'eslint-plugin-jest';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+import mocha from 'eslint-plugin-mocha';
+import reactHooks from 'eslint-plugin-react-hooks';
+import ts from 'typescript-eslint';
+
+const ESM_GLOBAL_MESSAGE =
+    'Not available in ES modules. Use `import.meta.url` with `fileURLToPath`, or add a documented exemption.';
+
+export default ts.config(
+    {
+        ignores: [
+            '.azure-pipelines',
+            '.config',
+            '.github',
+            '.vscode-test',
+            'coverage',
+            '**/dist',
+            '**/out',
+            '**/node_modules',
+            '**/__mocks__/**/*',
+            '**/*.d.ts',
+        ],
+    },
+    // Plugins are registered so that existing `eslint-disable` comments naming their
+    // rules still resolve. **No rule from them is enabled** - this config turns on
+    // exactly two rules, below.
+    {
+        plugins: {
+            '@typescript-eslint': ts.plugin,
+            import: importPlugin,
+            jest,
+            'jsx-a11y': jsxA11y,
+            mocha,
+            'react-hooks': reactHooks,
+        },
+        linterOptions: { reportUnusedDisableDirectives: 'off' },
+    },
+    // Deliberately does NOT extend any recommended set. This config exists to count
+    // two specific things; inheriting a general rule set would bury them in unrelated
+    // findings and misrepresent the size of the migration.
+    //
+    // Rule 1: `const enum` is unsupported by file-at-a-time transpilers, everywhere.
+    // Needs the TypeScript parser to see `TSEnumDeclaration`.
+    {
+        files: ['**/*.{ts,tsx}'],
+        languageOptions: { parser: ts.parser, ecmaVersion: 2023, sourceType: 'module' },
+        rules: {
+            'no-restricted-syntax': [
+                'error',
+                {
+                    selector: 'TSEnumDeclaration[const=true]',
+                    message:
+                        'Avoid `const enum`: bundlers transpile file-by-file and cannot inline its values. Use a regular `enum` or an `as const` object.',
+                },
+            ],
+        },
+    },
+    // Rule 2: `__dirname` / `__filename`, scoped to source that the migration converts.
+    // Build configs (`webpack.*.js`, `scripts/`) and test files stay CommonJS, so they
+    // are deliberately out of scope - counting them would overstate the work.
+    {
+        files: ['src/**/*.{ts,tsx}', 'packages/*/src/**/*.{ts,tsx}'],
+        ignores: ['**/*.test.ts', '**/*.test.tsx'],
+        languageOptions: { parser: ts.parser, ecmaVersion: 2023, sourceType: 'module' },
+        rules: {
+            'no-restricted-globals': [
+                'error',
+                { name: '__dirname', message: ESM_GLOBAL_MESSAGE },
+                { name: '__filename', message: ESM_GLOBAL_MESSAGE },
+            ],
+        },
+    },
+    // The three known exemptions. All resolve a file shipped beside the build output,
+    // and each is loaded by a CommonJS host today:
+    //
+    //   * WorkerSessionManager.ts   - spawns `playgroundWorker.js` via `new Worker(path)`.
+    //   * tsPlugin/index.ts         - a TypeScript language-service plugin; the TS server
+    //                                 loads it with `require()`, so it stays CommonJS even
+    //                                 after the extension host moves to ESM.
+    //   * shell-api-types/index.ts  - reads the shipped `documentdb-shell-api.d.ts`.
+    //
+    // Listing them turns "grep the repo" into an exact worklist. A clean run means the
+    // ESM surface is these three files and nothing else.
+    {
+        files: [
+            'src/documentdb/playground/WorkerSessionManager.ts',
+            'src/documentdb/playground/tsPlugin/index.ts',
+            'packages/documentdb-js-shell-api-types/src/index.ts',
+        ],
+        rules: {
+            'no-restricted-globals': 'off',
+        },
+    },
+);

--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -36,7 +36,7 @@ export { getPublicIpv4, isIpInRanges } from './src/utils/getIp';
 export { improveError } from './src/utils/improveError';
 export { randomUtils } from './src/utils/randomUtils';
 export { rejectOnTimeout, valueOnTimeout } from './src/utils/timeout';
-export { IDisposable } from './src/utils/vscodeUtils';
+export { type IDisposable } from './src/utils/vscodeUtils';
 export { wrapError } from './src/utils/wrapError';
 
 // NOTE: The auto-fix action "source.organizeImports" does weird things with this file, but there doesn't seem to be a way to disable it on a per-file basis so we'll just let it happen

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "package-prerelease:default": "npm run webpack-prod && cd dist && npm pkg delete \"scripts.vscode:prepublish\" && npx vsce package --pre-release --no-dependencies --out ../${npm_package_name}-${npm_package_version}-pre-release.vsix",
     "lint": "eslint --quiet .",
     "lint-fix": "eslint . --fix",
+    "esm:check": "node scripts/esm-readiness.mjs",
     "prettier": "prettier -c \"(src|test|l10n|grammar|docs|packages)/**/*.@(js|ts|jsx|tsx|json)\" \"./*.@(js|ts|jsx|tsx|json)\"",
     "prettier-fix": "prettier -w \"(src|test|l10n|grammar|docs|packages)/**/*.@(js|ts|jsx|tsx|json)\" \"./*.@(js|ts|jsx|tsx|json)\"",
     "test": "node -e \"console.log('\\n[vscode-documentdb] Integration tests are deprecated.\\nThe legacy vscode-test based integration test suite is no longer in use and will be replaced with a new framework in the 0.10.0 release.\\nThis command is now a no-op.\\n')\"",

--- a/packages/vscode-ext-webview/README.md
+++ b/packages/vscode-ext-webview/README.md
@@ -375,7 +375,7 @@ router context type so procedures read it without a telemetry-specific cast — 
 
 ## Entry points
 
-The package has four entry points so bundlers do not drag Node / VS Code APIs
+The package has five entry points so bundlers do not drag Node / VS Code APIs
 into the webview bundle, and so a non-React consumer never pulls React in.
 
 | Subpath     | Side                             | Imports                | Key exports                                                                                                                    |
@@ -384,6 +384,7 @@ into the webview bundle, and so a non-React consumer never pulls React in.
 | `./host`    | extension host (Node.js)         | `fs`, `path`, `vscode` | `openWebview`, `WebviewController`, `attachTrpc`, `telemetryMiddlewareBody`, `loggingMiddlewareBody`, `consoleProcedureLogger` |
 | `./webview` | webview (browser), any framework | no React               | `connectTrpc`, `createEventChannel`, `vscodeLink`, `errorLink`                                                                 |
 | `./react`   | webview (browser), React         | React                  | `useTrpcClient`, `useRpcEvents`, `useConfiguration`, `WithWebviewContext`                                                      |
+| `./testing` | tests and harnesses              | no `vscode`, no React  | `createFakeTransport`, `Scenario`, `ProcedurePath`, `ProcedureOutput`                                                         |
 
 ```ts
 // Shared. Safe to import from either side.
@@ -397,7 +398,44 @@ import { connectTrpc, createEventChannel, vscodeLink } from '@microsoft/vscode-e
 
 // Webview, React hooks.
 import { useTrpcClient, useConfiguration, WithWebviewContext } from '@microsoft/vscode-ext-webview/react';
+
+// Tests and harnesses. Never import this from a production webview.
+import { createFakeTransport, type Scenario } from '@microsoft/vscode-ext-webview/testing';
 ```
+
+### `./testing` — driving a webview without an extension host
+
+`connectTrpc` accepts anything with a compatible `postMessage`, so a component can
+run against canned answers instead of a live host. `createFakeTransport` supplies
+those answers from a **scenario**, and the scenario is typed against your router:
+an unknown procedure path, or a `result` that no longer matches the procedure's
+return type, is a compile error rather than a fixture quietly describing a state
+your product can no longer produce.
+
+```ts
+import { connectTrpc } from '@microsoft/vscode-ext-webview/webview';
+import { createFakeTransport, type Scenario } from '@microsoft/vscode-ext-webview/testing';
+import type { AppRouter } from './appRouter';
+
+const scenario: Scenario<AppRouter> = {
+    'common.openUrl': { result: true },
+    // `stream` drives a subscription; `error` drives a failure state.
+    'quickStart.start': { stream: [{ stage: 'checking', status: 'done' }] },
+    'docker.check': { error: { message: 'daemon unreachable' } },
+};
+
+const transport = createFakeTransport<AppRouter>({ scenario });
+const { client } = connectTrpc<AppRouter>(transport);
+
+await client.common.openUrl.mutate({ url: 'https://example.com' });
+
+// Assert what the UI *tried to do*, at the boundary it tried to cross.
+expect(transport.callsTo('common.openUrl')).toHaveLength(1);
+```
+
+Responses default to `window.postMessage`; pass `deliver` in a non-DOM test
+environment. Failure and empty states cost one line each here, which is what makes
+this cheaper than reaching the same states against a real backend.
 
 ## What's inside
 
@@ -470,7 +508,7 @@ extensions are working examples of that layout against this package.
 
 ## Status
 
-`0.10.1`. APIs are subject to change while the package is in preview. See
+`0.11.0`. APIs are subject to change while the package is in preview. See
 [ADVANCED.md](./ADVANCED.md) for the full set of primitives and patterns.
 
 ## Contributors

--- a/packages/vscode-ext-webview/package.json
+++ b/packages/vscode-ext-webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/vscode-ext-webview",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Webview infrastructure for VS Code extensions: type-safe tRPC over postMessage with pluggable telemetry middleware, plus an optional extension-host panel facade, a framework-agnostic webview client, and optional React hooks.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,6 +21,10 @@
     "./react": {
       "types": "./dist/react.d.ts",
       "default": "./dist/react.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "default": "./dist/testing.js"
     }
   },
   "typesVersions": {
@@ -33,6 +37,9 @@
       ],
       "react": [
         "./dist/react.d.ts"
+      ],
+      "testing": [
+        "./dist/testing.d.ts"
       ]
     }
   },

--- a/packages/vscode-ext-webview/src/harness/fakeTransport.test.ts
+++ b/packages/vscode-ext-webview/src/harness/fakeTransport.test.ts
@@ -1,0 +1,163 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { initWebviewTrpc } from '../shared/initWebviewTrpc';
+import { type VsCodeLinkResponseMessage } from '../shared/wireProtocol';
+import { connectTrpc } from '../webview/connectTrpc';
+import { createFakeTransport, type Scenario } from './fakeTransport';
+
+const { router, publicProcedure } = initWebviewTrpc();
+
+// A router whose *type* parametrizes both the client and the scenario. The
+// resolver bodies never run: the fake transport answers before anything reaches
+// them. That is the point — the scenario is checked against these signatures.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- referenced only via `typeof` to type the client
+const appRouter = router({
+    greet: publicProcedure.query((): string => 'unused'),
+    common: router({
+        // A void mutation, which is the case the wire protocol gets wrong if
+        // `undefined` is posted verbatim.
+        openUrl: publicProcedure.input((raw: unknown) => raw as { url: string }).mutation((): void => undefined),
+    }),
+    stages: publicProcedure.subscription(async function* (): AsyncGenerator<{ stage: string }> {
+        await Promise.resolve();
+        yield { stage: 'unused' };
+    }),
+});
+type AppRouter = typeof appRouter;
+
+// The package jest env is `node`, so there is no DOM. Install a minimal `window`
+// that records 'message' listeners, and route the fake transport's responses to
+// them. This mirrors `connectTrpc.test.ts`.
+type MessageListener = (event: MessageEvent) => void;
+const messageListeners = new Set<MessageListener>();
+
+function deliver(message: VsCodeLinkResponseMessage): void {
+    for (const listener of [...messageListeners]) {
+        listener({ data: message } as MessageEvent);
+    }
+}
+
+beforeEach(() => {
+    messageListeners.clear();
+    Object.assign(globalThis, {
+        window: {
+            addEventListener: (type: string, listener: MessageListener) => {
+                if (type === 'message') {
+                    messageListeners.add(listener);
+                }
+            },
+            removeEventListener: (_type: string, listener: MessageListener) => {
+                messageListeners.delete(listener);
+            },
+        },
+    });
+});
+
+afterEach(() => {
+    messageListeners.clear();
+    Reflect.deleteProperty(globalThis, 'window');
+});
+
+function connect(scenario: Scenario<AppRouter>) {
+    const transport = createFakeTransport<AppRouter>({ scenario, deliver });
+    const { client } = connectTrpc<AppRouter>(transport);
+    return { transport, client };
+}
+
+describe('createFakeTransport', () => {
+    it('resolves a query from its fixture', async () => {
+        const { client } = connect({ greet: { result: 'hello' } });
+
+        await expect(client.greet.query()).resolves.toBe('hello');
+    });
+
+    it('settles a void mutation whose fixture result is undefined', async () => {
+        // Regression guard for the wire protocol's sharpest edge: the structured-
+        // clone algorithm strips `undefined`, and the client only completes when
+        // `result !== undefined`. A fake that posts `undefined` verbatim leaves the
+        // caller hanging forever, so the host coerces to `null` and so must this.
+        const { client } = connect({ 'common.openUrl': { result: undefined } });
+
+        await expect(client.common.openUrl.mutate({ url: 'https://example.com' })).resolves.toBeNull();
+    });
+
+    it('rejects when the fixture is an error', async () => {
+        const { client } = connect({ greet: { error: { message: 'daemon unreachable' } } });
+
+        await expect(client.greet.query()).rejects.toThrow('daemon unreachable');
+    });
+
+    it('emits every stream value then completes a subscription', async () => {
+        const { client } = connect({
+            stages: { stream: [{ stage: 'checking' }, { stage: 'pulling' }, { stage: 'done' }] },
+        });
+
+        const seen: { stage: string }[] = [];
+        const completed = new Promise<void>((resolve, reject) => {
+            client.stages.subscribe(undefined, {
+                onData: (value) => seen.push(value),
+                onComplete: () => resolve(),
+                onError: (error) => reject(new Error(error.message)),
+            });
+        });
+
+        await completed;
+        expect(seen.map((event) => event.stage)).toEqual(['checking', 'pulling', 'done']);
+    });
+
+    it('records the path, type and input of every call', async () => {
+        const { transport, client } = connect({ 'common.openUrl': { result: undefined } });
+
+        await client.common.openUrl.mutate({ url: 'https://aka.ms/docker' });
+
+        expect(transport.calls).toHaveLength(1);
+        expect(transport.calls[0]).toMatchObject({
+            path: 'common.openUrl',
+            type: 'mutation',
+            input: { url: 'https://aka.ms/docker' },
+        });
+    });
+
+    it('filters recorded calls by procedure path', async () => {
+        const { transport, client } = connect({
+            greet: { result: 'hi' },
+            'common.openUrl': { result: undefined },
+        });
+
+        await client.greet.query();
+        await client.common.openUrl.mutate({ url: 'https://example.com' });
+
+        expect(transport.callsTo('common.openUrl')).toHaveLength(1);
+        expect(transport.callsTo('greet')).toHaveLength(1);
+    });
+
+    it('reports an unmocked procedure instead of hanging', async () => {
+        const { client } = connect({});
+
+        await expect(client.greet.query()).rejects.toThrow(/No fixture for 'greet'/);
+    });
+
+    it('ignores traffic that is not a transport request', () => {
+        const transport = createFakeTransport<AppRouter>({ scenario: {}, deliver });
+
+        expect(() => {
+            transport.postMessage(null);
+            transport.postMessage('a string');
+            transport.postMessage({ somethingElse: true });
+        }).not.toThrow();
+        expect(transport.calls).toHaveLength(0);
+    });
+
+    it('clears recorded calls on reset', async () => {
+        const { transport, client } = connect({ greet: { result: 'hi' } });
+
+        await client.greet.query();
+        expect(transport.calls).toHaveLength(1);
+
+        transport.reset();
+        expect(transport.calls).toHaveLength(0);
+    });
+});

--- a/packages/vscode-ext-webview/src/harness/fakeTransport.ts
+++ b/packages/vscode-ext-webview/src/harness/fakeTransport.ts
@@ -1,0 +1,288 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * A fake webview transport for tests and the visual harness.
+ *
+ * {@link connectTrpc} accepts anything with a compatible `postMessage`
+ * (`VsCodeApiLike`), so a webview can be driven without an extension host by
+ * substituting this object for `acquireVsCodeApi()`. Every procedure the
+ * component calls is answered from a **scenario**: a map of procedure path to
+ * canned outcome.
+ *
+ * The point of doing this in the framework rather than in each consumer's test
+ * folder is that a scenario written here is **typed against the router**. A path
+ * that does not exist, or a `result` whose shape no longer matches the
+ * procedure's return type, is a compile error rather than a fixture that quietly
+ * describes a state the product can no longer produce.
+ *
+ * @example
+ * ```ts
+ * const transport = createFakeTransport<AppRouter>({
+ *     scenario: {
+ *         'common.openUrl': { result: undefined },
+ *     },
+ * });
+ *
+ * const { client } = connectTrpc<AppRouter>(transport);
+ * await client.common.openUrl.mutate({ url: 'https://example.com' });
+ *
+ * expect(transport.callsTo('common.openUrl')).toHaveLength(1);
+ * ```
+ */
+
+import { type AnyProcedure, type AnyRouter, type inferProcedureOutput } from '@trpc/server';
+import { type VsCodeLinkRequestMessage, type VsCodeLinkResponseMessage } from '../shared/wireProtocol';
+import { type VsCodeApiLike } from '../webview/connectTrpc';
+
+/** The router's procedure tree, as tRPC stores it (nested, not flattened). */
+type ProcedureRecordOf<TRouter extends AnyRouter> = TRouter['_def']['procedures'];
+
+/**
+ * Every procedure in `T` as a dotted path.
+ *
+ * Procedures are the leaves; anything else that is an object is a nested router
+ * or a plain grouping record, so it recurses. `AnyProcedure` is tested first
+ * because a procedure is itself an object.
+ */
+type PathsIn<T> = {
+    [K in keyof T & string]: T[K] extends AnyProcedure ? K : T[K] extends object ? `${K}.${PathsIn<T[K]>}` : never;
+}[keyof T & string];
+
+/** Walks a dotted path back down to the node it names. */
+type NodeAt<T, TPath extends string> = TPath extends `${infer Head}.${infer Rest}`
+    ? Head extends keyof T
+        ? NodeAt<T[Head], Rest>
+        : never
+    : TPath extends keyof T
+      ? T[TPath]
+      : never;
+
+/** Union of every procedure path in `TRouter`, e.g. `'common.openUrl'`. */
+export type ProcedurePath<TRouter extends AnyRouter> = PathsIn<ProcedureRecordOf<TRouter>>;
+
+/** The value a procedure resolves to, given its dotted path. */
+export type ProcedureOutput<TRouter extends AnyRouter, TPath extends ProcedurePath<TRouter>> =
+    NodeAt<ProcedureRecordOf<TRouter>, TPath> extends infer TNode
+        ? TNode extends AnyProcedure
+            ? inferProcedureOutput<TNode>
+            : never
+        : never;
+
+/**
+ * The error half of a fixture. Only `message` is required; the rest mirrors what
+ * the real host serializes in `attachTrpc`'s `wrapInTrpcErrorMessage`.
+ */
+export interface FixtureError {
+    readonly message: string;
+    readonly name?: string;
+    readonly code?: number;
+    readonly stack?: string;
+    readonly cause?: unknown;
+    readonly data?: unknown;
+}
+
+/**
+ * The element type a subscription yields.
+ *
+ * `inferProcedureOutput` reports a subscription's output as the `AsyncIterable`
+ * the generator returns, but a fixture describes the values that travel over the
+ * wire — the host posts one message per yielded item. Unwrapping here keeps a
+ * `stream` fixture typed as the events a component actually receives.
+ */
+type StreamElement<TOutput> = TOutput extends AsyncIterable<infer TElement> ? TElement : TOutput;
+
+/**
+ * One procedure's canned outcome.
+ *
+ * - `result` — resolve once (queries and mutations).
+ * - `stream` — emit each value, then complete (subscriptions).
+ * - `error` — reject.
+ */
+export type ProcedureFixture<TRouter extends AnyRouter, TPath extends ProcedurePath<TRouter>> =
+    | { readonly result: ProcedureOutput<TRouter, TPath> }
+    | { readonly stream: readonly StreamElement<ProcedureOutput<TRouter, TPath>>[] }
+    | { readonly error: FixtureError };
+
+/**
+ * A named UI state, expressed as the answers the host would give.
+ *
+ * Partial by design: a scenario only needs to cover the procedures the component
+ * under test actually calls. Anything else is reported as an unmocked call
+ * rather than silently hanging.
+ */
+export type Scenario<TRouter extends AnyRouter> = {
+    readonly [TPath in ProcedurePath<TRouter>]?: ProcedureFixture<TRouter, TPath>;
+};
+
+/** One recorded attempt by the webview to reach the host. */
+export interface RecordedCall {
+    /** Dotted procedure path, e.g. `'common.openUrl'`. */
+    readonly path: string;
+    /** `'query'`, `'mutation'`, `'subscription'`, `'abort'` or `'subscription.stop'`. */
+    readonly type: string;
+    /** The procedure input, exactly as the webview sent it. */
+    readonly input: unknown;
+}
+
+/** Options for {@link createFakeTransport}. */
+export interface FakeTransportOptions<TRouter extends AnyRouter> {
+    /** The procedure answers for this UI state. */
+    readonly scenario: Scenario<TRouter>;
+    /**
+     * How a response reaches the client. Defaults to `window.postMessage`, which
+     * is what `connectTrpc` listens on in a browser. Supply this in a non-DOM
+     * test environment.
+     */
+    readonly deliver?: (message: VsCodeLinkResponseMessage) => void;
+}
+
+/** A fake `acquireVsCodeApi()` plus the assertions it makes possible. */
+export interface FakeTransport<TRouter extends AnyRouter> extends VsCodeApiLike {
+    /**
+     * Every host call the webview attempted, in order.
+     *
+     * This is the assertion surface for behaviour that would otherwise leave the
+     * page — "the install button opens the Docker Desktop page" is a check on
+     * this array rather than on a real browser navigation.
+     */
+    readonly calls: readonly RecordedCall[];
+    /** The subset of {@link FakeTransport.calls} recorded for one procedure. */
+    callsTo(path: ProcedurePath<TRouter>): readonly RecordedCall[];
+    /** Clears recorded calls and stops any in-flight streams. */
+    reset(): void;
+}
+
+/** Structural guard mirroring the host's `isTransportRequestMessage`. */
+function isTransportRequestMessage(message: unknown): message is VsCodeLinkRequestMessage {
+    if (message === null || typeof message !== 'object') {
+        return false;
+    }
+    const op = (message as { op?: unknown }).op;
+    return (
+        typeof (message as { id?: unknown }).id === 'string' &&
+        op !== null &&
+        typeof op === 'object' &&
+        typeof (op as { type?: unknown }).type === 'string'
+    );
+}
+
+/** Posts to the real `window` when there is one. */
+function defaultDeliver(message: VsCodeLinkResponseMessage): void {
+    const maybeWindow = (globalThis as { window?: { postMessage?: (data: unknown, origin: string) => void } }).window;
+    if (typeof maybeWindow?.postMessage === 'function') {
+        maybeWindow.postMessage(message, '*');
+        return;
+    }
+    throw new Error(
+        'createFakeTransport: no `window.postMessage` in this environment. Pass `deliver` to route responses to the client.',
+    );
+}
+
+/**
+ * Creates a fake transport that answers procedure calls from a typed scenario.
+ *
+ * @template TRouter - The application's root tRPC router type.
+ * @param options    - The scenario, and optionally how responses are delivered.
+ * @returns An object usable anywhere `acquireVsCodeApi()` is expected.
+ */
+export function createFakeTransport<TRouter extends AnyRouter>(
+    options: FakeTransportOptions<TRouter>,
+): FakeTransport<TRouter> {
+    const { scenario, deliver = defaultDeliver } = options;
+    const calls: RecordedCall[] = [];
+    // Operations whose stream should stop early because the client aborted or
+    // unsubscribed. Mirrors the host, which drops a cancelled subscription.
+    const cancelled = new Set<string>();
+
+    const fixtureFor = (path: string): ProcedureFixture<TRouter, ProcedurePath<TRouter>> | undefined =>
+        (scenario as Record<string, ProcedureFixture<TRouter, ProcedurePath<TRouter>> | undefined>)[path];
+
+    const respond = (message: VsCodeLinkResponseMessage): void => {
+        // `postMessage` is asynchronous in a real webview. Matching that here keeps
+        // ordering bugs reproducible instead of hiding them behind a synchronous
+        // fake that resolves before the caller has finished rendering.
+        queueMicrotask(() => {
+            deliver(message);
+        });
+    };
+
+    const respondWithError = (id: string, error: FixtureError): void => {
+        respond({
+            id,
+            error: {
+                name: error.name ?? 'TRPCClientError',
+                message: error.message,
+                code: error.code,
+                stack: error.stack,
+                cause: error.cause,
+                data: error.data,
+            },
+        });
+    };
+
+    const handle = (message: VsCodeLinkRequestMessage): void => {
+        const { id, op } = message;
+        const path = op.path;
+
+        // Control messages carry no fixture; record them so a test can assert that
+        // a component cancelled its work, then stop the stream.
+        if (op.type === 'abort' || op.type === 'subscription.stop') {
+            cancelled.add(id);
+            calls.push({ path, type: op.type, input: op.input });
+            return;
+        }
+
+        calls.push({ path, type: op.type, input: op.input });
+
+        const fixture = fixtureFor(path);
+        if (fixture === undefined) {
+            respondWithError(id, {
+                name: 'NotFoundError',
+                message: `No fixture for '${path}' in this scenario. Add one, or assert the call instead of invoking it.`,
+            });
+            return;
+        }
+
+        if ('error' in fixture) {
+            respondWithError(id, fixture.error);
+            return;
+        }
+
+        if ('stream' in fixture) {
+            for (const value of fixture.stream) {
+                // A later `subscription.stop` must not replay earlier queued values.
+                if (cancelled.has(id)) {
+                    return;
+                }
+                // `?? null` mirrors the host: the structured-clone algorithm strips
+                // `undefined`, and the client's observable would never settle.
+                respond({ id, result: value ?? null });
+            }
+            respond({ id, complete: true });
+            return;
+        }
+
+        respond({ id, result: fixture.result ?? null });
+    };
+
+    return {
+        calls,
+        postMessage(message: unknown): void {
+            // Behave like a guest on a shared bus: ignore traffic that is not a
+            // transport request rather than throwing on it.
+            if (isTransportRequestMessage(message)) {
+                handle(message);
+            }
+        },
+        callsTo(path: ProcedurePath<TRouter>): readonly RecordedCall[] {
+            return calls.filter((call) => call.path === path);
+        },
+        reset(): void {
+            calls.length = 0;
+            cancelled.clear();
+        },
+    };
+}

--- a/packages/vscode-ext-webview/src/harness/index.ts
+++ b/packages/vscode-ext-webview/src/harness/index.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Harness surface: a typed, host-free way to drive a webview.
+ *
+ * Re-exported through the package's `./testing` subpath.
+ */
+
+export {
+    createFakeTransport,
+    type FakeTransport,
+    type FakeTransportOptions,
+    type FixtureError,
+    type ProcedureFixture,
+    type ProcedureOutput,
+    type ProcedurePath,
+    type RecordedCall,
+    type Scenario,
+} from './fakeTransport';

--- a/packages/vscode-ext-webview/src/testing.ts
+++ b/packages/vscode-ext-webview/src/testing.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Test and harness utilities for `@microsoft/vscode-ext-webview`.
+ *
+ * Everything here is for driving a webview **without** an extension host: unit
+ * and component tests, and the browser-based visual harness. Nothing in a
+ * production webview should import from this entry.
+ */
+
+export * from './harness/index';

--- a/scripts/esm-readiness.mjs
+++ b/scripts/esm-readiness.mjs
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * ESM-readiness report - `npm run esm:check`.
+ *
+ * Answers one question for the modernization review (PR #880): **how much source
+ * has to change before this repo can be built by a bundler?**
+ *
+ * It changes nothing. It runs two read-only probes and prints what they find:
+ *
+ *   1. `tsc --noEmit` with `isolatedModules`, which rejects the constructs that
+ *      only `tsc`'s whole-program emit supports (chiefly `const enum`).
+ *   2. ESLint with the ESM guards, which finds `const enum` declarations and
+ *      `__dirname` / `__filename` in source that the migration would convert.
+ *
+ * Both probes live in their own config files so that neither `npm run build` nor
+ * `npm run lint` changes behaviour for anyone. If the review decides to enforce
+ * them, the configs fold into `tsconfig.json` / `eslint.config.mjs` and this
+ * script goes away.
+ *
+ * Exit code is 0 when both probes are clean, 1 otherwise, so it can be wired into
+ * CI later without modification.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+/** ANSI helpers, skipped when the output is redirected. */
+const useColor = process.stdout.isTTY === true;
+const bold = (text) => (useColor ? `\u001b[1m${text}\u001b[0m` : text);
+const green = (text) => (useColor ? `\u001b[32m${text}\u001b[0m` : text);
+const red = (text) => (useColor ? `\u001b[31m${text}\u001b[0m` : text);
+const dim = (text) => (useColor ? `\u001b[2m${text}\u001b[0m` : text);
+
+/**
+ * Runs one probe and returns its outcome.
+ *
+ * @param {string} label   Human-readable probe name.
+ * @param {string[]} args  Arguments passed to `npx`.
+ * @returns {{ label: string, ok: boolean, output: string }}
+ */
+function probe(label, args) {
+    const result = spawnSync('npx', args, {
+        encoding: 'utf8',
+        shell: process.platform === 'win32',
+    });
+    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
+    return { label, ok: result.status === 0, output };
+}
+
+console.log(bold('\nESM readiness report'));
+console.log(dim('Read-only. No build, lint or source file is modified by this command.\n'));
+
+const probes = [
+    probe('isolatedModules type-check', ['tsc', '--noEmit', '-p', 'tsconfig.esm-readiness.json']),
+    probe('ESM source guards (const enum, __dirname)', [
+        'eslint',
+        '--no-config-lookup',
+        '--config',
+        'eslint.esm-readiness.config.mjs',
+        '.',
+    ]),
+];
+
+for (const result of probes) {
+    console.log(`${result.ok ? green('  PASS') : red('  FAIL')}  ${result.label}`);
+    if (!result.ok && result.output.length > 0) {
+        console.log(`\n${result.output}\n`);
+    }
+}
+
+const allClean = probes.every((result) => result.ok);
+
+console.log('');
+if (allClean) {
+    console.log(green(bold('  Source is ESM-ready.')));
+    console.log(
+        dim(
+            '  The only remaining `__dirname` sites are the three documented exemptions in\n' +
+                '  eslint.esm-readiness.config.mjs, each of which is loaded by a CommonJS host.\n',
+        ),
+    );
+} else {
+    console.log(red(bold('  Not ESM-ready yet - see the findings above.\n')));
+}
+
+process.exit(allClean ? 0 : 1);

--- a/src/services/connectionStorageService.ts
+++ b/src/services/connectionStorageService.ts
@@ -210,7 +210,7 @@ export type ConnectionItem = StoredItem;
  * Auth config fields are stored individually as flat string values to avoid
  * nested object serialization issues with VS Code SecretStorage.
  */
-const enum SecretIndex {
+enum SecretIndex {
     ConnectionString = 0,
     // Native auth config fields (consolidated from legacy UserName/Password)
     NativeAuthConnectionUser = 1,

--- a/src/webviews/_integration/fakeTransport.integration.test.ts
+++ b/src/webviews/_integration/fakeTransport.integration.test.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Proves the framework's fake transport works against **this extension's real
+ * router**, not just a toy router defined inside the framework's own tests.
+ *
+ * `AppRouter` is imported as a **type only**, so nothing here loads `vscode` or
+ * the router's resolvers at runtime. That is what makes a component test cheap:
+ * the scenario is checked against the production procedure signatures at compile
+ * time, and costs nothing at run time.
+ *
+ * If a procedure is renamed, or its input or output shape changes, the fixtures
+ * below stop compiling. That is the property that keeps scenarios from drifting
+ * into describing states the product can no longer produce.
+ */
+
+import { createFakeTransport, type Scenario } from '@microsoft/vscode-ext-webview/testing';
+import { connectTrpc, type VsCodeLinkResponseMessage } from '@microsoft/vscode-ext-webview/webview';
+import { type AppRouter } from './appRouter';
+
+type MessageListener = (event: MessageEvent) => void;
+const messageListeners = new Set<MessageListener>();
+
+function deliver(message: VsCodeLinkResponseMessage): void {
+    for (const listener of [...messageListeners]) {
+        listener({ data: message } as MessageEvent);
+    }
+}
+
+beforeEach(() => {
+    messageListeners.clear();
+    Object.assign(globalThis, {
+        window: {
+            addEventListener: (type: string, listener: MessageListener) => {
+                if (type === 'message') {
+                    messageListeners.add(listener);
+                }
+            },
+            removeEventListener: (_type: string, listener: MessageListener) => {
+                messageListeners.delete(listener);
+            },
+        },
+    });
+});
+
+afterEach(() => {
+    messageListeners.clear();
+    Reflect.deleteProperty(globalThis, 'window');
+});
+
+describe('fake transport against the real AppRouter', () => {
+    it('answers a real procedure and records the attempt', async () => {
+        // `common.openUrl` reports whether the URL was actually opened. Note the
+        // fixture is `true`, not `undefined`: this procedure's return type is part
+        // of the scenario's type, so a fixture that disagrees with the production
+        // signature fails to compile rather than passing against a shape the
+        // product no longer returns.
+        const scenario: Scenario<AppRouter> = {
+            'common.openUrl': { result: true },
+        };
+        const transport = createFakeTransport<AppRouter>({ scenario, deliver });
+        const { client } = connectTrpc<AppRouter>(transport);
+
+        await expect(client.common.openUrl.mutate({ url: 'https://aka.ms/documentdb' })).resolves.toBe(true);
+
+        // The assertion that replaces "did the browser navigate?" - the UI's
+        // attempt to leave the page is observable without it leaving the page.
+        expect(transport.callsTo('common.openUrl')).toEqual([
+            { path: 'common.openUrl', type: 'mutation', input: { url: 'https://aka.ms/documentdb' } },
+        ]);
+    });
+
+    it('reaches a failure state that a real backend could not produce on demand', async () => {
+        // "The browser refused to open" is a one-line fixture here, and an
+        // orchestration problem against a real host.
+        const scenario: Scenario<AppRouter> = {
+            'common.openUrl': { result: false },
+        };
+        const transport = createFakeTransport<AppRouter>({ scenario, deliver });
+        const { client } = connectTrpc<AppRouter>(transport);
+
+        await expect(client.common.openUrl.mutate({ url: 'https://example.com' })).resolves.toBe(false);
+    });
+
+    it('propagates a host error to the webview', async () => {
+        const scenario: Scenario<AppRouter> = {
+            'common.openUrl': { error: { message: 'no default browser configured' } },
+        };
+        const transport = createFakeTransport<AppRouter>({ scenario, deliver });
+        const { client } = connectTrpc<AppRouter>(transport);
+
+        await expect(client.common.openUrl.mutate({ url: 'https://example.com' })).rejects.toThrow(
+            'no default browser configured',
+        );
+    });
+});

--- a/src/webviews/documentdb/localQuickStart/harnessScenarios.test.ts
+++ b/src/webviews/documentdb/localQuickStart/harnessScenarios.test.ts
@@ -1,0 +1,216 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * The PR #867 harness scenarios, expressed as **typed** fixtures.
+ *
+ * #867 declared these states as untyped object literals inside a hand-written
+ * HTML page, and named the risk against itself: fixtures drift into describing
+ * states the product can no longer produce. This file is the structural fix —
+ * the same states, checked against the production router at compile time.
+ *
+ * Two of #867's original fixtures would **not** compile today, which is the
+ * point rather than a footnote:
+ *
+ *   * `message` was a plain English sentence (`'Docker CLI was not found…'`).
+ *     It is now a {@link QuickStartMessage} — a localization key plus data — so
+ *     the harness would have kept rendering hard-coded English that the product
+ *     had stopped emitting.
+ *   * `StageEvent` never had the `error` field those fixtures set, and
+ *     `status.state` moved from a bare string to {@link InstanceState}.
+ *
+ * None of that is detectable by reading the harness, and none of it makes a
+ * screenshot look wrong. It is only caught by typing the fixtures.
+ */
+
+import { createFakeTransport, type Scenario } from '@microsoft/vscode-ext-webview/testing';
+import { connectTrpc, type VsCodeLinkResponseMessage } from '@microsoft/vscode-ext-webview/webview';
+import {
+    type DockerDiagnosedReadiness,
+    InstanceState,
+    QUICK_START_PORT,
+} from '../../../services/localQuickStart/quickStartTypes';
+import { type AppRouter } from '../../_integration/appRouter';
+
+type MessageListener = (event: MessageEvent) => void;
+const messageListeners = new Set<MessageListener>();
+
+function deliver(message: VsCodeLinkResponseMessage): void {
+    for (const listener of [...messageListeners]) {
+        listener({ data: message } as MessageEvent);
+    }
+}
+
+beforeEach(() => {
+    messageListeners.clear();
+    Object.assign(globalThis, {
+        window: {
+            addEventListener: (type: string, listener: MessageListener) => {
+                if (type === 'message') {
+                    messageListeners.add(listener);
+                }
+            },
+            removeEventListener: (_type: string, listener: MessageListener) => {
+                messageListeners.delete(listener);
+            },
+        },
+    });
+});
+
+afterEach(() => {
+    messageListeners.clear();
+    Reflect.deleteProperty(globalThis, 'window');
+});
+
+/** #867's `docker-missing-windows`: Windows host with no Docker CLI on PATH. */
+const cliMissingWindows: DockerDiagnosedReadiness = {
+    outcome: 'diagnosed',
+    environment: 'windows',
+    endpointKind: 'namedPipe',
+    provider: 'unknown',
+    providerEvidence: 'none',
+    executionTarget: 'local',
+    failureKind: 'cliMissing',
+    canContinueAnyway: false,
+    checkedAtMs: 1,
+    cliInstalled: false,
+    daemonReachable: false,
+};
+
+function connect(scenario: Scenario<AppRouter>) {
+    const transport = createFakeTransport<AppRouter>({ scenario, deliver });
+    const { client } = connectTrpc<AppRouter>(transport);
+    return { transport, client };
+}
+
+describe('Local Quick Start harness scenarios (typed)', () => {
+    it('reaches the "Docker missing" state with no Docker, no daemon and no container', async () => {
+        const { client } = connect({
+            'localQuickStart.getDockerStatus': {
+                result: {
+                    readiness: cliMissingWindows,
+                    status: { state: InstanceState.NotInstalled },
+                    busy: false,
+                    canReuseExistingData: false,
+                    suggestedPort: QUICK_START_PORT,
+                },
+            },
+        });
+
+        const status = await client.localQuickStart.getDockerStatus.query();
+
+        expect(status.readiness.outcome).toBe('diagnosed');
+        expect(status.readiness).toMatchObject({ failureKind: 'cliMissing', cliInstalled: false });
+    });
+
+    it('streams the full provisioning sequence to a successful finish', async () => {
+        // #867's `success` scenario. Each event is one subscription message, and the
+        // stream is closed by the transport exactly as the host closes it.
+        const { client } = connect({
+            'localQuickStart.startQuickStart': {
+                stream: [
+                    { stage: 'checking', status: 'done' },
+                    { stage: 'pulling', status: 'done' },
+                    { stage: 'creating', status: 'done' },
+                    { stage: 'starting', status: 'done' },
+                    { stage: 'waiting', status: 'done', boundPort: QUICK_START_PORT },
+                ],
+            },
+        });
+
+        const seen: string[] = [];
+        await new Promise<void>((resolve, reject) => {
+            client.localQuickStart.startQuickStart.subscribe(
+                {},
+                {
+                    onData: (event) => seen.push(`${event.stage}:${event.status}`),
+                    onComplete: () => resolve(),
+                    onError: (error) => reject(new Error(error.message)),
+                },
+            );
+        });
+
+        expect(seen).toEqual(['checking:done', 'pulling:done', 'creating:done', 'starting:done', 'waiting:done']);
+    });
+
+    it('reaches the "port already in use" failure without binding a port', async () => {
+        // #867's `failed-port-in-use`. Against a real daemon this needs a genuinely
+        // occupied socket; here it is one fixture, and the message is a localization
+        // key rather than the English sentence the original fixture hard-coded.
+        const { client } = connect({
+            'localQuickStart.startQuickStart': {
+                stream: [{ stage: 'checking', status: 'error', message: { key: 'portInUse', port: 12345 } }],
+            },
+        });
+
+        const seen: { stage: string; status: string; key?: string }[] = [];
+        await new Promise<void>((resolve, reject) => {
+            client.localQuickStart.startQuickStart.subscribe(
+                {},
+                {
+                    onData: (event) => seen.push({ stage: event.stage, status: event.status, key: event.message?.key }),
+                    onComplete: () => resolve(),
+                    onError: (error) => reject(new Error(error.message)),
+                },
+            );
+        });
+
+        expect(seen).toEqual([{ stage: 'checking', status: 'error', key: 'portInUse' }]);
+    });
+
+    it('reaches the readiness-timeout state, which leaves the container running', async () => {
+        // #867's `failed-timeout`. `timedOut` is what makes the panel offer
+        // "Wait longer" instead of a hard failure - an edge state that is
+        // essentially unreachable on demand against a real backend.
+        const { client } = connect({
+            'localQuickStart.startQuickStart': {
+                stream: [
+                    { stage: 'checking', status: 'done' },
+                    {
+                        stage: 'waiting',
+                        status: 'error',
+                        timedOut: true,
+                        message: { key: 'readinessTimeout', environment: 'windows' },
+                    },
+                ],
+            },
+        });
+
+        const terminal: { timedOut?: boolean; key?: string }[] = [];
+        await new Promise<void>((resolve, reject) => {
+            client.localQuickStart.startQuickStart.subscribe(
+                {},
+                {
+                    onData: (event) => {
+                        if (event.status === 'error') {
+                            terminal.push({ timedOut: event.timedOut, key: event.message?.key });
+                        }
+                    },
+                    onComplete: () => resolve(),
+                    onError: (error) => reject(new Error(error.message)),
+                },
+            );
+        });
+
+        expect(terminal).toEqual([{ timedOut: true, key: 'readinessTimeout' }]);
+    });
+
+    it('records the install-button call without leaving the page', async () => {
+        // The #867 assertion that motivated `window.__harnessCalls`: the Windows
+        // install button opens the Docker Desktop page. Asserted at the boundary
+        // the UI tries to cross, rather than by watching for a navigation.
+        const { transport, client } = connect({ 'common.openUrl': { result: true } });
+
+        await client.common.openUrl.mutate({ url: 'https://www.docker.com/products/docker-desktop/' });
+
+        expect(transport.callsTo('common.openUrl')).toEqual([
+            {
+                path: 'common.openUrl',
+                type: 'mutation',
+                input: { url: 'https://www.docker.com/products/docker-desktop/' },
+            },
+        ]);
+    });
+});

--- a/tsconfig.esm-readiness.json
+++ b/tsconfig.esm-readiness.json
@@ -1,0 +1,22 @@
+{
+  // ESM-readiness probe. NOT part of any build - `npm run esm:check` runs it.
+  //
+  // Bundlers (esbuild/Rollup, and Vite by extension) transpile one file at a time,
+  // so they cannot inline `const enum` values across a module boundary. Turning on
+  // `isolatedModules` rejects exactly the constructs that only `tsc`'s whole-program
+  // emit can support, which makes it a cheap, precise measure of how far the source
+  // is from being bundler-portable.
+  //
+  // It lives in its own file, rather than in tsconfig.json, because switching it on
+  // repo-wide is a decision for the modernization review (PR #880) - it would apply
+  // to every contributor and every open PR. This file lets that decision be made
+  // from a number instead of an estimate: run the script and read the error count.
+  //
+  // If the review adopts it, the change is to move `isolatedModules` into
+  // tsconfig.json and delete this file.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
> **RFC, not a merge request.** This is my Tuesday position on #880, with the evidence
> attached as running code. Everything here is scoped so that **nothing is decided by
> merging it** — see [What is your call, not mine](#what-is-your-call-not-mine).

Companion to **#880** (`build-and-test-stack.md` + `e2e-testing-strategy.md`). Based on
`release/0.10.0`, same as #880.

I agree with the verdict — **ESM + Vite + Vitest + Playwright**, with the packaged-VSIX check as
a hard precondition. I am not reopening either. What follows is the Wave 0 audit the research
defers, plus an answer to the one open question that is mine to answer.

---

## 1. The audit is smaller than the docs assume

The research lists a Wave 0 audit as work to be done before migrating ("four greps; each maps to
a documented breakage"). I ran it:

| Ref1 breakage class | Found | Notes |
| --- | --- | --- |
| `const enum` | **1** | `connectionStorageService.ts`, file-local, 22 uses. Now a plain `enum`. |
| `__dirname` / `__filename` / `require.resolve` | **3 in shipped source** | Everything else is build config or test code, which stays CommonJS. |
| Guarded requires (`try { require(x) } catch {}`) | **0** | — |
| `constructor.name` / `fn.name` | **4** | Not clean — see §3. |

**`isolatedModules` across the entire repo produces exactly one error**, a missing `export type`
in `extension.bundle.ts`. That is the headline: the ESM blocker surface is four files, not a
discovery project.

All three `__dirname` sites are the same pattern — *resolve a file shipped beside the bundle*:

- `WorkerSessionManager.ts` — spawns `playgroundWorker.js`
- `tsPlugin/index.ts` — a TypeScript language-service plugin. **The TS server loads it with
  `require()`, so it stays CommonJS even after the extension host moves to ESM** — not migration
  work at all.
- `documentdb-js-shell-api-types/src/index.ts` — reads the shipped `.d.ts`

### Verify it yourself

```bash
npm run esm:check
```
```
ESM readiness report
Read-only. No build, lint or source file is modified by this command.

  PASS  isolatedModules type-check
  PASS  ESM source guards (const enum, __dirname)

  Source is ESM-ready.
```

**This enforces nothing.** The checks live in `tsconfig.esm-readiness.json` and
`eslint.esm-readiness.config.mjs`; `tsconfig.json` and `eslint.config.mjs` are byte-identical to
`release/0.10.0`. No contributor's build or lint changes, and no open PR can start failing
because of this branch.

---

## 2. My answer on #867: **Option B**

`e2e-testing-strategy.md` §4.3 offers three vehicles. I take **B** (typed transport + one
runner), and the cost is lower than the doc estimates.

The doc prices the fake transport at **Complexity M** and calls it one of "two things neither
project has… the honest cost". **The seam already existed:** `connectTrpc(vscodeApi:
VsCodeApiLike)` takes a one-method interface and its own JSDoc says *"or anything with a
compatible `postMessage`"*. The package also already ships `MockWebviewPanel` for the host side.

So I finished it — `@microsoft/vscode-ext-webview/testing` → `createFakeTransport`. Scenarios are
**typed against the router**: an unknown procedure path or a wrong result shape is a compile
error.

### The evidence: two of my own #867 fixtures no longer compile

I ported five #867 scenarios — `docker-missing-windows`, `success`, `failed-port-in-use`,
`failed-timeout`, and the install-button assertion. They run in **under two seconds**, no Docker,
no container, no extension host.

- `message` was a plain English sentence (`'Docker CLI was not found…'`). It is now a
  `QuickStartMessage` — a **localization key** plus data. The harness would have gone on
  rendering hard-coded English the product had stopped emitting.
- `StageEvent` never had the `error` field those fixtures set, and `status.state` moved from a
  bare string to the `InstanceState` enum.

A third turned up while rebasing: `common.openUrl` returns `boolean` here, not `void`.

**Three real drifts, none visible in a screenshot.** That is exactly the failure #867 documents
against itself, converted from a review discipline into a compile error.

Two wire-protocol details the types caught, not a reviewer:

1. The host posts `result ?? null` because structured-clone strips `undefined` — **without it
   every void mutation hangs forever.** Regression test added.
2. `inferProcedureOutput` reports a subscription's output as `AsyncIterable<T>`, not `T`.

---

## 3. One risk the research does not mention: `keepNames`

Four `constructor.name` sites — three feed telemetry (`errorKind` / `errorType`), one is
`providerName`, which *returns* the class name as an identity.

- `webpack.config.ext.js` protects them with an explicit `keep_classnames` / `keep_fnames`,
  carrying a TODO that says "code should not rely on function names".
- **`webpack.config.views.js` has no minifier configuration at all.**
- **esbuild/Rollup do not preserve names by default.**

So the Vite config must carry `keepNames: true` from day one, or telemetry silently degrades to
mangled identifiers **in production only** — invisible in F5 and in every unit test.

---

## 4. A correction to myself

I first read `main` and drafted a claim that the webview surface is two, not four. On
`release/0.10.0` `WebviewRegistry` has **four** (`collectionView`, `documentView`,
`localQuickStart`, `atlasCredentials`). **The docs are right; I was reading the wrong branch.**

---

## What is your call, not mine

1. **Whether to enforce the ESM checks repo-wide.** If yes: `isolatedModules` moves into
   `tsconfig.json`, the two rules move into `eslint.config.mjs`, and three files get deleted.
   That is written in each file's header. If no, the report still stands as evidence.
2. **The `./testing` subpath is new public API on a released package.** I bumped to `0.11.0` and
   documented it in the README, following the existing release pattern — but say the word and it
   goes back to being internal.
3. **Engine floor**, per `build-and-test-stack.md`. We are at `^1.105.0`; the Azure Tools guide
   puts the only hard floor at VS Code 1.101.0, so I read this as a check rather than a blocker.

---

## Commits

Independent and separately revertable, deliberately.

| Commit | Type | Scope |
| --- | --- | --- |
| `d54aedfb` | `chore:` | Opt-in ESM-readiness report + the two safe source fixes |
| `8dee657d` | `feat(webview):` | `./testing` entry point, v0.11.0, README |
| `0d6f8a01` | `test:` | Five #867 scenarios as typed fixtures |

## Verification

| Check | Result |
| --- | --- |
| `npm run lint` | Pass |
| `npx jest --no-coverage` | **222 suites / 3527 tests** |
| `npm run build` | Pass |
| `npm run esm:check` | Pass |
| `npm run l10n` | No string changes |

## What I did not do

- **The Vite/ESM migration.** Multi-week, and the research is explicit that the VSIX check comes
  first.
- **Phase 0a, the installed-VSIX activation tripwire.** The #1 shortlist item, and the honest gap
  here. It needs packaging, a VS Code CLI download, a temp extensions dir and CI wiring —
  its own PR. Happy to take it next.
- **The §4.5 mutation-check script.** It belongs with the Option B port, as that port's
  acceptance test.
