### PR TITLE
Fix: Document View stuck on loading placeholder due to Monaco mount race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - **Collection View Import and Export**: Fixes import and export resolution for Atlas Discovery and DocumentDB Local collections, reports resolution failures with a Show Output action, and replaces the destructive credentials-missing tree action with a guided review step. [#871](https://github.com/microsoft/vscode-documentdb/pull/871)
 - **Single-Click Collection View**: Based on user requests, restores opening the Collection View with one click on the Documents tree item. [#889](https://github.com/microsoft/vscode-documentdb/pull/889)
+- **Document View Stuck on Loading**: Fixes a race condition where the Document View editor could stay on its loading placeholder forever if the document finished loading before Monaco mounted, most noticeable against fast local backends. [#891](https://github.com/microsoft/vscode-documentdb/pull/891)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 - **Collection View Import and Export**: Fixes import and export resolution for Atlas Discovery and DocumentDB Local collections, reports resolution failures with a Show Output action, and replaces the destructive credentials-missing tree action with a guided review step. [#871](https://github.com/microsoft/vscode-documentdb/pull/871)
 - **Single-Click Collection View**: Based on user requests, restores opening the Collection View with one click on the Documents tree item. [#889](https://github.com/microsoft/vscode-documentdb/pull/889)
-- **Document View Stuck on Loading**: Fixes a race condition where the Document View editor could stay on its loading placeholder forever if the document finished loading before Monaco mounted, most noticeable against fast local backends. [#891](https://github.com/microsoft/vscode-documentdb/pull/891)
+- **Document View Stuck on Loading**: Fixes a race condition where the Document View editor could stay on its loading placeholder forever if the document finished loading before Monaco mounted, most noticeable against fast local backends. Also disables Save and Reload while a document is loading, saving, or refreshing. [#891](https://github.com/microsoft/vscode-documentdb/pull/891)
 
 ### Security
 

--- a/src/webviews/documentdb/documentView/components/toolbarDocuments.tsx
+++ b/src/webviews/documentdb/documentView/components/toolbarDocuments.tsx
@@ -11,6 +11,7 @@ import { ToolbarDividerTransparent } from '../../collectionView/components/toolb
 
 interface ToolbarDocumentsProps {
     disableSaveButton: boolean;
+    disableRefreshButton: boolean;
     onValidateRequest: () => void;
     onRefreshRequest: () => void;
     onSaveRequest: () => void;
@@ -21,6 +22,7 @@ interface ToolbarDocumentsProps {
 
 export const ToolbarDocuments = ({
     disableSaveButton,
+    disableRefreshButton,
     onValidateRequest,
     onRefreshRequest,
     onSaveRequest,
@@ -59,6 +61,7 @@ export const ToolbarDocuments = ({
                     onClick={onRefreshRequest}
                     aria-label={l10n.t('Reload document from the database')}
                     icon={<ArrowClockwiseRegular />}
+                    disabled={disableRefreshButton}
                 >
                     {l10n.t('Reload')}
                 </ToolbarButton>

--- a/src/webviews/documentdb/documentView/documentView.tsx
+++ b/src/webviews/documentdb/documentView/documentView.tsx
@@ -61,8 +61,18 @@ export const DocumentView = (): JSX.Element => {
     const saveButtonRef = useRef<HTMLButtonElement>(null);
 
     const editorRef = useRef<monacoEditor.editor.IStandaloneCodeEditor | null>(null);
+    // Monaco can mount after the initial document fetch resolves (e.g. fast local emulator
+    // responses beat Monaco's async module load), so we stash the value here and flush it
+    // in handleMonacoEditorMount instead of silently dropping it.
+    const pendingContentRef = useRef<string | null>(null);
     const getCurrentContent = () => editorRef.current?.getValue() || '';
-    const setContent = (newValue: string) => editorRef.current?.setValue(newValue);
+    const setContent = (newValue: string) => {
+        if (editorRef.current) {
+            editorRef.current.setValue(newValue);
+        } else {
+            pendingContentRef.current = newValue;
+        }
+    };
 
     useSelectiveContextMenuPrevention();
 
@@ -106,6 +116,12 @@ export const DocumentView = (): JSX.Element => {
     ) => {
         // Store the editor instance in ref
         editorRef.current = editor;
+
+        // Flush any content that arrived before the editor finished mounting
+        if (pendingContentRef.current !== null) {
+            editor.setValue(pendingContentRef.current);
+            pendingContentRef.current = null;
+        }
 
         handleResize();
 

--- a/src/webviews/documentdb/documentView/documentView.tsx
+++ b/src/webviews/documentdb/documentView/documentView.tsx
@@ -65,7 +65,9 @@ export const DocumentView = (): JSX.Element => {
     // responses beat Monaco's async module load), so we stash the value here and flush it
     // in handleMonacoEditorMount instead of silently dropping it.
     const pendingContentRef = useRef<string | null>(null);
-    const getCurrentContent = () => editorRef.current?.getValue() || '';
+    // Falls back to pending/initial content if called before Monaco has mounted,
+    // so callers (e.g. Save) never operate on an empty string.
+    const getCurrentContent = () => editorRef.current?.getValue() ?? pendingContentRef.current ?? editorContent;
     const setContent = (newValue: string) => {
         if (editorRef.current) {
             editorRef.current.setValue(newValue);
@@ -291,7 +293,8 @@ export const DocumentView = (): JSX.Element => {
             <div className="toolbarContainer">
                 {isLoading && <ProgressBar thickness="large" shape="square" className="progressBar" />}
                 <ToolbarDocuments
-                    disableSaveButton={configuration.mode === 'view' || !isDirty}
+                    disableSaveButton={configuration.mode === 'view' || !isDirty || isLoading}
+                    disableRefreshButton={isLoading}
                     onSaveRequest={handleOnSaveRequest}
                     onValidateRequest={handleOnValidateRequest}
                     onRefreshRequest={handleOnRefreshRequest}


### PR DESCRIPTION
## Summary

Fixes a race condition in the Document View where the Monaco editor could get stuck showing the `{ "loading…": true }` placeholder indefinitely, even though the document had already been fetched successfully.

## Root Cause

In [`documentView.tsx`](src/webviews/documentdb/documentView/documentView.tsx), the initial `useEffect` fetches the document via `getDocumentById` and applies the result by calling `editorRef.current?.setValue(newValue)`. However, `editorRef.current` is only populated once Monaco's own `onMount` callback fires, which happens asynchronously and independently of the fetch.

If the tRPC round-trip resolves *before* Monaco finishes mounting, `editorRef.current` is still `null`, so `setValue()` silently no-ops and the fetched content is discarded. The editor is then stuck showing the loading placeholder forever, since nothing re-triggers the render with the fetched value. Clicking **Refresh** appears to "fix" it only because by then Monaco has long since mounted.

This is most reproducible against fast local backends (e.g. the DocumentDB Local emulator), where the round-trip is quick enough to consistently beat Monaco's async initialization. It's less likely (but not impossible) against a remote server with higher latency, which is why it may not have been caught during testing against those endpoints.

## Fix

Cache content passed to `setContent()` before the editor has mounted in a `pendingContentRef`, and flush it in `handleMonacoEditorMount` once the editor instance is available. This guarantees the fetched (or refreshed/saved) content is never silently dropped, regardless of timing between the tRPC response and Monaco's mount.

## Testing

- Verified locally against a DocumentDB Local emulator instance, where the issue was consistently reproducible before the fix and no longer occurs after.

## Notes

This is a pre-release fix targeted for inclusion in the 0.10.0 release.
