### PR TITLE
docs: release notes and version bump for v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 0.10.1
+
+### Improvements
+
+- **Deep Links to DocumentDB Local Setup**: `vscode://` links can now open the DocumentDB Local setup wizard directly instead of only carrying a connection string, with clearer connection confirmations and actionable errors for malformed links. [#898](https://github.com/microsoft/vscode-documentdb/pull/898)
+- **Development Workflow**: Restructures the AI-assisted feature documentation into per-feature folders, rewrites the release process guidance, and adds a `prepare-pull-request` skill for contributors readying a PR for review. [#892](https://github.com/microsoft/vscode-documentdb/pull/892)
+
+### Security
+
+- **Dependency Updates**: Updates `brace-expansion` to 1.1.18 and `JamesIves/github-pages-deploy-action` from 4.8.0 to 4.9.0. [#896](https://github.com/microsoft/vscode-documentdb/pull/896), [#893](https://github.com/microsoft/vscode-documentdb/pull/893)
+
 ## 0.10.0
 
 ### New Features

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ The User Manual provides guidance on using DocumentDB for VS Code. It contains d
 
 Explore the history of updates and improvements to the DocumentDB for VS Code extension. Each release brings new features, enhancements, and fixes to improve your experience.
 
-- [0.10](./release-notes/0.10)
+- [0.10](./release-notes/0.10), [0.10.1](./release-notes/0.10#patch-release-v0101)
 - [0.9](./release-notes/0.9), [0.9.1](./release-notes/0.9#patch-release-v091), [0.9.2](./release-notes/0.9#patch-release-v092)
 - [0.8](./release-notes/0.8), [0.8.1](./release-notes/0.8#patch-release-v081)
 - [0.7](./release-notes/0.7), [0.7.2](./release-notes/0.7#patch-release-v072), [0.7.3](./release-notes/0.7#patch-release-v073), [0.7.4](./release-notes/0.7#patch-release-v074)

--- a/docs/release-notes/0.10.md
+++ b/docs/release-notes/0.10.md
@@ -129,3 +129,26 @@ Pre-release refinements: [#836](https://github.com/microsoft/vscode-documentdb/p
 
 See the full changelog entry for this release:
 ➡️ [CHANGELOG.md#0100](https://github.com/microsoft/vscode-documentdb/blob/main/CHANGELOG.md#0100)
+
+---
+
+## Patch Release v0.10.1
+
+This patch release lets deep links open the DocumentDB Local setup wizard directly, and updates a couple of dependencies.
+
+### What's Changed in v0.10.1
+
+#### 💠 **Deep Links Can Open Local Setup Directly** ([#898](https://github.com/microsoft/vscode-documentdb/pull/898))
+
+A `vscode://` link previously could only carry a connection string. It can now name what it wants: `vscode://ms-azuretools.vscode-documentdb/local` (or `/local/documentdb`) opens the DocumentDB Local setup wizard directly, so a documentation page or quick-start guide can send you straight into provisioning a local instance instead of a generic connection prompt.
+
+Existing connection links keep working exactly as before, and their confirmation dialog now spells out the sanitized connection target plus any database and collection on separate lines, making it easier to see exactly what you are about to connect to. Malformed or unsupported links now surface a plain, actionable error instead of an internal URI prefix.
+
+#### 💠 **Dependency Updates** ([#896](https://github.com/microsoft/vscode-documentdb/pull/896), [#893](https://github.com/microsoft/vscode-documentdb/pull/893))
+
+Updates `brace-expansion` to 1.1.18 and `JamesIves/github-pages-deploy-action` from 4.8.0 to 4.9.0.
+
+### Changelog
+
+See the full changelog entry for this release:
+➡️ [CHANGELOG.md#0101](https://github.com/microsoft/vscode-documentdb/blob/main/CHANGELOG.md#0101)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-documentdb",
-  "version": "0.10.1-alpha",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-documentdb",
-      "version": "0.10.1-alpha",
+      "version": "0.10.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-documentdb",
-  "version": "0.10.1-alpha",
+  "version": "0.10.1",
   "releaseNotesUrl": "https://github.com/microsoft/vscode-documentdb/discussions/890",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "publisher": "ms-azuretools",


### PR DESCRIPTION
## What changed

Adds the `0.10.1` changelog section, appends the patch release notes to `docs/release-notes/0.10.md`, updates `docs/index.md` with the new patch link, and bumps the package version from `0.10.1-alpha` to `0.10.1`.

## Why

Prepares the `release/0.10.1` branch for release, documenting the changes merged under the 0.10.1 milestone (#898, #896, #893, #892).