### PR TITLE
Fix local Quick Start demo loading with DocumentDB 0.116

### DIFF
--- a/docs/ai-and-plans/features/local-quickstart/README.md
+++ b/docs/ai-and-plans/features/local-quickstart/README.md
@@ -60,11 +60,6 @@ regular new-connection wizard instead ([0001](./decisions.md#0001--single-manage
   is a Docker CLI that can reach a Linux-container daemon from the extension host.
 - **Collision safety is non-negotiable.** A pre-existing container holding a planned name or port is
   never recreated over. Ours gets re-adopted; anything else is rejected with an inline error.
-- **Sample data loads after readiness.** When requested and `sampledb` is absent, setup waits for
-  the image's bundled init script to finish before reporting Running. Image 0.116 removed the
-  script's password argument; Quick Start supplies `DOCUMENTDB_PASSWORD` inside the container
-  instead, using the legacy argument only when the script's help identifies the older interface.
-  See [design §8.4](./design.md#84-container-initialization-and-seed-data).
 
 ## Timeline
 

--- a/docs/ai-and-plans/features/local-quickstart/README.md
+++ b/docs/ai-and-plans/features/local-quickstart/README.md
@@ -60,6 +60,11 @@ regular new-connection wizard instead ([0001](./decisions.md#0001--single-manage
   is a Docker CLI that can reach a Linux-container daemon from the extension host.
 - **Collision safety is non-negotiable.** A pre-existing container holding a planned name or port is
   never recreated over. Ours gets re-adopted; anything else is rejected with an inline error.
+- **Sample data loads after readiness.** When requested and `sampledb` is absent, setup waits for
+  the image's bundled init script to finish before reporting Running. Image 0.116 removed the
+  script's password argument; Quick Start supplies `DOCUMENTDB_PASSWORD` inside the container
+  instead, using the legacy argument only when the script's help identifies the older interface.
+  See [design §8.4](./design.md#84-container-initialization-and-seed-data).
 
 ## Timeline
 

--- a/docs/ai-and-plans/features/local-quickstart/design.md
+++ b/docs/ai-and-plans/features/local-quickstart/design.md
@@ -544,28 +544,32 @@ truth.
 
 ### 8.4 Container initialization and seed data
 
-Initialization uses the container image's **standard init-script
-convention**, not a bespoke VS Code mechanism. This keeps the behavior
-portable (it works identically when the user runs the image by hand) and
-testable outside the extension.
+Quick Start uses the image's bundled `init_documentdb_data.sh` and
+`sample-data` directory. It runs the script through `docker exec` after the
+authenticated wire-protocol readiness probe succeeds, and waits for it
+before marking setup complete.
 
-- On create, Quick Start mounts a host directory into the image's
-  documented init directory. Scripts placed there run once, the first time
-  the data volume is initialized.
-- **Seed sample data** (the Advanced toggle and the success-card button)
-  simply drops a known, bundled init script into that directory before the
-  first start. It is therefore the same mechanism as user init scripts, not
-  a special path.
-- **Init-script development.** The Advanced panel lets the user point at a
-  local scripts folder, which is mounted into the init directory. Editing a
-  script and resetting the data volume re-runs it, so users can iterate on
-  their own initialization without leaving VS Code.
+- **Seed sample data** is enabled by default and can be disabled in
+  Configure. Seeding is skipped when `sampledb` already exists, so a
+  recreate does not overwrite existing data.
+- The script connects to the container's internal port `10260`, independent
+  of the host port selected in Configure.
+- Image `0.116.0` removed the script's `-p` / `--password` argument.
+  Quick Start passes `DOCUMENTDB_PASSWORD="$PASSWORD"` in the container's
+  shell instead. The value comes from the credentials supplied at creation
+  through `--env-file`; it is not placed on the host command line.
+- Quick Start detects environment-password support from the script's
+  `--help` output. Older image-tag overrides retain the legacy `-p`
+  invocation. A failed help command stops seeding; an initialization
+  failure is never retried with another password interface.
+- Quick Start does not set `--init-data true` on the container. Older image
+  versions rerun that flag on restart and fail on duplicate sample keys.
+  Post-readiness seeding keeps those restarts safe.
+- A seed failure is logged in **DocumentDB Local Setup** and remains
+  non-fatal: the ready database can still be used without sample data.
 
-Because init scripts run only on first volume initialization, re-running
-them requires a **Reset** (drops the data volume, §11), never a plain
-restart. Seed and init scripts must never embed the generated password;
-they receive credentials through the same `--env-file` the container uses
-(§8.2).
+The previously described custom init-folder mounting and separate
+success-card load action are not implemented by Quick Start.
 
 ---
 

--- a/src/services/localQuickStart/ContainerRuntime.ts
+++ b/src/services/localQuickStart/ContainerRuntime.ts
@@ -270,7 +270,7 @@ class ContainerRuntimeImpl implements IContainerRuntime {
      * Run a `/bin/sh -c <script>` command inside a running container (`docker exec`).
      * Used to seed the image's built-in sample data via its native init script — see
      * {@link QuickStartService} — instead of baking `--init-data true` into the run args
-     * (which re-runs on every restart and crashes the container).
+     * (which re-runs on every restart and crashes older images).
      *
      * The script is passed as a single STRONG-quoted argument (single quotes on bash,
      * double quotes on cmd) so the host shell the command runner spawns through does NOT

--- a/src/services/localQuickStart/QuickStartProvisionDurability.test.ts
+++ b/src/services/localQuickStart/QuickStartProvisionDurability.test.ts
@@ -47,8 +47,7 @@ jest.mock('mongodb', () => ({
             return {
                 command: () => Promise.resolve({ ok: 1 }),
                 admin: () => ({
-                    listDatabases: () =>
-                        Promise.resolve({ databases: existingDatabases.map((name) => ({ name })) }),
+                    listDatabases: () => Promise.resolve({ databases: existingDatabases.map((name) => ({ name })) }),
                 }),
             };
         }

--- a/src/services/localQuickStart/QuickStartProvisionDurability.test.ts
+++ b/src/services/localQuickStart/QuickStartProvisionDurability.test.ts
@@ -34,6 +34,7 @@ import {
 
 /** Called on every readiness/sample-data probe, so a test can observe the world mid-provision. */
 let onProbe: () => void | Promise<void> = () => undefined;
+let existingDatabases: string[] = ['sampledb'];
 
 jest.mock('mongodb', () => ({
     MongoClient: class {
@@ -45,7 +46,10 @@ jest.mock('mongodb', () => ({
         public db(): unknown {
             return {
                 command: () => Promise.resolve({ ok: 1 }),
-                admin: () => ({ listDatabases: () => Promise.resolve({ databases: [{ name: 'sampledb' }] }) }),
+                admin: () => ({
+                    listDatabases: () =>
+                        Promise.resolve({ databases: existingDatabases.map((name) => ({ name })) }),
+                }),
             };
         }
         public close(): Promise<void> {
@@ -189,6 +193,7 @@ describe('QuickStartService — WP-3 provisioning durability and port model', ()
         ext.secretStorage = secretStorage;
         ext.context = fakeContext(globalState);
         onProbe = () => undefined;
+        existingDatabases = ['sampledb'];
     });
 
     afterEach(() => {
@@ -368,6 +373,88 @@ describe('QuickStartService — WP-3 provisioning durability and port model', ()
         await collect(service.provision(new AbortController().signal, { port: 10333 }));
 
         expect((createAndRunContainer.mock.calls[0][0] as { hostPort: number }).hostPort).toBe(10333);
+    });
+
+    describe('sample data initialization', () => {
+        it('detects environment-based passwords for 0.116 while preserving older image tags', async () => {
+            existingDatabases = [];
+            const runtime = runtimeFor();
+            const service = new QuickStartServiceImpl(runtime);
+
+            const events = await collect(service.provision(new AbortController().signal, { port: 10333 }));
+
+            expect(runtime.execShellInContainer).toHaveBeenCalledWith(
+                'c1',
+                'init_help="$(/home/documentdb/gateway/scripts/init_documentdb_data.sh --help)" || exit $?; ' +
+                    'case "$init_help" in ' +
+                    '*DOCUMENTDB_PASSWORD*) DOCUMENTDB_PASSWORD="$PASSWORD" /home/documentdb/gateway/scripts/init_documentdb_data.sh -H localhost -P 10260 -u "$USERNAME" -d /home/documentdb/gateway/sample-data ;; ' +
+                    '*) /home/documentdb/gateway/scripts/init_documentdb_data.sh -H localhost -P 10260 -u "$USERNAME" -d /home/documentdb/gateway/sample-data -p "$PASSWORD" ;; ' +
+                    'esac',
+                expect.any(Array),
+                expect.anything(),
+            );
+            expect(events.at(-1)).toMatchObject({ stage: 'done', status: 'done' });
+        });
+
+        it('finishes loading sample data before reporting the instance as running', async () => {
+            existingDatabases = [];
+            const runtime = runtimeFor();
+            const service = new QuickStartServiceImpl(runtime);
+            let seeded = false;
+            jest.spyOn(runtime, 'execShellInContainer').mockImplementation(async () => {
+                await Promise.resolve();
+                expect(service.getStatus().state).not.toBe(InstanceState.Running);
+                seeded = true;
+            });
+
+            for await (const event of service.provision(new AbortController().signal)) {
+                if (event.stage === 'done') {
+                    expect(seeded).toBe(true);
+                }
+            }
+
+            expect(seeded).toBe(true);
+            expect(service.getStatus().state).toBe(InstanceState.Running);
+            expect(runtime.createAndRunContainer).toHaveBeenCalledWith(
+                expect.not.objectContaining({ command: expect.anything() }),
+                expect.any(Array),
+                expect.anything(),
+            );
+        });
+
+        it('does not load sample data when the user disables it', async () => {
+            existingDatabases = [];
+            const runtime = runtimeFor();
+            const service = new QuickStartServiceImpl(runtime);
+
+            await collect(service.provision(new AbortController().signal, { loadSampleData: false }));
+
+            expect(runtime.execShellInContainer).not.toHaveBeenCalled();
+            expect(service.getStatus().state).toBe(InstanceState.Running);
+        });
+
+        it('does not overwrite an existing sample database', async () => {
+            const runtime = runtimeFor();
+            const service = new QuickStartServiceImpl(runtime);
+
+            await collect(service.provision(new AbortController().signal));
+
+            expect(runtime.execShellInContainer).not.toHaveBeenCalled();
+            expect(service.getStatus().state).toBe(InstanceState.Running);
+        });
+
+        it('keeps the database usable without retrying a failed sample load', async () => {
+            existingDatabases = [];
+            const runtime = runtimeFor();
+            jest.spyOn(runtime, 'execShellInContainer').mockRejectedValue(new Error('initialization failed'));
+            const service = new QuickStartServiceImpl(runtime);
+
+            const events = await collect(service.provision(new AbortController().signal));
+
+            expect(runtime.execShellInContainer).toHaveBeenCalledTimes(1);
+            expect(events.at(-1)).toMatchObject({ stage: 'done', status: 'done' });
+            expect(service.getStatus().state).toBe(InstanceState.Running);
+        });
     });
 
     // M5/3b: the port is pre-checked before the pull, which can take minutes — so a bind failure at

--- a/src/services/localQuickStart/QuickStartService.ts
+++ b/src/services/localQuickStart/QuickStartService.ts
@@ -115,8 +115,8 @@ const PROBE_SERVER_SELECTION_TIMEOUT_MS = 3_000;
  * The image ships a native init script + sample-data directory (see
  * `Dockerfile_documentdb_local`). We run that script ONCE via `docker exec` after
  * the gateway is ready, instead of baking `--init-data true` into the run args:
- * the baked flag re-runs the init on every Stop/Start, hits a duplicate-key error,
- * and crashes the container (`set -e`). Exec-once keeps restarts safe while loading
+ * older images re-run the baked flag on every Stop/Start, hit a duplicate-key error,
+ * and crash the container (`set -e`). Exec-once keeps restarts safe while loading
  * the same `sampledb` (users/products/orders/analytics). `-P` is the container's
  * internal gateway port (always {@link QUICK_START_PORT} inside the container,
  * independent of the bound host port).
@@ -786,8 +786,8 @@ export class QuickStartServiceImpl {
                         volumeName: volumeName(alias),
                         dataPath: QUICK_START_DATA_PATH,
                         // Credentials via env-file (§8.2), not CLI args. We also do NOT bake
-                        // `--init-data true`: it re-runs the sample-data init on every
-                        // Stop/Start and crashes on duplicate keys; sample data is seeded
+                        // `--init-data true`: older images re-run it on every
+                        // Stop/Start and crash on duplicate keys; sample data is seeded
                         // once, post-readiness, via `docker exec` (see seedSampleData).
                         environmentFiles: [createdEnvFilePath],
                     },
@@ -1259,7 +1259,9 @@ export class QuickStartServiceImpl {
      * `%VAR%`). {@link ContainerRuntime.execShellInContainer} strong-quotes the script so
      * the host shell passes the `$VAR` references through verbatim and the container's own
      * shell performs the expansion. The interpolated values are all constants — no user
-     * input reaches the script.
+     * input reaches the script. Image 0.116 requires `DOCUMENTDB_PASSWORD` instead of
+     * `-p`. Detect that capability from --help so older image-tag overrides still work,
+     * without retrying a failed initialization that may already have modified data.
      */
     private async seedSampleData(
         containerId: string,
@@ -1267,7 +1269,13 @@ export class QuickStartServiceImpl {
         token: vscode.CancellationToken,
     ): Promise<void> {
         try {
-            const script = `${SAMPLE_DATA_INIT_SCRIPT} -H localhost -P ${QUICK_START_PORT} -u "$USERNAME" -p "$PASSWORD" -d ${SAMPLE_DATA_DIR}`;
+            const initCommand = `${SAMPLE_DATA_INIT_SCRIPT} -H localhost -P ${QUICK_START_PORT} -u "$USERNAME" -d ${SAMPLE_DATA_DIR}`;
+            const script =
+                `init_help="$(${SAMPLE_DATA_INIT_SCRIPT} --help)" || exit $?; ` +
+                `case "$init_help" in ` +
+                `*DOCUMENTDB_PASSWORD*) DOCUMENTDB_PASSWORD="$PASSWORD" ${initCommand} ;; ` +
+                `*) ${initCommand} -p "$PASSWORD" ;; ` +
+                `esac`;
             await this.runtime.execShellInContainer(containerId, script, secrets, token);
         } catch (error) {
             getQuickStartOutputChannel().appendLine(`Sample data load skipped: ${errMessage(error)}`);


### PR DESCRIPTION
## Summary

Restore demo-data loading when creating a local DocumentDB instance with Quick Start.

DocumentDB `v0.116-0` removed the init script's `-p` / `--password` argument and requires `DOCUMENTDB_PASSWORD` instead. Quick Start still passed `-p`, so the container started successfully but sample loading failed and was logged as skipped.

The fix detects the supported password interface from the script's `--help` output. It uses the environment variable on 0.116 and retains the legacy argument for older image tags. A failed initialization is not retried with another interface.

**Target release:** 0.10.2.

## Scope

- Keep loading after authenticated readiness and before setup completes.
- Preserve the sample-data opt-out, existing `sampledb`, restart behavior, and non-fatal handling of seed failures.
- Add regression coverage and correct the related feature documentation.
- No image-version pinning, container-path changes, or VS Code UI changes. Keep post-readiness loading rather than enabling `--init-data true`, which is unsafe on older images during restart.

## Validation

- `npm run build`
- `npx jest --no-coverage src/services/localQuickStart/QuickStartProvisionDurability.test.ts src/services/localQuickStart/QuickStartService.test.ts` — 76 tests passed.
- Real local Docker/database runs on official 0.116.0 and 0.114.0 images: reproduced the incompatible password interfaces, then loaded all 16 demo documents with the fixed command.
- Stop/start preserved the demo data and an additional user document. The 0.116 run also covered password shell metacharacters.
- The full VS Code UI flow was not exercised. Before requesting review, run the repository's ready-for-review checks and AI pre-review, then create a fresh instance through Quick Start and confirm the sample collections appear.

## References

- [Upstream password-interface change](https://github.com/documentdb/documentdb/commit/b186adcc5d73d78c7adf930639fe85ffea71df6f)
- [Init script at v0.116-0](https://github.com/documentdb/documentdb/blob/v0.116-0/documentdb-local/scripts/init_documentdb_data.sh#L97-L127)
- [Local Quick Start feature notes](https://github.com/microsoft/vscode-documentdb/blob/main/docs/ai-and-plans/features/local-quickstart/README.md)
