### PR TITLE
chore: prepare 0.10.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@
 
 ### Security
 
-- **Dependency Security Updates**: Updates `fast-uri` in the extension and API package to 3.1.7, `postcss-selector-parser` to 7.1.6, `browserslist` to 4.28.9, and `fflate` to 0.8.3, addressing URI, selector parsing, browser query, and archive handling vulnerabilities. [#903](https://github.com/microsoft/vscode-documentdb/pull/903), [#902](https://github.com/microsoft/vscode-documentdb/pull/902), [#900](https://github.com/microsoft/vscode-documentdb/pull/900), [#908](https://github.com/microsoft/vscode-documentdb/pull/908), [#906](https://github.com/microsoft/vscode-documentdb/pull/906)
-- **Connection Dependency Updates**: Updates `ip-address` to 10.7.0 and `@mongodb-js/devtools-proxy-support` to 0.7.21. [#911](https://github.com/microsoft/vscode-documentdb/pull/911)
+- **Dependency Security Updates**: Updates `fast-uri` in the extension and API package to 3.1.7, `postcss-selector-parser` to 7.1.6, and `fflate` to 0.8.3, addressing URI, selector parsing, and archive handling vulnerabilities. [#903](https://github.com/microsoft/vscode-documentdb/pull/903), [#902](https://github.com/microsoft/vscode-documentdb/pull/902), [#900](https://github.com/microsoft/vscode-documentdb/pull/900), [#906](https://github.com/microsoft/vscode-documentdb/pull/906)
 
 ## 0.10.1
 

--- a/docs/release-notes/0.10.md
+++ b/docs/release-notes/0.10.md
@@ -165,9 +165,9 @@ This patch release restores DocumentDB Local demo-data loading and delivers depe
 
 DocumentDB Local Quick Start now reliably loads sample data with DocumentDB 0.116 and later while preserving compatibility with earlier images, so a new local instance is ready to explore with the included demo collections.
 
-#### 💠 **Dependency Security and Reliability Updates** ([#903](https://github.com/microsoft/vscode-documentdb/pull/903), [#902](https://github.com/microsoft/vscode-documentdb/pull/902), [#900](https://github.com/microsoft/vscode-documentdb/pull/900), [#908](https://github.com/microsoft/vscode-documentdb/pull/908), [#906](https://github.com/microsoft/vscode-documentdb/pull/906), [#911](https://github.com/microsoft/vscode-documentdb/pull/911))
+#### 💠 **Dependency Security and Reliability Updates** ([#903](https://github.com/microsoft/vscode-documentdb/pull/903), [#902](https://github.com/microsoft/vscode-documentdb/pull/902), [#900](https://github.com/microsoft/vscode-documentdb/pull/900), [#906](https://github.com/microsoft/vscode-documentdb/pull/906))
 
-This release updates URI parsing, selector parsing, browser query, archive handling, IP address, and connection proxy dependencies. These updates address reported vulnerabilities in several dependencies and improve the extension's underlying reliability.
+This release updates URI parsing, selector parsing, and archive handling dependencies. These updates address reported vulnerabilities in several dependencies and improve the extension's underlying reliability.
 
 ### Changelog
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5512,17 +5512,17 @@
       }
     },
     "node_modules/@mongodb-js/devtools-proxy-support": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.7.21.tgz",
-      "integrity": "sha512-dNYh0xL0rqmyDi2hqg5qY0Rv/HpWDjiQX80pmS3+f8EWFHzNU4bMuC1Np1LGFjhcyeCZ0LYkAdQGwtk50vKyLQ==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.7.10.tgz",
+      "integrity": "sha512-MQwH8vL0oXSxdyJZJ36xqO7eRCh23gij3nwghSLrNvmxy/OfEsm0OuS7sjVGQQNRBxGJR+g7SdvleBN+kSBV8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/socksv5": "^0.0.11",
+        "@mongodb-js/socksv5": "^0.0.10",
         "agent-base": "^7.1.1",
         "debug": "^4.4.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
-        "lru-cache": "^11.3.5",
+        "lru-cache": "^11.3.3",
         "node-fetch": "^3.3.2",
         "pac-proxy-agent": "^7.0.2",
         "socks-proxy-agent": "^8.0.4",
@@ -5583,12 +5583,12 @@
       }
     },
     "node_modules/@mongodb-js/socksv5": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/socksv5/-/socksv5-0.0.11.tgz",
-      "integrity": "sha512-vA4OvtpE/A4dWBlnrkVN1HqwQSJeTdC16AyJ2Gd0jmUbqYDUkEogjkXDRZM0flM6ZD8PErlD4QHhXKC1c2uPNw==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/socksv5/-/socksv5-0.0.10.tgz",
+      "integrity": "sha512-JDz2fLKsjMiSNUxKrCpGptsgu7DzsXfu4gnUQ3RhUaBS1d4YbLrt6HejpckAiHIAa+niBpZAeiUsoop0IihWsw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.2.0"
+        "ip-address": "^9.0.5"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -11415,9 +11415,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.21",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
-      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -11803,9 +11803,9 @@
       "license": "ISC"
     },
     "node_modules/browserslist": {
-      "version": "4.28.9",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
-      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -11822,11 +11822,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.11.20",
-        "caniuse-lite": "^1.0.30001810",
-        "electron-to-chromium": "^1.5.420",
-        "node-releases": "^2.0.54",
-        "update-browserslist-db": "^1.3.2"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -12112,9 +12112,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001810",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
-      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
       "funding": [
         {
           "type": "opencollective",
@@ -13349,9 +13349,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.422",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
-      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "license": "ISC"
     },
     "node_modules/embla-carousel": {
@@ -16241,10 +16241,14 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
-      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
       "engines": {
         "node": ">= 12"
       }
@@ -17823,6 +17827,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
     },
     "node_modules/jsep": {
       "version": "1.4.0",
@@ -19901,13 +19911,10 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.54",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
-      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "license": "MIT"
     },
     "node_modules/node-sarif-builder": {
       "version": "3.4.0",
@@ -22976,6 +22983,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/socks/node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -23160,6 +23176,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/ssh2": {
       "version": "1.17.0",
@@ -25194,9 +25216,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
-      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -26785,6 +26807,24 @@
         "react": {
           "optional": true
         },
+        "vscode-webview": {
+          "optional": true
+        }
+      }
+    },
+    "packages/vscode-webview-api": {
+      "name": "@microsoft/vscode-webview-api",
+      "version": "0.1.0-pre",
+      "extraneous": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@trpc/client": "^11.0.0",
+        "@trpc/server": "^11.0.0",
+        "@vscode/l10n": "^0.0.18",
+        "react": ">=18.0.0",
+        "vscode-webview": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
         "vscode-webview": {
           "optional": true
         }


### PR DESCRIPTION
## Summary

- revert the deferred `browserslist` update from PR #908
- revert the combined `ip-address` and `@mongodb-js/devtools-proxy-support` update from PR #911
- remove both deferred updates from the 0.10.2 changelog and release notes

## Validation

- `npm ci --dry-run --ignore-scripts`
- `npm run build`

## Notes

PR #911 updated `ip-address` and `@mongodb-js/devtools-proxy-support` in one lockfile-only change. Reverting it necessarily restores both packages to their prior locked versions.